### PR TITLE
[TEST] Text rendering comparison

### DIFF
--- a/themes/intellij/build.gradle.kts
+++ b/themes/intellij/build.gradle.kts
@@ -21,12 +21,6 @@ kotlin {
     }
 }
 
-repositories {
-    jetbrainsCompose()
-    maven("https://androidx.dev/storage/compose-compiler/repository/")
-    mavenCentral()
-}
-
 dependencies {
     implementation(compose.desktop.currentOs) {
         exclude(group = "org.jetbrains.compose.material")

--- a/themes/intellij/idea/build.gradle.kts
+++ b/themes/intellij/idea/build.gradle.kts
@@ -27,7 +27,7 @@ kotlin {
 intellij {
 //    pluginName.set("Compose support for IJ UI development")
     version.set("LATEST-EAP-SNAPSHOT")
-    plugins.set(listOf("org.jetbrains.kotlin", "org.jetbrains.compose.desktop.ide:1.1.1"))
+    plugins.set(listOf("org.jetbrains.kotlin", "org.jetbrains.compose.desktop.ide:${libs.versions.composeDesktop.get()}"))
     version.set("2022.1.4")
 }
 

--- a/themes/intellij/idea/build.gradle.kts
+++ b/themes/intellij/idea/build.gradle.kts
@@ -27,7 +27,7 @@ kotlin {
 intellij {
 //    pluginName.set("Compose support for IJ UI development")
     version.set("LATEST-EAP-SNAPSHOT")
-    plugins.set(listOf("org.jetbrains.kotlin", "org.jetbrains.compose.desktop.ide:${libs.versions.composeDesktop.get()}"))
+    plugins.set(listOf("org.jetbrains.kotlin", "org.jetbrains.compose.desktop.ide:1.1.1"))
     version.set("2022.1.4")
 }
 

--- a/themes/intellij/idea/src/main/kotlin/org/jetbrains/jewel/theme/idea/Bridge.kt
+++ b/themes/intellij/idea/src/main/kotlin/org/jetbrains/jewel/theme/idea/Bridge.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontSynthesis
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.platform.Typeface
 import androidx.compose.ui.unit.TextUnit
@@ -130,7 +131,8 @@ suspend fun retrieveFont(
             fontWeight = FontWeight.Normal,
             fontFamily = FontFamily(Typeface(typeface)),
             // todo textDecoration might be defined in the awt theme
-            lineHeight = lineHeight
+            lineHeight = lineHeight,
+            fontSynthesis = FontSynthesis.None // TODO remove this, for testing only
         )
     }
 }

--- a/themes/intellij/idea/src/main/kotlin/org/jetbrains/jewel/theme/idea/ComposePanel.kt
+++ b/themes/intellij/idea/src/main/kotlin/org/jetbrains/jewel/theme/idea/ComposePanel.kt
@@ -7,9 +7,15 @@ import com.intellij.openapi.wm.ToolWindow
 fun ToolWindow.addComposePanel(
     displayName: String,
     isLockable: Boolean = true,
+    isCloseable: Boolean = true,
     content: @Composable ComposePanel.() -> Unit
-) = ComposePanel(content = content)
-    .also { contentManager.addContent(contentManager.factory.createContent(it, displayName, isLockable)) }
+): ComposePanel {
+    val composePanel = ComposePanel(content = content)
+    val panel = contentManager.factory.createContent(composePanel, displayName, isLockable)
+    panel.isCloseable = isCloseable
+    contentManager.addContent(panel)
+    return composePanel
+}
 
 internal fun ComposePanel(
     height: Int = 800,

--- a/themes/intellij/idea/src/main/kotlin/org/jetbrains/jewel/theme/idea/CurrentIntelliJThemeDefinition.kt
+++ b/themes/intellij/idea/src/main/kotlin/org/jetbrains/jewel/theme/idea/CurrentIntelliJThemeDefinition.kt
@@ -3,7 +3,9 @@ package org.jetbrains.jewel.theme.idea
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.intellij.icons.AllIcons
 import com.intellij.ui.JBColor
 import org.jetbrains.jewel.theme.intellij.IntelliJMetrics
@@ -51,7 +53,7 @@ suspend fun CurrentIntelliJThemeDefinition(): IntelliJThemeDefinition {
         isLight = JBColor.isBright(),
         button = buttonPalette,
         background = retrieveColorOrUnspecified("Panel.background"),
-        text = retrieveColorOrUnspecified("Panel.foreground"),
+        text = retrieveColorOrUnspecified("Label.foreground"),
         textDisabled = retrieveColorOrUnspecified("Label.disabledForeground"),
         controlStroke = retrieveColorOrUnspecified("Component.borderColor"),
         controlStrokeDisabled = retrieveColorOrUnspecified("Component.disabledBorderColor"),
@@ -159,8 +161,24 @@ suspend fun CurrentIntelliJThemeDefinition(): IntelliJThemeDefinition {
         )
     )
 
+    val baseTextStyle = retrieveFont("Label.font", palette.text)
+
+    fun TextStyle.scaleFont(amount: Float): TextStyle {
+        val size = this.fontSize.value
+        return this.copy(
+            fontSize = (size + amount).sp
+        )
+    }
+
     val typography = IntelliJTypography(
-        default = retrieveFont("Panel.font", palette.text),
+        h0 = baseTextStyle.scaleFont(12f),
+        h1 = baseTextStyle.scaleFont(9f),
+        h2 = baseTextStyle.scaleFont(5f),
+        h3 = baseTextStyle.scaleFont(3f),
+        h4 = baseTextStyle,
+        default = baseTextStyle,
+        medium = baseTextStyle.scaleFont(-1f),
+        small = baseTextStyle.scaleFont(-2f),
         button = retrieveFont("Button.font", palette.button.foreground),
         checkBox = retrieveFont("CheckBox.font", palette.checkbox.foreground),
         radioButton = retrieveFont("RadioButton.font", palette.radioButton.foreground),

--- a/themes/intellij/idea/src/main/kotlin/org/jetbrains/jewel/theme/idea/CurrentIntelliJThemeDefinition.kt
+++ b/themes/intellij/idea/src/main/kotlin/org/jetbrains/jewel/theme/idea/CurrentIntelliJThemeDefinition.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.intellij.icons.AllIcons
@@ -161,21 +162,21 @@ suspend fun CurrentIntelliJThemeDefinition(): IntelliJThemeDefinition {
         )
     )
 
-    val baseTextStyle = retrieveFont("Label.font", palette.text)
+    val baseTextStyle = retrieveFont(key = "Label.font", color = palette.text)
 
     fun TextStyle.scaleFont(amount: Float): TextStyle {
-        val size = this.fontSize.value
-        return this.copy(
-            fontSize = (size + amount).sp
-        )
+        val size = fontSize.value
+        return copy(fontSize = (size + amount).sp)
     }
 
+    fun TextStyle.withWeight(weight: FontWeight) = copy(fontWeight = weight)
+
     val typography = IntelliJTypography(
-        h0 = baseTextStyle.scaleFont(12f),
-        h1 = baseTextStyle.scaleFont(9f),
+        h0 = baseTextStyle.scaleFont(12f).withWeight(FontWeight.Bold),
+        h1 = baseTextStyle.scaleFont(9f).withWeight(FontWeight.Bold),
         h2 = baseTextStyle.scaleFont(5f),
         h3 = baseTextStyle.scaleFont(3f),
-        h4 = baseTextStyle,
+        h4 = baseTextStyle.withWeight(FontWeight.Bold),
         default = baseTextStyle,
         medium = baseTextStyle.scaleFont(-1f),
         small = baseTextStyle.scaleFont(-2f),

--- a/themes/intellij/idea/src/main/kotlin/org/jetbrains/jewel/theme/idea/demo/JewelDemoToolWindow.kt
+++ b/themes/intellij/idea/src/main/kotlin/org/jetbrains/jewel/theme/idea/demo/JewelDemoToolWindow.kt
@@ -5,8 +5,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -16,11 +19,17 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.SwingPanel
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.ui.layout.panel
+import com.intellij.util.ui.JBFont
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.jetbrains.jewel.Orientation
 import org.jetbrains.jewel.theme.idea.IntelliJTheme
@@ -141,6 +150,80 @@ internal class JewelDemoToolWindow : ToolWindowFactory, DumbAware {
                             checked = checked,
                             onCheckedChange = { checked = it }
                         )
+                    }
+                }
+            }
+        }
+
+        toolWindow.addComposePanel("Text rendering comparison") {
+            val panel = this
+            val sampleText = "Lorem ipsum 1234567890"
+
+            Row(
+                modifier = Modifier.fillMaxSize()
+            ) {
+                val colModifiers = Modifier
+                    .padding(20.dp)
+                    .fillMaxHeight()
+                    .weight(1f)
+
+                SwingPanel(
+                    background = Color.Transparent,
+                    modifier = colModifiers,
+                    factory = {
+                        panel {
+                            row("H0")           {  label(sampleText, JBFont.h0().asBold())  }
+                            row("H1")           {  label(sampleText, JBFont.h1().asBold())  }
+                            row("H2")           {  label(sampleText, JBFont.h2())  }
+                            row("H2 Bold")      {  label(sampleText, JBFont.h2().asBold())  }
+                            row("H3")           {  label(sampleText, JBFont.h3())  }
+                            row("H3 Bold")      {  label(sampleText, JBFont.h3().asBold())  }
+                            row("H4")           {  label(sampleText, JBFont.h4().asBold())  }
+                            row("Default")      {  label(sampleText, JBFont.regular())  }
+                            row("Default Bold") {  label(sampleText, JBFont.regular().asBold())  }
+                            row("Medium")       {  label(sampleText, JBFont.medium())  }
+                            row("Medium Bold")  {  label(sampleText, JBFont.medium().asBold())  }
+                            row("Small")        {  label(sampleText, JBFont.small())  }
+                        }
+                    }
+                )
+                IntelliJTheme(panel) {
+                    @Composable
+                    fun TypeRow(label: String, style: TextStyle) {
+                        Row {
+                            Text(
+                                label,
+                                style = IntelliJTheme.typography.default,
+                                modifier = Modifier
+                                    .alignByBaseline()
+                                    .width(92.dp)
+                            )
+                            Text(
+                                sampleText,
+                                style = style,
+                                modifier = Modifier
+                                    .alignByBaseline()
+                                    .weight(1f)
+                            )
+                        }
+                    }
+
+                    Column(
+                        modifier = colModifiers,
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        TypeRow("H0", IntelliJTheme.typography.h0.copy(fontWeight = FontWeight.Bold))
+                        TypeRow("H1", IntelliJTheme.typography.h1.copy(fontWeight = FontWeight.Bold))
+                        TypeRow("H2", IntelliJTheme.typography.h2)
+                        TypeRow("H2 Bold", IntelliJTheme.typography.h2.copy(fontWeight = FontWeight.Bold))
+                        TypeRow("H3", IntelliJTheme.typography.h3)
+                        TypeRow("H3 Bold", IntelliJTheme.typography.h3.copy(fontWeight = FontWeight.Bold))
+                        TypeRow("H4", IntelliJTheme.typography.h4.copy(fontWeight = FontWeight.Bold))
+                        TypeRow("Default", IntelliJTheme.typography.default)
+                        TypeRow("Default Bold", IntelliJTheme.typography.default.copy(fontWeight = FontWeight.Bold))
+                        TypeRow("Medium", IntelliJTheme.typography.medium)
+                        TypeRow("Medium Bold", IntelliJTheme.typography.medium.copy(fontWeight = FontWeight.Bold))
+                        TypeRow("Small", IntelliJTheme.typography.small)
                     }
                 }
             }

--- a/themes/intellij/idea/src/main/kotlin/org/jetbrains/jewel/theme/idea/demo/JewelDemoToolWindow.kt
+++ b/themes/intellij/idea/src/main/kotlin/org/jetbrains/jewel/theme/idea/demo/JewelDemoToolWindow.kt
@@ -16,7 +16,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.SwingPanel
 import androidx.compose.ui.graphics.Color
@@ -52,9 +51,8 @@ internal class JewelDemoToolWindow : ToolWindowFactory, DumbAware {
         Enabled, Disabled, Automatic, Unavailable
     }
 
-    @OptIn(ExperimentalComposeUiApi::class)
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
-        toolWindow.addComposePanel("Compose Demo") {
+        toolWindow.addComposePanel("Compose Demo", isCloseable = false) {
             IntelliJTheme(this) {
                 Box(
                     modifier = Modifier
@@ -134,7 +132,7 @@ internal class JewelDemoToolWindow : ToolWindowFactory, DumbAware {
                 }
             }
         }
-        toolWindow.addComposePanel("Compose Demo 2") {
+        toolWindow.addComposePanel("Compose Demo 2", isCloseable = false) {
             IntelliJTheme(this) {
                 Box(
                     modifier = Modifier
@@ -157,7 +155,7 @@ internal class JewelDemoToolWindow : ToolWindowFactory, DumbAware {
             }
         }
 
-        toolWindow.addComposePanel("Text rendering comparison") {
+        toolWindow.addComposePanel("Text rendering comparison", isCloseable = false) {
             val sampleText = "Lorem ipsum 1234567890"
             IntelliJTheme(this) {
                 Row(
@@ -214,13 +212,13 @@ internal class JewelDemoToolWindow : ToolWindowFactory, DumbAware {
                         modifier = colModifiers,
                         verticalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
-                        TypeRow("H0", IntelliJTheme.typography.h0.copy(fontWeight = FontWeight.Bold))
-                        TypeRow("H1", IntelliJTheme.typography.h1.copy(fontWeight = FontWeight.Bold))
+                        TypeRow("H0", IntelliJTheme.typography.h0)
+                        TypeRow("H1", IntelliJTheme.typography.h1)
                         TypeRow("H2", IntelliJTheme.typography.h2)
                         TypeRow("H2 Bold", IntelliJTheme.typography.h2.copy(fontWeight = FontWeight.Bold))
                         TypeRow("H3", IntelliJTheme.typography.h3)
                         TypeRow("H3 Bold", IntelliJTheme.typography.h3.copy(fontWeight = FontWeight.Bold))
-                        TypeRow("H4", IntelliJTheme.typography.h4.copy(fontWeight = FontWeight.Bold))
+                        TypeRow("H4", IntelliJTheme.typography.h4)
                         TypeRow("Default", IntelliJTheme.typography.default)
                         TypeRow("Default Bold", IntelliJTheme.typography.default.copy(fontWeight = FontWeight.Bold))
                         TypeRow("Medium", IntelliJTheme.typography.medium)

--- a/themes/intellij/idea/src/main/kotlin/org/jetbrains/jewel/theme/idea/demo/JewelDemoToolWindow.kt
+++ b/themes/intellij/idea/src/main/kotlin/org/jetbrains/jewel/theme/idea/demo/JewelDemoToolWindow.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.selection.selectableGroup
@@ -100,7 +99,7 @@ internal class JewelDemoToolWindow : ToolWindowFactory, DumbAware {
                         }
 
                         val tabState = rememberTabContainerState("1")
-                        TabRow(tabState, ) {
+                        TabRow(tabState) {
                             Section("1", "One")
                             Section("2", "Two")
                             Section("3", "Three")
@@ -138,7 +137,10 @@ internal class JewelDemoToolWindow : ToolWindowFactory, DumbAware {
         toolWindow.addComposePanel("Compose Demo 2") {
             IntelliJTheme(this) {
                 Box(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(IntelliJTheme.palette.background)
+                        .padding(16.dp),
                     contentAlignment = Alignment.Center
                 ) {
                     var checked by remember { mutableStateOf(true) }
@@ -156,38 +158,38 @@ internal class JewelDemoToolWindow : ToolWindowFactory, DumbAware {
         }
 
         toolWindow.addComposePanel("Text rendering comparison") {
-            val panel = this
             val sampleText = "Lorem ipsum 1234567890"
+            IntelliJTheme(this) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(IntelliJTheme.palette.background)
+                ) {
+                    val colModifiers = Modifier
+                        .padding(20.dp)
+                        .fillMaxHeight()
+                        .weight(1f)
 
-            Row(
-                modifier = Modifier.fillMaxSize()
-            ) {
-                val colModifiers = Modifier
-                    .padding(20.dp)
-                    .fillMaxHeight()
-                    .weight(1f)
-
-                SwingPanel(
-                    background = Color.Transparent,
-                    modifier = colModifiers,
-                    factory = {
-                        panel {
-                            row("H0")           {  label(sampleText, JBFont.h0().asBold())  }
-                            row("H1")           {  label(sampleText, JBFont.h1().asBold())  }
-                            row("H2")           {  label(sampleText, JBFont.h2())  }
-                            row("H2 Bold")      {  label(sampleText, JBFont.h2().asBold())  }
-                            row("H3")           {  label(sampleText, JBFont.h3())  }
-                            row("H3 Bold")      {  label(sampleText, JBFont.h3().asBold())  }
-                            row("H4")           {  label(sampleText, JBFont.h4().asBold())  }
-                            row("Default")      {  label(sampleText, JBFont.regular())  }
-                            row("Default Bold") {  label(sampleText, JBFont.regular().asBold())  }
-                            row("Medium")       {  label(sampleText, JBFont.medium())  }
-                            row("Medium Bold")  {  label(sampleText, JBFont.medium().asBold())  }
-                            row("Small")        {  label(sampleText, JBFont.small())  }
+                    SwingPanel(
+                        background = Color.Unspecified,
+                        modifier = colModifiers,
+                        factory = {
+                            panel {
+                                row("H0") { label(sampleText, JBFont.h0()) }
+                                row("H1") { label(sampleText, JBFont.h1()) }
+                                row("H2") { label(sampleText, JBFont.h2()) }
+                                row("H2 Bold") { label(sampleText, JBFont.h2().asBold()) }
+                                row("H3") { label(sampleText, JBFont.h3()) }
+                                row("H3 Bold") { label(sampleText, JBFont.h3().asBold()) }
+                                row("H4") { label(sampleText, JBFont.h4()) }
+                                row("Default") { label(sampleText, JBFont.regular()) }
+                                row("Default Bold") { label(sampleText, JBFont.regular().asBold()) }
+                                row("Medium") { label(sampleText, JBFont.medium()) }
+                                row("Medium Bold") { label(sampleText, JBFont.medium().asBold()) }
+                                row("Small") { label(sampleText, JBFont.small()) }
+                            }
                         }
-                    }
-                )
-                IntelliJTheme(panel) {
+                    )
                     @Composable
                     fun TypeRow(label: String, style: TextStyle) {
                         Row {

--- a/themes/intellij/src/main/kotlin/org/jetbrains/jewel/theme/intellij/IntelliJPalette.kt
+++ b/themes/intellij/src/main/kotlin/org/jetbrains/jewel/theme/intellij/IntelliJPalette.kt
@@ -17,7 +17,7 @@ data class IntelliJPalette(
 
     val background: Color, // Panel.background
 
-    val text: Color, // Panel.foreground
+    val text: Color, // Label.foreground
     val textDisabled: Color, // Label.disabledForeground
 
     val controlStroke: Color, // Component.borderColor

--- a/themes/intellij/src/main/kotlin/org/jetbrains/jewel/theme/intellij/IntelliJTypography.kt
+++ b/themes/intellij/src/main/kotlin/org/jetbrains/jewel/theme/intellij/IntelliJTypography.kt
@@ -3,13 +3,17 @@ package org.jetbrains.jewel.theme.intellij
 import androidx.compose.ui.text.TextStyle
 
 data class IntelliJTypography(
+    val h0: TextStyle,
+    val h1: TextStyle,
+    val h2: TextStyle,
+    val h3: TextStyle,
+    val h4: TextStyle,
     val default: TextStyle,
+    val medium: TextStyle,
+    val small: TextStyle,
     val button: TextStyle,
     val checkBox: TextStyle,
     val radioButton: TextStyle,
     val textField: TextStyle,
     val slider: TextStyle
-) {
-
-    companion object
-}
+)

--- a/themes/intellij/src/main/kotlin/org/jetbrains/jewel/theme/intellij/components/Table.kt
+++ b/themes/intellij/src/main/kotlin/org/jetbrains/jewel/theme/intellij/components/Table.kt
@@ -108,7 +108,7 @@ class TableState(
                 mapOf(
                     "initialFirstVisibleRowIndex" to it.firstVisibleRowIndex,
                     "initialFirstVisibleRowScrollOffset" to it.firstVisibleRowScrollOffset,
-                    *it.dividerOffsets.map { (k, v) -> it.toString() to v }.toTypedArray()
+                    *it.dividerOffsets.map { (_, v) -> it.toString() to v }.toTypedArray()
                 )
             },
             restore = {


### PR DESCRIPTION
Branch to show and discuss text rendering differences between Swing and Compose for Desktop.

Font styles are based on the current typography spec for [IntelliJ](https://jetbrains.github.io/ui/principles/typography/#03). You can also run an internal action to see the Swing demo with **Tools > Internal Actions > UI > Demos > Test Label Sizes** (this is also where I pulled the Swing code for comparison).