### PR TITLE
Update version of IJ and CfD

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,10 @@
 [versions]
-composeDesktop = "1.2.0-beta01"
+composeDesktop = "1.2.1"
 coroutines = "1.6.0"
-ideaGradlePlugin = "1.9.0"
+ideaGradlePlugin = "1.10.0"
 jna = "5.10.0"
 kotlin = "1.7.10"
 kotlinxSerialization = "1.3.1"
-skiko = "0.7.26"
 
 [libraries]
 compose-components-splitpane = { module = "org.jetbrains.compose.components:components-splitpane", version.ref = "composeDesktop" }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -9,7 +9,7 @@ kotlin {
     target {
         compilations.all {
             kotlinOptions {
-                jvmTarget = "11"
+                jvmTarget = "17"
                 freeCompilerArgs = listOf("-Xopt-in=kotlin.RequiresOptIn")
             }
         }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -11,7 +11,7 @@ kotlin {
     target {
         compilations.all {
             kotlinOptions {
-                jvmTarget = "11"
+                jvmTarget = "17"
             }
         }
     }
@@ -30,7 +30,6 @@ dependencies {
         exclude(group = "org.jetbrains.compose.material")
     }
     implementation(projects.library)
-    implementation(projects.themes.toolbox)
     implementation(projects.themes.intellij.standalone)
     api(libs.compose.components.splitpane)
 }

--- a/themes/intellij/build.gradle.kts
+++ b/themes/intellij/build.gradle.kts
@@ -9,7 +9,7 @@ kotlin {
     target {
         compilations.all {
             kotlinOptions {
-                jvmTarget = "11"
+                jvmTarget = "17"
             }
         }
     }

--- a/themes/intellij/idea/build.gradle.kts
+++ b/themes/intellij/idea/build.gradle.kts
@@ -10,7 +10,7 @@ kotlin {
     target {
         compilations.all {
             kotlinOptions {
-                jvmTarget = "11"
+                jvmTarget = "17"
                 freeCompilerArgs = listOf("-Xopt-in=kotlin.RequiresOptIn", "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi")
             }
         }
@@ -27,8 +27,8 @@ kotlin {
 intellij {
     pluginName.set("Jewel")
     version.set("LATEST-EAP-SNAPSHOT")
-    plugins.set(listOf("org.jetbrains.kotlin", "org.jetbrains.compose.desktop.ide:1.1.1"))
-    version.set("2022.1.4")
+    plugins.set(listOf("org.jetbrains.kotlin"))
+    version.set("223.7571.123-EAP-SNAPSHOT") // IJ 22.3 RC2
 }
 
 repositories {
@@ -38,7 +38,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly(compose.desktop.currentOs) {
+    implementation(compose.desktop.currentOs) {
         exclude(group = "org.jetbrains.compose.material")
     }
     implementation(projects.themes.intellij) {

--- a/themes/intellij/idea/src/main/resources/META-INF/plugin.xml
+++ b/themes/intellij/idea/src/main/resources/META-INF/plugin.xml
@@ -1,11 +1,7 @@
 <idea-plugin implementation-detail="false">
     <id>org.jetbrains.compose.desktop.ide.theme</id>
-    <name>CfD IJ Theme</name>
+    <name>Jewel</name>
     <vendor>JetBrains</vendor>
-
-    <dependencies>
-        <plugin id="org.jetbrains.compose.desktop.ide"/>
-    </dependencies>
 
     <extensions defaultExtensionNs="com.intellij">
         <projectService serviceImplementation="org.jetbrains.jewel.theme.idea.ProjectLifecycle"/>

--- a/themes/intellij/standalone/build.gradle.kts
+++ b/themes/intellij/standalone/build.gradle.kts
@@ -7,7 +7,7 @@ kotlin {
     target {
         compilations.all {
             kotlinOptions {
-                jvmTarget = "11"
+                jvmTarget = "17"
                 freeCompilerArgs = listOf("-Xopt-in=kotlin.RequiresOptIn")
             }
         }


### PR DESCRIPTION
Since the CfD plugin is out of date, but we need the newer version (and to support newer IJ versions), this smol PR bumps the numbers where needed and replaces the usage of the CfD plugin with a direct Maven dependency*.

We also bump the Java version to 17, matching the newer IJ versions' JBR.

--

* As pointed out by @igordmn, this is an acceptable workaround until a more permanent solution is found to support CfD in IJP. The only downside is that the entire runtime will be bundled with each plugin, but that's not an issue for now.
