### PR TITLE
Avoid putting compose content in condition branches

### DIFF
--- a/themes/darcula/darcula-standalone/src/main/kotlin/org/jetbrains/jewel/themes/darcula/standalone/IntelliJThemeDefinition.kt
+++ b/themes/darcula/darcula-standalone/src/main/kotlin/org/jetbrains/jewel/themes/darcula/standalone/IntelliJThemeDefinition.kt
@@ -9,7 +9,13 @@ import org.jetbrains.jewel.IntelliJTheme as BaseIntelliJTheme
 
 @Composable
 fun IntelliJTheme(isDark: Boolean, content: @Composable () -> Unit) =
-    if (isDark) IntelliJThemeDark(content) else IntelliJThemeLight(content)
+    BaseIntelliJTheme(
+        if (isDark) IntelliJPalette.darcula else IntelliJPalette.light,
+        IntelliJMetrics.default,
+        if (isDark) IntelliJPainters.darcula else IntelliJPainters.light,
+        if (isDark) IntelliJTypography.darcula else IntelliJTypography.light,
+        content
+    )
 
 @Composable
 fun IntelliJThemeLight(content: @Composable () -> Unit) =


### PR DESCRIPTION
When switch the `isDark` argument, the `content` will be full recomposed, because content in different branch is different compose scope, remembers also will be re-evaluated.