### PR TITLE
Fix focus state not saved after selected state changed

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/jewel/components/Checkbox.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/components/Checkbox.kt
@@ -91,8 +91,11 @@ fun CheckboxImpl(
     content: @Composable (Modifier, Modifier, Int, Painter?, TextStyle, Dp) -> Unit
 ) {
     var isHovered by remember { mutableStateOf(false) }
-    var interactionState by remember(state, interactionSource, enabled) {
+    var interactionState by remember(interactionSource, enabled) {
         mutableStateOf(CheckboxState(state, ButtonMouseState.None, enabled = enabled))
+    }
+    remember(state) {
+        interactionState = interactionState.copy(toggle = state)
     }
     LaunchedEffect(interactionSource) {
         interactionSource.interactions.collect { interaction ->

--- a/core/src/main/kotlin/org/jetbrains/jewel/components/RadioButton.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/components/RadioButton.kt
@@ -90,8 +90,11 @@ fun RadioButtonImpl(
     content: @Composable (Modifier, Modifier, Int, Painter?, TextStyle, Dp) -> Unit
 ) {
     var isHovered by remember { mutableStateOf(false) }
-    var interactionState by remember(selected, interactionSource, enabled) {
+    var interactionState by remember(interactionSource, enabled) {
         mutableStateOf(RadioButtonState(selected, ButtonMouseState.None, enabled = enabled))
+    }
+    remember(selected) {
+        interactionState = interactionState.copy(checked = selected)
     }
     LaunchedEffect(interactionSource) {
         interactionSource.interactions.collect { interaction ->


### PR DESCRIPTION
The state remember by `state`, it will cause the focused state will not be saved when `selected` changed.

The behavior on the control is that when the checkbox is clicked with the mouse, the checkbox will not be displayed as focused.

This PR fixed it by not remember state by `selected`, then use another remember to update the `selected` state in `state`