### PR TITLE
Border alignment support

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/jewel/ShapeModifier.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/ShapeModifier.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.jewel
 
-import androidx.compose.foundation.background
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.Brush
@@ -9,13 +8,28 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.debugInspectorInfo
 import org.jetbrains.jewel.modifiers.BorderAlignment
+import org.jetbrains.jewel.modifiers.background
 import org.jetbrains.jewel.modifiers.border
 
-@Deprecated("Use Modifier.border and Modifier.background instead", ReplaceWith("border(BorderAlignment.INSIDE, width, color, shape)"))
+@Deprecated(
+    "Use Modifier.border and Modifier.background instead",
+    ReplaceWith(
+        "border(BorderAlignment.Inside, shapeStroke.width, shapeStroke.brush, shape).background(fillColor, shape)",
+        "org.jetbrains.jewel.modifiers.border",
+        "org.jetbrains.jewel.modifiers.background"
+    )
+)
 fun Modifier.shape(shape: Shape, shapeStroke: ShapeStroke<*>? = null, fillColor: Color = Color.Unspecified): Modifier =
     shape(shape, shapeStroke, fillColor.nullIfUnspecified()?.toBrush())
 
-@Deprecated("Use Modifier.border and Modifier.background instead", ReplaceWith("border(BorderAlignment.INSIDE, width, color, shape)"))
+@Deprecated(
+    "Use Modifier.border and Modifier.background instead",
+    ReplaceWith(
+        "border(BorderAlignment.Inside, shapeStroke.width, shapeStroke.brush, shape).background(fillBrush, shape)",
+        "org.jetbrains.jewel.modifiers.border",
+        "org.jetbrains.jewel.modifiers.background"
+    )
+)
 fun Modifier.shape(shape: Shape, shapeStroke: ShapeStroke<*>? = null, fillBrush: Brush?): Modifier =
     composed(
         factory = {

--- a/core/src/main/kotlin/org/jetbrains/jewel/ShapeModifier.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/ShapeModifier.kt
@@ -25,7 +25,7 @@ fun Modifier.shape(shape: Shape, shapeStroke: ShapeStroke<*>? = null, fillBrush:
                 this
             }
             if (shapeStroke != null) {
-                backgroundModifier.border(BorderAlignment.INSIDE, shapeStroke.width, shapeStroke.brush, shape)
+                backgroundModifier.border(BorderAlignment.Inside, shapeStroke.width, shapeStroke.brush, shape)
             } else {
                 backgroundModifier
             }

--- a/core/src/main/kotlin/org/jetbrains/jewel/ShapeModifier.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/ShapeModifier.kt
@@ -1,37 +1,34 @@
 package org.jetbrains.jewel
 
+import androidx.compose.foundation.background
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
-import androidx.compose.ui.draw.CacheDrawScope
-import androidx.compose.ui.draw.drawWithCache
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.geometry.isSimple
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Outline
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.drawscope.Fill
-import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.graphics.drawscope.withTransform
 import androidx.compose.ui.platform.debugInspectorInfo
-import androidx.compose.ui.unit.Dp
+import org.jetbrains.jewel.modifiers.BorderAlignment
+import org.jetbrains.jewel.modifiers.border
 
+@Deprecated("Use Modifier.border and Modifier.background instead", ReplaceWith("border(BorderAlignment.INSIDE, width, color, shape)"))
 fun Modifier.shape(shape: Shape, shapeStroke: ShapeStroke<*>? = null, fillColor: Color = Color.Unspecified): Modifier =
     shape(shape, shapeStroke, fillColor.nullIfUnspecified()?.toBrush())
 
+@Deprecated("Use Modifier.border and Modifier.background instead", ReplaceWith("border(BorderAlignment.INSIDE, width, color, shape)"))
 fun Modifier.shape(shape: Shape, shapeStroke: ShapeStroke<*>? = null, fillBrush: Brush?): Modifier =
     composed(
         factory = {
-            this.then(
-                when {
-                    shape === RectangleShape -> rectangleModifier(shapeStroke, fillBrush)
-                    else -> shapeModifier(shapeStroke, fillBrush, shape)
-                }
-            )
+            val backgroundModifier = if (fillBrush != null) {
+                this.background(fillBrush, shape)
+            } else {
+                this
+            }
+            if (shapeStroke != null) {
+                backgroundModifier.border(BorderAlignment.INSIDE, shapeStroke.width, shapeStroke.brush, shape)
+            } else {
+                backgroundModifier
+            }
         },
         inspectorInfo = debugInspectorInfo {
             name = "shape"
@@ -39,136 +36,6 @@ fun Modifier.shape(shape: Shape, shapeStroke: ShapeStroke<*>? = null, fillBrush:
             properties["shape"] = shape
         }
     )
-
-private fun rectangleModifier(shapeStroke: ShapeStroke<*>?, brush: Brush?) = Modifier.drawWithCache {
-    if (shapeStroke != null) {
-        val strokeWidth = if (shapeStroke.width == Dp.Hairline) 1f else shapeStroke.width.toPx()
-        val stroke = Stroke(strokeWidth)
-        val insets = shapeStroke.insets
-        val insetOffset = Offset(insets.left.toPx(), insets.top.toPx())
-        val insetSize = Size(
-            size.width - insets.left.toPx() - insets.right.toPx(),
-            size.height - insets.top.toPx() - insets.bottom.toPx()
-        )
-        drawRectangleShape(insetOffset, insetSize, stroke, shapeStroke.brush, brush)
-    } else {
-        drawRectangleShape(Offset.Zero, size, null, null, brush)
-    }
-}
-
-private fun CacheDrawScope.drawRectangleShape(
-    insetOffset: Offset,
-    insetSize: Size,
-    stroke: Stroke?,
-    strokeBrush: Brush?,
-    fillBrush: Brush?
-) =
-    onDrawWithContent {
-        val strokeWidth = stroke?.width ?: 0f
-        val enoughSpace = size.width > strokeWidth && size.height > strokeWidth
-        if (fillBrush != null && enoughSpace) {
-            drawRect(brush = fillBrush, topLeft = insetOffset, size = insetSize, style = Fill)
-        }
-        drawContent()
-        if (stroke != null && strokeBrush != null && enoughSpace) {
-            drawRect(brush = strokeBrush, topLeft = insetOffset, size = insetSize, style = stroke)
-        }
-    }
-
-private fun CacheDrawScope.drawRoundedShape(
-    insetOffset: Offset,
-    outline: Outline.Rounded,
-    stroke: Stroke?,
-    strokeBrush: Brush?,
-    fillBrush: Brush?
-) =
-    onDrawWithContent {
-        when {
-            outline.roundRect.isSimple -> {
-                val roundRect = outline.roundRect
-                if (fillBrush != null) {
-                    withTransform({ translate(insetOffset.x, insetOffset.y) }) {
-                        drawRoundRect(
-                            brush = fillBrush,
-                            topLeft = Offset(roundRect.left, roundRect.top),
-                            size = Size(roundRect.width, roundRect.height),
-                            cornerRadius = roundRect.topLeftCornerRadius,
-                            style = Fill
-                        )
-                    }
-                }
-                drawContent()
-                if (stroke != null && strokeBrush != null) {
-                    withTransform({ translate(insetOffset.x, insetOffset.y) }) {
-                        drawRoundRect(
-                            brush = strokeBrush,
-                            topLeft = Offset(roundRect.left, roundRect.top),
-                            size = Size(roundRect.width, roundRect.height),
-                            cornerRadius = roundRect.topLeftCornerRadius,
-                            style = stroke
-                        )
-                    }
-                }
-            }
-
-            else -> {
-                val path = Path().apply {
-                    addRoundRect(outline.roundRect)
-                    translate(insetOffset)
-                }
-                if (fillBrush != null) {
-                    drawPath(path, brush = fillBrush, style = Fill)
-                }
-                drawContent()
-                if (stroke != null && strokeBrush != null) {
-                    drawPath(path, strokeBrush, style = stroke)
-                }
-            }
-        }
-    }
-
-private fun CacheDrawScope.drawPathShape(path: Path, stroke: Stroke?, strokeBrush: Brush?, fillBrush: Brush?) =
-    onDrawWithContent {
-        if (fillBrush != null) {
-            drawPath(path, brush = fillBrush, style = Fill)
-        }
-        drawContent()
-        if (stroke != null && strokeBrush != null) {
-            drawPath(path, strokeBrush, style = stroke)
-        }
-    }
-
-private fun shapeModifier(shapeStroke: ShapeStroke<*>?, fillBrush: Brush?, shape: Shape) = Modifier.drawWithCache {
-    val strokeWidth = when (shapeStroke?.width) {
-        null -> 0f
-        Dp.Hairline -> 1f
-        else -> shapeStroke.width.toPx()
-    }
-    val insets = shapeStroke?.insets ?: Insets.Empty
-    val insetOffset = Offset(insets.left.toPx(), insets.top.toPx())
-    val insetSize = Size(
-        size.width - insets.left.toPx() - insets.right.toPx(),
-        size.height - insets.top.toPx() - insets.bottom.toPx()
-    )
-    val stroke = if (shapeStroke != null) Stroke(strokeWidth) else null
-    val strokeBrush = shapeStroke?.brush
-    val outline: Outline = shape.createOutline(insetSize, layoutDirection, this)
-
-    when {
-        size.minDimension > 0f -> when (outline) {
-            is Outline.Rectangle -> drawRectangleShape(insetOffset, insetSize, stroke, strokeBrush, fillBrush)
-            is Outline.Rounded -> drawRoundedShape(insetOffset, outline, stroke, strokeBrush, fillBrush)
-            is Outline.Generic -> {
-                val path = Path().apply { addPath(outline.path, insetOffset) }
-                drawPathShape(path, stroke, strokeBrush, fillBrush)
-            }
-        }
-
-        else -> onDrawWithContent {
-            drawContent()
-        }
-    }
-}
 
 fun Color.toBrush() = SolidColor(this)
 

--- a/core/src/main/kotlin/org/jetbrains/jewel/components/Button.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/components/Button.kt
@@ -115,11 +115,11 @@ fun Button(
     } ?: Modifier
 
     val borderModifier = appearance.shapeStroke?.let {
-        Modifier.border(BorderAlignment.INSIDE, it.width, it.brush, appearance.shape)
+        Modifier.border(BorderAlignment.Inside, it.width, it.brush, appearance.shape)
     } ?: Modifier
 
     val haloModifier = appearance.haloStroke?.let {
-        Modifier.border(BorderAlignment.OUTSIDE, it.width, it.brush, appearance.shape)
+        Modifier.border(BorderAlignment.Outside, it.width, it.brush, appearance.shape)
     } ?: Modifier
 
     Box(

--- a/core/src/main/kotlin/org/jetbrains/jewel/components/Button.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/components/Button.kt
@@ -2,6 +2,7 @@
 
 package org.jetbrains.jewel.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.HoverInteraction
@@ -22,18 +23,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.graphics.drawOutline
-import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.graphics.drawscope.translate
 import androidx.compose.ui.semantics.Role
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import org.jetbrains.jewel.components.state.ButtonMouseState
 import org.jetbrains.jewel.components.state.ButtonState
+import org.jetbrains.jewel.modifiers.BorderAlignment
 import org.jetbrains.jewel.modifiers.background
+import org.jetbrains.jewel.modifiers.border
 import org.jetbrains.jewel.shape
 import org.jetbrains.jewel.styles.ButtonAppearance
 import org.jetbrains.jewel.styles.ButtonStyle
@@ -114,30 +112,17 @@ fun Button(
 
     val appearance = style.appearance(buttonState, variation)
 
-    val shapeModifier = if (appearance.shapeStroke != null || appearance.background != null) {
-        Modifier.shape(appearance.shape, appearance.shapeStroke, appearance.background)
-    } else {
-        Modifier
-    }
+    val backgroundModifier = appearance.background?.let { background ->
+        Modifier.background(background, appearance.shape)
+    } ?: Modifier
 
-    val haloStroke = appearance.haloStroke
-    val haloModifier = if (haloStroke != null) {
-        Modifier.drawBehind {
-            val stroke = haloStroke.width.toPx() / 2f
-            translate(stroke / -2f, stroke / -2f) {
-                val holoSize = Size(size.width + stroke, size.height + stroke)
-                val outline = appearance.haloShape.createOutline(holoSize, layoutDirection, this)
+    val borderModifier = appearance.shapeStroke?.let {
+        Modifier.border(BorderAlignment.INSIDE, it.width, it.brush, appearance.shape)
+    } ?: Modifier
 
-                drawOutline(
-                    outline = outline,
-                    brush = haloStroke.brush,
-                    style = Stroke(haloStroke.width.toPx())
-                )
-            }
-        }
-    } else {
-        Modifier
-    }
+    val haloModifier = appearance.haloStroke?.let {
+        Modifier.border(BorderAlignment.OUTSIDE, it.width, it.brush, appearance.shape)
+    } ?: Modifier
 
     Box(
         modifier
@@ -148,7 +133,8 @@ fun Button(
                 interactionSource = interactionSource,
                 indication = null
             )
-            .then(shapeModifier)
+            .then(backgroundModifier)
+            .then(borderModifier)
             .then(haloModifier),
         propagateMinConstraints = true
     ) {

--- a/core/src/main/kotlin/org/jetbrains/jewel/components/Button.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/components/Button.kt
@@ -2,7 +2,6 @@
 
 package org.jetbrains.jewel.components
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.HoverInteraction
@@ -32,7 +31,6 @@ import org.jetbrains.jewel.components.state.ButtonState
 import org.jetbrains.jewel.modifiers.BorderAlignment
 import org.jetbrains.jewel.modifiers.background
 import org.jetbrains.jewel.modifiers.border
-import org.jetbrains.jewel.shape
 import org.jetbrains.jewel.styles.ButtonAppearance
 import org.jetbrains.jewel.styles.ButtonStyle
 import org.jetbrains.jewel.styles.LocalButtonStyle

--- a/core/src/main/kotlin/org/jetbrains/jewel/components/Checkbox.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/components/Checkbox.kt
@@ -122,11 +122,11 @@ fun CheckboxImpl(
     val backgroundModifier = Modifier.background(appearance.backgroundColor, appearance.shape)
 
     val borderModifier = appearance.shapeStroke?.let {
-        Modifier.border(BorderAlignment.INSIDE, it.width, it.brush, appearance.shape)
+        Modifier.border(BorderAlignment.Inside, it.width, it.brush, appearance.shape)
     } ?: Modifier
 
     val haloModifier = appearance.haloStroke?.let {
-        Modifier.border(BorderAlignment.OUTSIDE, it.width, it.brush, appearance.shape)
+        Modifier.border(BorderAlignment.Outside, it.width, it.brush, appearance.shape)
     } ?: Modifier
 
     val designModifier = Modifier.size(appearance.width, appearance.height)

--- a/core/src/main/kotlin/org/jetbrains/jewel/components/Checkbox.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/components/Checkbox.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.jewel.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.HoverInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -22,10 +23,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.paint
-import androidx.compose.ui.graphics.drawOutline
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.Role
@@ -34,7 +32,8 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import org.jetbrains.jewel.components.state.ButtonMouseState
 import org.jetbrains.jewel.components.state.CheckboxState
-import org.jetbrains.jewel.shape
+import org.jetbrains.jewel.modifiers.BorderAlignment
+import org.jetbrains.jewel.modifiers.border
 import org.jetbrains.jewel.styles.CheckboxStyle
 import org.jetbrains.jewel.styles.LocalCheckboxStyle
 import org.jetbrains.jewel.styles.LocalTextStyle
@@ -120,21 +119,19 @@ fun CheckboxImpl(
         indication = null
     )
 
-    val haloModifier = if (appearance.haloStroke != null) {
-        Modifier.drawBehind {
-            val outline = appearance.haloShape.createOutline(size, layoutDirection, this)
-            drawOutline(
-                outline = outline,
-                brush = appearance.haloStroke.brush,
-                style = Stroke(appearance.haloStroke.width.toPx())
-            )
-        }
-    } else {
-        Modifier
-    }
+    val backgroundModifier = Modifier.background(appearance.backgroundColor, appearance.shape)
+
+    val borderModifier = appearance.shapeStroke?.let {
+        Modifier.border(BorderAlignment.INSIDE, it.width, it.brush, appearance.shape)
+    } ?: Modifier
+
+    val haloModifier = appearance.haloStroke?.let {
+        Modifier.border(BorderAlignment.OUTSIDE, it.width, it.brush, appearance.shape)
+    } ?: Modifier
 
     val designModifier = Modifier.size(appearance.width, appearance.height)
-        .shape(appearance.shape, appearance.shapeStroke, appearance.backgroundColor)
+        .then(backgroundModifier)
+        .then(borderModifier)
         .then(haloModifier)
         .padding(appearance.symbolPadding)
 

--- a/core/src/main/kotlin/org/jetbrains/jewel/components/RadioButton.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/components/RadioButton.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.jewel.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.HoverInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -22,17 +23,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.draw.paint
-import androidx.compose.ui.graphics.drawOutline
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import org.jetbrains.jewel.components.state.ButtonMouseState
-import org.jetbrains.jewel.shape
+import org.jetbrains.jewel.modifiers.BorderAlignment
+import org.jetbrains.jewel.modifiers.border
 import org.jetbrains.jewel.styles.LocalRadioButtonStyle
 import org.jetbrains.jewel.styles.LocalTextStyle
 import org.jetbrains.jewel.styles.RadioButtonState
@@ -119,21 +118,19 @@ fun RadioButtonImpl(
         onClick = onClick
     )
 
-    val haloModifier = if (appearance.haloStroke != null) {
-        Modifier.drawBehind {
-            val outline = appearance.haloShape.createOutline(size, layoutDirection, this)
-            drawOutline(
-                outline = outline,
-                brush = appearance.haloStroke.brush,
-                style = Stroke(appearance.haloStroke.width.toPx())
-            )
-        }
-    } else {
-        Modifier
-    }
+    val backgroundModifier = Modifier.background(appearance.backgroundColor, appearance.shape)
+
+    val borderModifier = appearance.shapeStroke?.let {
+        Modifier.border(BorderAlignment.INSIDE, it.width, it.brush, appearance.shape)
+    } ?: Modifier
+
+    val haloModifier = appearance.haloStroke?.let {
+        Modifier.border(BorderAlignment.OUTSIDE, it.width, it.brush, appearance.shape)
+    } ?: Modifier
 
     val designModifier = Modifier.size(appearance.width, appearance.height)
-        .shape(appearance.shape, appearance.shapeStroke, appearance.backgroundColor)
+        .then(backgroundModifier)
+        .then(borderModifier)
         .then(haloModifier)
         .padding(appearance.symbolPadding)
 

--- a/core/src/main/kotlin/org/jetbrains/jewel/components/RadioButton.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/components/RadioButton.kt
@@ -121,11 +121,11 @@ fun RadioButtonImpl(
     val backgroundModifier = Modifier.background(appearance.backgroundColor, appearance.shape)
 
     val borderModifier = appearance.shapeStroke?.let {
-        Modifier.border(BorderAlignment.INSIDE, it.width, it.brush, appearance.shape)
+        Modifier.border(BorderAlignment.Inside, it.width, it.brush, appearance.shape)
     } ?: Modifier
 
     val haloModifier = appearance.haloStroke?.let {
-        Modifier.border(BorderAlignment.OUTSIDE, it.width, it.brush, appearance.shape)
+        Modifier.border(BorderAlignment.Outside, it.width, it.brush, appearance.shape)
     } ?: Modifier
 
     val designModifier = Modifier.size(appearance.width, appearance.height)

--- a/core/src/main/kotlin/org/jetbrains/jewel/modifiers/Background.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/modifiers/Background.kt
@@ -2,15 +2,26 @@ package org.jetbrains.jewel.modifiers
 
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.DrawModifier
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.drawOutline
 import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.platform.InspectorInfo
 import androidx.compose.ui.platform.InspectorValueInfo
 import androidx.compose.ui.platform.debugInspectorInfo
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import org.jetbrains.jewel.components.ImageSlice
 import org.jetbrains.jewel.components.ImageSliceValues
+import org.jetbrains.jewel.shape.QuadRoundedCornerShape
+import org.jetbrains.jewel.shape.addQuadRoundRect
 
 fun Modifier.background(image: ImageBitmap, maintainAspect: Boolean = true): Modifier =
     then(
@@ -38,6 +49,106 @@ fun Modifier.background(imageSlice: ImageSlice): Modifier =
             }
         )
     )
+
+fun Modifier.background(
+    color: Color,
+    shape: Shape = RectangleShape
+) = this.then(
+    Background(
+        color = color,
+        shape = shape,
+        inspectorInfo = debugInspectorInfo {
+            name = "background"
+            value = color
+            properties["color"] = color
+            properties["shape"] = shape
+        }
+    )
+)
+
+fun Modifier.background(
+    brush: Brush,
+    shape: Shape = RectangleShape
+) = this.then(
+    Background(
+        brush = brush,
+        shape = shape,
+        inspectorInfo = debugInspectorInfo {
+            name = "background"
+            value = brush
+            properties["brush"] = brush
+            properties["shape"] = shape
+        }
+    )
+)
+
+private class Background constructor(
+    private val color: Color? = null,
+    private val brush: Brush? = null,
+    private val alpha: Float = 1.0f,
+    private val shape: Shape,
+    inspectorInfo: InspectorInfo.() -> Unit
+) : DrawModifier, InspectorValueInfo(inspectorInfo) {
+
+    private var lastSize: Size? = null
+    private var lastLayoutDirection: LayoutDirection? = null
+    private var lastOutline: Outline? = null
+
+    override fun ContentDrawScope.draw() {
+        if (shape === RectangleShape) {
+            drawRect()
+        } else {
+            drawOutline()
+        }
+        drawContent()
+    }
+
+    private fun ContentDrawScope.drawRect() {
+        color?.let { drawRect(color = it) }
+        brush?.let { drawRect(brush = it, alpha = alpha) }
+    }
+
+    private fun ContentDrawScope.drawOutline() {
+        val outline =
+            if (size == lastSize && layoutDirection == lastLayoutDirection) {
+                lastOutline!!
+            } else {
+                shape.createOutline(size, layoutDirection, this)
+            }
+
+        if (outline is Outline.Rounded && shape is QuadRoundedCornerShape) {
+            val path = Path().apply {
+                addQuadRoundRect(outline.roundRect)
+            }
+            color?.let { drawPath(path, color = color) }
+            brush?.let { drawPath(path, brush = brush, alpha = alpha) }
+        } else {
+            color?.let { drawOutline(outline, color = color) }
+            brush?.let { drawOutline(outline, brush = brush, alpha = alpha) }
+        }
+        lastOutline = outline
+        lastSize = size
+    }
+
+    override fun hashCode(): Int {
+        var result = color?.hashCode() ?: 0
+        result = 31 * result + (brush?.hashCode() ?: 0)
+        result = 31 * result + alpha.hashCode()
+        result = 31 * result + shape.hashCode()
+        return result
+    }
+
+    override fun equals(other: Any?): Boolean {
+        val otherModifier = other as? Background ?: return false
+        return color == otherModifier.color &&
+            brush == otherModifier.brush &&
+            alpha == otherModifier.alpha &&
+            shape == otherModifier.shape
+    }
+
+    override fun toString(): String =
+        "Background(color=$color, brush=$brush, alpha = $alpha, shape=$shape)"
+}
 
 abstract class CustomBackgroundModifier(
     inspectorInfo: InspectorInfo.() -> Unit

--- a/core/src/main/kotlin/org/jetbrains/jewel/modifiers/Background.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/modifiers/Background.kt
@@ -147,7 +147,7 @@ private class Background constructor(
     }
 
     override fun toString(): String =
-        "Background(color=$color, brush=$brush, alpha = $alpha, shape=$shape)"
+        "Background(color=$color, brush=$brush, alpha=$alpha, shape=$shape)"
 }
 
 abstract class CustomBackgroundModifier(

--- a/core/src/main/kotlin/org/jetbrains/jewel/modifiers/Border.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/modifiers/Border.kt
@@ -48,7 +48,20 @@ fun Modifier.border(alignment: BorderAlignment, border: BorderStroke, shape: Sha
 fun Modifier.border(alignment: BorderAlignment, width: Dp, color: Color, shape: Shape = RectangleShape) =
     border(alignment, width, SolidColor(color), shape)
 
-fun Modifier.border(alignment: BorderAlignment, width: Dp, brush: Brush, shape: Shape): Modifier = composed(
+fun Modifier.border(alignment: BorderAlignment, width: Dp, brush: Brush, shape: Shape): Modifier =
+    if (alignment == BorderAlignment.Inside && shape !is QuadRoundedCornerShape) {
+        // The compose native border modifier(androidx.compose.foundation.border) draws the border inside the shape,
+        // so we can just use that for getting a more native experience when drawing inside borders
+        border(width, brush, shape)
+    } else {
+        drawBorderWithAlignment(alignment, width, brush, shape)
+    }
+
+enum class BorderAlignment {
+    Inside, Center, Outside
+}
+
+private fun Modifier.drawBorderWithAlignment(alignment: BorderAlignment, width: Dp, brush: Brush, shape: Shape): Modifier = composed(
     factory = {
         val borderCacheRef = remember { Ref<BorderCache>() }
         this.then(
@@ -108,10 +121,6 @@ fun Modifier.border(alignment: BorderAlignment, width: Dp, brush: Brush, shape: 
         properties["shape"] = shape
     }
 )
-
-enum class BorderAlignment {
-    Inside, Center, Outside
-}
 
 private class BorderCache(
     private var imageBitmap: ImageBitmap? = null,

--- a/core/src/main/kotlin/org/jetbrains/jewel/modifiers/Border.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/modifiers/Border.kt
@@ -161,14 +161,8 @@ private fun CacheDrawScope.drawRectBorder(
     drawContent()
     when (alignment) {
         BorderAlignment.INSIDE -> {
-            val cache = borderCacheRef.obtain()
-            val borderPath = cache.obtainPath().apply {
-                reset()
-                fillType = PathFillType.EvenOdd
-                addOutline(outline)
-                addRect(outline.rect.deflate(strokeWidthPx))
-            }
-            drawPath(borderPath, brush)
+            val rect = outline.rect.deflate(strokeWidthPx / 2f)
+            drawRect(brush, rect.topLeft, rect.size, style = Stroke(strokeWidthPx))
         }
 
         BorderAlignment.CENTER -> {
@@ -176,14 +170,8 @@ private fun CacheDrawScope.drawRectBorder(
         }
 
         BorderAlignment.OUTSIDE -> {
-            val cache = borderCacheRef.obtain()
-            val borderPath = cache.obtainPath().apply {
-                reset()
-                fillType = PathFillType.EvenOdd
-                addOutline(outline)
-                addRect(outline.rect.inflate(strokeWidthPx))
-            }
-            drawPath(borderPath, brush)
+            val rect = outline.rect.inflate(strokeWidthPx / 2f)
+            drawRect(brush, rect.topLeft, rect.size, style = Stroke(strokeWidthPx))
         }
     }
 }
@@ -206,10 +194,35 @@ private fun CacheDrawScope.drawRoundedBorder(
                 addRoundRect(outline.roundRect.deflate(strokeWidthPx))
             }
             drawPath(borderPath, brush)
+
+            // This is the option 3 implementation
+//            val rrect = outline.roundRect.deflate(strokeWidthPx / 2f)
+//            val radius = rrect.bottomLeftCornerRadius.x
+//            drawRoundRect(
+//                brush = brush,
+//                topLeft = Offset(rrect.top, rrect.left),
+//                size = Size(rrect.width, rrect.height),
+//                cornerRadius = CornerRadius(radius),
+//                style = Stroke(strokeWidthPx)
+//            )
         }
 
         BorderAlignment.CENTER -> {
-            drawOutline(outline, brush, style = Stroke(strokeWidthPx))
+            val rrect = outline.roundRect
+            val radius = rrect.bottomLeftCornerRadius.x
+
+            if (radius == 0f) {
+                val cache = borderCacheRef.obtain()
+                val borderPath = cache.obtainPath().apply {
+                    reset()
+                    fillType = PathFillType.EvenOdd
+                    addRoundRect(outline.roundRect.deflate(strokeWidthPx / 2f))
+                    addRoundRect(outline.roundRect.inflate(strokeWidthPx / 2f))
+                }
+                drawPath(borderPath, brush)
+            } else {
+                drawOutline(outline, brush, style = Stroke(strokeWidthPx))
+            }
         }
 
         BorderAlignment.OUTSIDE -> {
@@ -221,6 +234,17 @@ private fun CacheDrawScope.drawRoundedBorder(
                 addRoundRect(outline.roundRect.inflate(strokeWidthPx))
             }
             drawPath(borderPath, brush)
+
+            // This is the option 3 implementation
+//            val rrect = outline.roundRect.inflate(strokeWidthPx / 2f)
+//            val radius = rrect.bottomLeftCornerRadius.x
+//            drawRoundRect(
+//                brush = brush,
+//                topLeft = Offset(rrect.top, rrect.left),
+//                size = Size(rrect.width, rrect.height),
+//                cornerRadius = CornerRadius(radius),
+//                style = Stroke(strokeWidthPx)
+//            )
         }
     }
 }

--- a/core/src/main/kotlin/org/jetbrains/jewel/modifiers/Border.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/modifiers/Border.kt
@@ -1,0 +1,346 @@
+package org.jetbrains.jewel.modifiers
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.border
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.CacheDrawScope
+import androidx.compose.ui.draw.DrawResult
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.RoundRect
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.ImageBitmapConfig
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.PathFillType
+import androidx.compose.ui.graphics.PathOperation
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.addOutline
+import androidx.compose.ui.graphics.drawOutline
+import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.node.Ref
+import androidx.compose.ui.platform.debugInspectorInfo
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.toSize
+import kotlin.math.ceil
+import kotlin.math.min
+
+enum class BorderAlignment {
+    INSIDE, CENTER, OUTSIDE
+}
+
+fun Modifier.border(alignment: BorderAlignment, border: BorderStroke, shape: Shape = RectangleShape) =
+    border(alignment = alignment, width = border.width, brush = border.brush, shape = shape)
+
+fun Modifier.border(alignment: BorderAlignment, width: Dp, color: Color, shape: Shape = RectangleShape) =
+    border(alignment, width, SolidColor(color), shape)
+
+fun Modifier.border(alignment: BorderAlignment, width: Dp, brush: Brush, shape: Shape): Modifier = if (alignment == BorderAlignment.INSIDE && false) {
+    // The default border modifier draws the border inside the shape, so we can just use that
+    border(width, brush, shape)
+} else {
+    composed(
+        factory = {
+            val borderCacheRef = remember { Ref<BorderCache>() }
+            this.then(
+                Modifier.drawWithCache {
+                    val strokeWidthPx = min(
+                        if (width == Dp.Hairline) 1f else ceil(width.toPx()),
+                        ceil(size.minDimension / 2)
+                    )
+                    when (val outline = shape.createOutline(size, layoutDirection, this)) {
+                        is Outline.Rectangle -> {
+                            if (shape is RoundedCornerShape) {
+                                drawRoundedBorder(borderCacheRef, alignment, Outline.Rounded(RoundRect(outline.rect)), brush, strokeWidthPx)
+                            } else {
+                                drawRectBorder(borderCacheRef, alignment, outline, brush, strokeWidthPx)
+                            }
+                        }
+
+                        is Outline.Rounded -> drawRoundedBorder(borderCacheRef, alignment, outline, brush, strokeWidthPx)
+                        is Outline.Generic -> drawGenericBorder(borderCacheRef, alignment, outline, brush, strokeWidthPx)
+                    }
+                }
+            )
+        },
+        inspectorInfo = debugInspectorInfo {
+            name = "border"
+            properties["alignment"] = alignment
+            properties["width"] = width
+            if (brush is SolidColor) {
+                properties["color"] = brush.value
+                value = brush.value
+            } else {
+                properties["brush"] = brush
+            }
+            properties["shape"] = shape
+        }
+    )
+}
+
+private data class BorderCache(
+    private var imageBitmap: ImageBitmap? = null,
+    private var canvas: androidx.compose.ui.graphics.Canvas? = null,
+    private var canvasDrawScope: CanvasDrawScope? = null,
+    private var borderPath: Path? = null
+) {
+
+    inline fun CacheDrawScope.drawBorderCache(
+        borderSize: IntSize,
+        config: ImageBitmapConfig,
+        block: DrawScope.() -> Unit
+    ): ImageBitmap {
+        var targetImageBitmap = imageBitmap
+        var targetCanvas = canvas
+        val compatibleConfig = targetImageBitmap?.config == ImageBitmapConfig.Argb8888 ||
+            config == targetImageBitmap?.config
+        if (targetImageBitmap == null ||
+            targetCanvas == null ||
+            size.width > targetImageBitmap.width ||
+            size.height > targetImageBitmap.height ||
+            !compatibleConfig
+        ) {
+            targetImageBitmap = ImageBitmap(
+                borderSize.width,
+                borderSize.height,
+                config = config
+            ).also {
+                imageBitmap = it
+            }
+            targetCanvas = androidx.compose.ui.graphics.Canvas(targetImageBitmap).also {
+                canvas = it
+            }
+        }
+
+        val targetDrawScope = canvasDrawScope ?: CanvasDrawScope().also { canvasDrawScope = it }
+        val drawSize = borderSize.toSize()
+        targetDrawScope.draw(
+            this,
+            layoutDirection,
+            targetCanvas,
+            drawSize
+        ) {
+            drawRect(
+                color = Color.Black,
+                size = drawSize,
+                blendMode = BlendMode.Clear
+            )
+            block()
+        }
+        targetImageBitmap.prepareToDraw()
+        return targetImageBitmap
+    }
+
+    fun obtainPath(): Path =
+        borderPath ?: Path().also { borderPath = it }
+}
+
+private fun Ref<BorderCache>.obtain(): BorderCache =
+    this.value ?: BorderCache().also { value = it }
+
+private fun CacheDrawScope.drawRectBorder(
+    borderCacheRef: Ref<BorderCache>,
+    alignment: BorderAlignment,
+    outline: Outline.Rectangle,
+    brush: Brush,
+    strokeWidthPx: Float
+): DrawResult = onDrawWithContent {
+    drawContent()
+    when (alignment) {
+        BorderAlignment.INSIDE -> {
+            val cache = borderCacheRef.obtain()
+            val borderPath = cache.obtainPath().apply {
+                reset()
+                fillType = PathFillType.EvenOdd
+                addOutline(outline)
+                addRect(outline.rect.deflate(strokeWidthPx))
+            }
+            drawPath(borderPath, brush)
+        }
+
+        BorderAlignment.CENTER -> {
+            drawOutline(outline, brush, style = Stroke(strokeWidthPx))
+        }
+
+        BorderAlignment.OUTSIDE -> {
+            val cache = borderCacheRef.obtain()
+            val borderPath = cache.obtainPath().apply {
+                reset()
+                fillType = PathFillType.EvenOdd
+                addOutline(outline)
+                addRect(outline.rect.inflate(strokeWidthPx))
+            }
+            drawPath(borderPath, brush)
+        }
+    }
+}
+
+private fun CacheDrawScope.drawRoundedBorder(
+    borderCacheRef: Ref<BorderCache>,
+    alignment: BorderAlignment,
+    outline: Outline.Rounded,
+    brush: Brush,
+    strokeWidthPx: Float
+): DrawResult = onDrawWithContent {
+    drawContent()
+    when (alignment) {
+        BorderAlignment.INSIDE -> {
+            val cache = borderCacheRef.obtain()
+            val borderPath = cache.obtainPath().apply {
+                reset()
+                fillType = PathFillType.EvenOdd
+                addOutline(outline)
+                addRoundRect(outline.roundRect.deflate(strokeWidthPx))
+            }
+            drawPath(borderPath, brush)
+        }
+
+        BorderAlignment.CENTER -> {
+            drawOutline(outline, brush, style = Stroke(strokeWidthPx))
+        }
+
+        BorderAlignment.OUTSIDE -> {
+            val cache = borderCacheRef.obtain()
+            val borderPath = cache.obtainPath().apply {
+                reset()
+                fillType = PathFillType.EvenOdd
+                addOutline(outline)
+                addRoundRect(outline.roundRect.inflate(strokeWidthPx))
+            }
+            drawPath(borderPath, brush)
+        }
+    }
+}
+
+private fun CacheDrawScope.drawGenericBorder(
+    borderCacheRef: Ref<BorderCache>,
+    alignment: BorderAlignment,
+    outline: Outline.Generic,
+    brush: Brush,
+    strokeWidth: Float
+): DrawResult = onDrawWithContent {
+    drawContent()
+    when (alignment) {
+        BorderAlignment.INSIDE -> {
+            val config: ImageBitmapConfig
+            val colorFilter: ColorFilter?
+            if (brush is SolidColor) {
+                config = ImageBitmapConfig.Alpha8
+                colorFilter = ColorFilter.tint(brush.value)
+            } else {
+                config = ImageBitmapConfig.Argb8888
+                colorFilter = null
+            }
+            val pathBounds = outline.path.getBounds()
+            val borderCache = borderCacheRef.obtain()
+            val maskPath = borderCache.obtainPath().apply {
+                reset()
+                addRect(pathBounds)
+                op(this, outline.path, PathOperation.Difference)
+            }
+            val cacheImageBitmap: ImageBitmap
+            val pathBoundsSize = IntSize(
+                ceil(pathBounds.width).toInt(),
+                ceil(pathBounds.height).toInt()
+            )
+
+            with(borderCache) {
+                cacheImageBitmap = drawBorderCache(
+                    pathBoundsSize,
+                    config
+                ) {
+                    translate(-pathBounds.left, -pathBounds.top) {
+                        drawPath(path = outline.path, brush = brush, style = Stroke(strokeWidth * 2))
+
+                        drawPath(path = maskPath, brush = brush, blendMode = BlendMode.Clear)
+                    }
+                }
+            }
+
+            onDrawWithContent {
+                drawContent()
+                translate(pathBounds.left, pathBounds.top) {
+                    drawImage(cacheImageBitmap, srcSize = pathBoundsSize, colorFilter = colorFilter)
+                }
+            }
+        }
+
+        BorderAlignment.CENTER -> {
+            drawOutline(outline, brush, style = Stroke(strokeWidth))
+        }
+
+        BorderAlignment.OUTSIDE -> {
+            val config: ImageBitmapConfig
+            val colorFilter: ColorFilter?
+            if (brush is SolidColor) {
+                config = ImageBitmapConfig.Alpha8
+                colorFilter = ColorFilter.tint(brush.value)
+            } else {
+                config = ImageBitmapConfig.Argb8888
+                colorFilter = null
+            }
+            val pathBounds = outline.path.getBounds().inflate(strokeWidth)
+            val borderCache = borderCacheRef.obtain()
+            val cacheImageBitmap: ImageBitmap
+            val pathBoundsSize = IntSize(
+                ceil(pathBounds.width).toInt(),
+                ceil(pathBounds.height).toInt()
+            )
+
+            with(borderCache) {
+                cacheImageBitmap = drawBorderCache(
+                    pathBoundsSize,
+                    config
+                ) {
+                    translate(-pathBounds.left, -pathBounds.top) {
+                        drawPath(path = outline.path, brush = brush, style = Stroke(strokeWidth * 2))
+
+                        drawPath(path = outline.path, brush = brush, blendMode = BlendMode.Clear)
+                    }
+                }
+            }
+
+            onDrawWithContent {
+                drawContent()
+                translate(pathBounds.left, pathBounds.top) {
+                    drawImage(cacheImageBitmap, srcSize = pathBoundsSize, colorFilter = colorFilter)
+                }
+            }
+        }
+    }
+}
+
+fun RoundRect.inflate(delta: Float) = RoundRect(
+    left = left - delta,
+    top = top - delta,
+    right = right + delta,
+    bottom = bottom + delta,
+    topLeftCornerRadius = CornerRadius(topLeftCornerRadius.x + delta, topLeftCornerRadius.y + delta),
+    topRightCornerRadius = CornerRadius(topRightCornerRadius.x + delta, topRightCornerRadius.y + delta),
+    bottomLeftCornerRadius = CornerRadius(bottomLeftCornerRadius.x + delta, bottomLeftCornerRadius.y + delta),
+    bottomRightCornerRadius = CornerRadius(bottomRightCornerRadius.x + delta, bottomRightCornerRadius.y + delta)
+)
+
+fun RoundRect.deflate(delta: Float) = RoundRect(
+    left = left + delta,
+    top = top + delta,
+    right = right - delta,
+    bottom = bottom - delta,
+    topLeftCornerRadius = CornerRadius(topLeftCornerRadius.x - delta, topLeftCornerRadius.y - delta),
+    topRightCornerRadius = CornerRadius(topRightCornerRadius.x - delta, topRightCornerRadius.y - delta),
+    bottomLeftCornerRadius = CornerRadius(bottomLeftCornerRadius.x - delta, bottomLeftCornerRadius.y - delta),
+    bottomRightCornerRadius = CornerRadius(bottomRightCornerRadius.x - delta, bottomRightCornerRadius.y - delta)
+)

--- a/core/src/main/kotlin/org/jetbrains/jewel/modifiers/Border.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/modifiers/Border.kt
@@ -10,7 +10,9 @@ import androidx.compose.ui.draw.CacheDrawScope
 import androidx.compose.ui.draw.DrawResult
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.RoundRect
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -24,7 +26,6 @@ import androidx.compose.ui.graphics.PathOperation
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.graphics.addOutline
 import androidx.compose.ui.graphics.drawOutline
 import androidx.compose.ui.graphics.drawscope.CanvasDrawScope
 import androidx.compose.ui.graphics.drawscope.DrawScope
@@ -38,17 +39,13 @@ import androidx.compose.ui.unit.toSize
 import kotlin.math.ceil
 import kotlin.math.min
 
-enum class BorderAlignment {
-    INSIDE, CENTER, OUTSIDE
-}
-
 fun Modifier.border(alignment: BorderAlignment, border: BorderStroke, shape: Shape = RectangleShape) =
     border(alignment = alignment, width = border.width, brush = border.brush, shape = shape)
 
 fun Modifier.border(alignment: BorderAlignment, width: Dp, color: Color, shape: Shape = RectangleShape) =
     border(alignment, width, SolidColor(color), shape)
 
-fun Modifier.border(alignment: BorderAlignment, width: Dp, brush: Brush, shape: Shape): Modifier = if (alignment == BorderAlignment.INSIDE && false) {
+fun Modifier.border(alignment: BorderAlignment, width: Dp, brush: Brush, shape: Shape): Modifier = if (alignment == BorderAlignment.INSIDE) {
     // The default border modifier draws the border inside the shape, so we can just use that
     border(width, brush, shape)
 } else {
@@ -91,6 +88,11 @@ fun Modifier.border(alignment: BorderAlignment, width: Dp, brush: Brush, shape: 
     )
 }
 
+enum class BorderAlignment {
+    INSIDE, CENTER, OUTSIDE
+}
+
+@Suppress("DataClassShouldBeImmutable")
 private data class BorderCache(
     private var imageBitmap: ImageBitmap? = null,
     private var canvas: androidx.compose.ui.graphics.Canvas? = null,
@@ -107,6 +109,7 @@ private data class BorderCache(
         var targetCanvas = canvas
         val compatibleConfig = targetImageBitmap?.config == ImageBitmapConfig.Argb8888 ||
             config == targetImageBitmap?.config
+        @Suppress("ComplexCondition")
         if (targetImageBitmap == null ||
             targetCanvas == null ||
             size.width > targetImageBitmap.width ||
@@ -186,25 +189,15 @@ private fun CacheDrawScope.drawRoundedBorder(
     drawContent()
     when (alignment) {
         BorderAlignment.INSIDE -> {
-            val cache = borderCacheRef.obtain()
-            val borderPath = cache.obtainPath().apply {
-                reset()
-                fillType = PathFillType.EvenOdd
-                addOutline(outline)
-                addRoundRect(outline.roundRect.deflate(strokeWidthPx))
-            }
-            drawPath(borderPath, brush)
-
-            // This is the option 3 implementation
-//            val rrect = outline.roundRect.deflate(strokeWidthPx / 2f)
-//            val radius = rrect.bottomLeftCornerRadius.x
-//            drawRoundRect(
-//                brush = brush,
-//                topLeft = Offset(rrect.top, rrect.left),
-//                size = Size(rrect.width, rrect.height),
-//                cornerRadius = CornerRadius(radius),
-//                style = Stroke(strokeWidthPx)
-//            )
+            val rrect = outline.roundRect.deflate(strokeWidthPx / 2f)
+            val radius = rrect.bottomLeftCornerRadius.x
+            drawRoundRect(
+                brush = brush,
+                topLeft = Offset(rrect.top, rrect.left),
+                size = Size(rrect.width, rrect.height),
+                cornerRadius = CornerRadius(radius),
+                style = Stroke(strokeWidthPx)
+            )
         }
 
         BorderAlignment.CENTER -> {
@@ -226,25 +219,15 @@ private fun CacheDrawScope.drawRoundedBorder(
         }
 
         BorderAlignment.OUTSIDE -> {
-            val cache = borderCacheRef.obtain()
-            val borderPath = cache.obtainPath().apply {
-                reset()
-                fillType = PathFillType.EvenOdd
-                addOutline(outline)
-                addRoundRect(outline.roundRect.inflate(strokeWidthPx))
-            }
-            drawPath(borderPath, brush)
-
-            // This is the option 3 implementation
-//            val rrect = outline.roundRect.inflate(strokeWidthPx / 2f)
-//            val radius = rrect.bottomLeftCornerRadius.x
-//            drawRoundRect(
-//                brush = brush,
-//                topLeft = Offset(rrect.top, rrect.left),
-//                size = Size(rrect.width, rrect.height),
-//                cornerRadius = CornerRadius(radius),
-//                style = Stroke(strokeWidthPx)
-//            )
+            val rrect = outline.roundRect.inflate(strokeWidthPx / 2f)
+            val radius = rrect.bottomLeftCornerRadius.x
+            drawRoundRect(
+                brush = brush,
+                topLeft = Offset(rrect.top, rrect.left),
+                size = Size(rrect.width, rrect.height),
+                cornerRadius = CornerRadius(radius),
+                style = Stroke(strokeWidthPx)
+            )
         }
     }
 }

--- a/core/src/main/kotlin/org/jetbrains/jewel/modifiers/Border.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/modifiers/Border.kt
@@ -47,71 +47,72 @@ fun Modifier.border(alignment: BorderAlignment, border: BorderStroke, shape: Sha
 fun Modifier.border(alignment: BorderAlignment, width: Dp, color: Color, shape: Shape = RectangleShape) =
     border(alignment, width, SolidColor(color), shape)
 
-fun Modifier.border(alignment: BorderAlignment, width: Dp, brush: Brush, shape: Shape): Modifier = if (alignment == BorderAlignment.INSIDE && shape !is QuadRoundedCornerShape) {
-    // The default border modifier draws the border inside the shape, so we can just use that
-    border(width, brush, shape)
-} else {
-    composed(
-        factory = {
-            val borderCacheRef = remember { Ref<BorderCache>() }
-            this.then(
-                Modifier.drawWithCache {
-                    val strokeWidthPx = min(
-                        if (width == Dp.Hairline) 1f else ceil(width.toPx()),
-                        ceil(size.minDimension / 2)
-                    )
-                    when (val outline = shape.createOutline(size, layoutDirection, this)) {
-                        is Outline.Rectangle -> {
-                            when (shape) {
-                                is RoundedCornerShape -> drawRoundedBorder(
-                                    borderCacheRef,
-                                    alignment,
-                                    Outline.Rounded(RoundRect(outline.rect)),
-                                    brush,
-                                    strokeWidthPx
-                                )
+fun Modifier.border(alignment: BorderAlignment, width: Dp, brush: Brush, shape: Shape): Modifier =
+    if (alignment == BorderAlignment.Inside && shape !is QuadRoundedCornerShape) {
+        // The default border modifier draws the border inside the shape, so we can just use that
+        border(width, brush, shape)
+    } else {
+        composed(
+            factory = {
+                val borderCacheRef = remember { Ref<BorderCache>() }
+                this.then(
+                    Modifier.drawWithCache {
+                        val strokeWidthPx = min(
+                            if (width == Dp.Hairline) 1f else ceil(width.toPx()),
+                            ceil(size.minDimension / 2)
+                        )
+                        when (val outline = shape.createOutline(size, layoutDirection, this)) {
+                            is Outline.Rectangle -> {
+                                when (shape) {
+                                    is RoundedCornerShape -> drawRoundedBorder(
+                                        borderCacheRef,
+                                        alignment,
+                                        Outline.Rounded(RoundRect(outline.rect)),
+                                        brush,
+                                        strokeWidthPx
+                                    )
 
-                                is QuadRoundedCornerShape -> drawQuadRoundedBorder(
-                                    borderCacheRef,
-                                    alignment,
-                                    Outline.Rounded(RoundRect(outline.rect)),
-                                    brush,
-                                    strokeWidthPx
-                                )
+                                    is QuadRoundedCornerShape -> drawQuadRoundedBorder(
+                                        borderCacheRef,
+                                        alignment,
+                                        Outline.Rounded(RoundRect(outline.rect)),
+                                        brush,
+                                        strokeWidthPx
+                                    )
 
-                                else -> drawRectBorder(borderCacheRef, alignment, outline, brush, strokeWidthPx)
+                                    else -> drawRectBorder(borderCacheRef, alignment, outline, brush, strokeWidthPx)
+                                }
                             }
-                        }
 
-                        is Outline.Rounded -> {
-                            when (shape) {
-                                is QuadRoundedCornerShape -> drawQuadRoundedBorder(borderCacheRef, alignment, outline, brush, strokeWidthPx)
-                                else -> drawRoundedBorder(borderCacheRef, alignment, outline, brush, strokeWidthPx)
+                            is Outline.Rounded -> {
+                                when (shape) {
+                                    is QuadRoundedCornerShape -> drawQuadRoundedBorder(borderCacheRef, alignment, outline, brush, strokeWidthPx)
+                                    else -> drawRoundedBorder(borderCacheRef, alignment, outline, brush, strokeWidthPx)
+                                }
                             }
-                        }
 
-                        is Outline.Generic -> drawGenericBorder(borderCacheRef, alignment, outline, brush, strokeWidthPx)
+                            is Outline.Generic -> drawGenericBorder(borderCacheRef, alignment, outline, brush, strokeWidthPx)
+                        }
                     }
+                )
+            },
+            inspectorInfo = debugInspectorInfo {
+                name = "border"
+                properties["alignment"] = alignment
+                properties["width"] = width
+                if (brush is SolidColor) {
+                    properties["color"] = brush.value
+                    value = brush.value
+                } else {
+                    properties["brush"] = brush
                 }
-            )
-        },
-        inspectorInfo = debugInspectorInfo {
-            name = "border"
-            properties["alignment"] = alignment
-            properties["width"] = width
-            if (brush is SolidColor) {
-                properties["color"] = brush.value
-                value = brush.value
-            } else {
-                properties["brush"] = brush
+                properties["shape"] = shape
             }
-            properties["shape"] = shape
-        }
-    )
-}
+        )
+    }
 
 enum class BorderAlignment {
-    INSIDE, CENTER, OUTSIDE
+    Inside, Center, Outside
 }
 
 @Suppress("DataClassShouldBeImmutable")
@@ -185,16 +186,16 @@ private fun CacheDrawScope.drawRectBorder(
 ): DrawResult = onDrawWithContent {
     drawContent()
     when (alignment) {
-        BorderAlignment.INSIDE -> {
+        BorderAlignment.Inside -> {
             val rect = outline.rect.deflate(strokeWidthPx / 2f)
             drawRect(brush, rect.topLeft, rect.size, style = Stroke(strokeWidthPx))
         }
 
-        BorderAlignment.CENTER -> {
+        BorderAlignment.Center -> {
             drawOutline(outline, brush, style = Stroke(strokeWidthPx))
         }
 
-        BorderAlignment.OUTSIDE -> {
+        BorderAlignment.Outside -> {
             val rect = outline.rect.inflate(strokeWidthPx / 2f)
             drawRect(brush, rect.topLeft, rect.size, style = Stroke(strokeWidthPx))
         }
@@ -210,7 +211,7 @@ private fun CacheDrawScope.drawRoundedBorder(
 ): DrawResult = onDrawWithContent {
     drawContent()
     when (alignment) {
-        BorderAlignment.INSIDE -> {
+        BorderAlignment.Inside -> {
             val rrect = outline.roundRect.deflate(strokeWidthPx / 2f)
             val radius = rrect.bottomLeftCornerRadius.x
             drawRoundRect(
@@ -222,7 +223,7 @@ private fun CacheDrawScope.drawRoundedBorder(
             )
         }
 
-        BorderAlignment.CENTER -> {
+        BorderAlignment.Center -> {
             val rrect = outline.roundRect
             val radius = rrect.bottomLeftCornerRadius.x
 
@@ -240,7 +241,7 @@ private fun CacheDrawScope.drawRoundedBorder(
             }
         }
 
-        BorderAlignment.OUTSIDE -> {
+        BorderAlignment.Outside -> {
             val rrect = outline.roundRect.inflate(strokeWidthPx / 2f)
             val radius = rrect.bottomLeftCornerRadius.x
             drawRoundRect(
@@ -263,7 +264,7 @@ private fun CacheDrawScope.drawQuadRoundedBorder(
 ): DrawResult = onDrawWithContent {
     drawContent()
     when (alignment) {
-        BorderAlignment.INSIDE -> {
+        BorderAlignment.Inside -> {
             val cache = borderCacheRef.obtain()
             val borderPath = cache.obtainPath().apply {
                 reset()
@@ -272,7 +273,7 @@ private fun CacheDrawScope.drawQuadRoundedBorder(
             drawPath(borderPath, brush, style = Stroke(strokeWidthPx))
         }
 
-        BorderAlignment.CENTER -> {
+        BorderAlignment.Center -> {
             val rrect = outline.roundRect
             val radius = rrect.bottomLeftCornerRadius.x
             val cache = borderCacheRef.obtain()
@@ -294,7 +295,7 @@ private fun CacheDrawScope.drawQuadRoundedBorder(
             }
         }
 
-        BorderAlignment.OUTSIDE -> {
+        BorderAlignment.Outside -> {
             val cache = borderCacheRef.obtain()
             val borderPath = cache.obtainPath().apply {
                 reset()
@@ -314,7 +315,7 @@ private fun CacheDrawScope.drawGenericBorder(
 ): DrawResult = onDrawWithContent {
     drawContent()
     when (alignment) {
-        BorderAlignment.INSIDE -> {
+        BorderAlignment.Inside -> {
             val config: ImageBitmapConfig
             val colorFilter: ColorFilter?
             if (brush is SolidColor) {
@@ -358,11 +359,11 @@ private fun CacheDrawScope.drawGenericBorder(
             }
         }
 
-        BorderAlignment.CENTER -> {
+        BorderAlignment.Center -> {
             drawOutline(outline, brush, style = Stroke(strokeWidth))
         }
 
-        BorderAlignment.OUTSIDE -> {
+        BorderAlignment.Outside -> {
             val config: ImageBitmapConfig
             val colorFilter: ColorFilter?
             if (brush is SolidColor) {

--- a/core/src/main/kotlin/org/jetbrains/jewel/shape/QuadRoundedCornerShape.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/shape/QuadRoundedCornerShape.kt
@@ -180,36 +180,6 @@ fun Path.addQuadRoundRect(roundRect: RoundRect) {
     close()
 }
 
-fun Path.toData(): String = buildString {
-    var index = 0
-    val path = this@toData.asSkiaPath()
-    path.verbs.forEach {
-        when (it) {
-            PathVerb.MOVE -> append("M ${path.points[index]?.x} ${path.points[index]?.y} ")
-            PathVerb.LINE -> append("L ${path.points[index]?.x} ${path.points[index]?.y} ")
-            PathVerb.QUAD, PathVerb.CONIC -> {
-                append("Q ${path.points[index]?.x} ${path.points[index]?.y} ")
-                index++
-                append(",${path.points[index]?.x} ${path.points[index]?.y} ")
-            }
-            PathVerb.CUBIC -> {
-                append("C ${path.points[index]?.x} ${path.points[index]?.y} ")
-                index++
-                append(",${path.points[index]?.x} ${path.points[index]?.y} ")
-                index++
-                append(",${path.points[index]?.x} ${path.points[index]?.y} ")
-            }
-            PathVerb.CLOSE -> {
-                append("Z")
-                index--
-            }
-            PathVerb.DONE -> TODO()
-            null -> TODO()
-        }
-        index++
-    }
-}
-
 private fun RoundRect.normalized(): RoundRect = copy(
     topRightCornerRadius = topRightCornerRadius.normalized(this),
     topLeftCornerRadius = topLeftCornerRadius.normalized(this),

--- a/core/src/main/kotlin/org/jetbrains/jewel/shape/QuadRoundedCornerShape.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/shape/QuadRoundedCornerShape.kt
@@ -8,11 +8,9 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.geometry.toRect
 import androidx.compose.ui.graphics.Outline
 import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.asSkiaPath
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
-import org.jetbrains.skia.PathVerb
 import kotlin.math.max
 import kotlin.math.min
 

--- a/core/src/main/kotlin/org/jetbrains/jewel/shape/QuadRoundedCornerShape.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/shape/QuadRoundedCornerShape.kt
@@ -1,0 +1,223 @@
+package org.jetbrains.jewel.shape
+
+import androidx.compose.foundation.shape.CornerBasedShape
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.RoundRect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.geometry.toRect
+import androidx.compose.ui.graphics.Outline
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.asSkiaPath
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import org.jetbrains.skia.PathVerb
+import kotlin.math.max
+import kotlin.math.min
+
+class QuadRoundedCornerShape(
+    topStart: CornerSize,
+    topEnd: CornerSize,
+    bottomEnd: CornerSize,
+    bottomStart: CornerSize
+) : CornerBasedShape(
+    topStart = topStart,
+    topEnd = topEnd,
+    bottomEnd = bottomEnd,
+    bottomStart = bottomStart
+) {
+
+    override fun copy(topStart: CornerSize, topEnd: CornerSize, bottomEnd: CornerSize, bottomStart: CornerSize): CornerBasedShape =
+        QuadRoundedCornerShape(
+            topStart = topStart,
+            topEnd = topEnd,
+            bottomEnd = bottomEnd,
+            bottomStart = bottomStart
+        )
+
+    override fun createOutline(
+        size: Size,
+        topStart: Float,
+        topEnd: Float,
+        bottomEnd: Float,
+        bottomStart: Float,
+        layoutDirection: LayoutDirection
+    ): Outline = if (topStart + topEnd + bottomEnd + bottomStart == 0.0f) {
+        Outline.Rectangle(size.toRect())
+    } else {
+        Outline.Rounded(
+            RoundRect(
+                rect = size.toRect(),
+                topLeft = CornerRadius(if (layoutDirection == LayoutDirection.Ltr) topStart else topEnd),
+                topRight = CornerRadius(if (layoutDirection == LayoutDirection.Ltr) topEnd else topStart),
+                bottomRight = CornerRadius(if (layoutDirection == LayoutDirection.Ltr) bottomEnd else bottomStart),
+                bottomLeft = CornerRadius(if (layoutDirection == LayoutDirection.Ltr) bottomStart else bottomEnd)
+            )
+        )
+    }
+
+    override fun toString(): String {
+        return "QuadRoundedCornerShape(topStart = $topStart, topEnd = $topEnd, bottomEnd = " +
+            "$bottomEnd, bottomStart = $bottomStart)"
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is QuadRoundedCornerShape) return false
+
+        if (topStart != other.topStart) return false
+        if (topEnd != other.topEnd) return false
+        if (bottomEnd != other.bottomEnd) return false
+        if (bottomStart != other.bottomStart) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = topStart.hashCode()
+        result = 31 * result + topEnd.hashCode()
+        result = 31 * result + bottomEnd.hashCode()
+        result = 31 * result + bottomStart.hashCode()
+        return result
+    }
+}
+
+/**
+ * Creates [QuadRoundedCornerShape] with the same size applied for all four corners.
+ * @param corner [CornerSize] to apply.
+ */
+fun QuadRoundedCornerShape(corner: CornerSize) =
+    QuadRoundedCornerShape(corner, corner, corner, corner)
+
+/**
+ * Creates [QuadRoundedCornerShape] with the same size applied for all four corners.
+ * @param size Size in [Dp] to apply.
+ */
+fun QuadRoundedCornerShape(size: Dp) = QuadRoundedCornerShape(CornerSize(size))
+
+/**
+ * Creates [QuadRoundedCornerShape] with the same size applied for all four corners.
+ * @param size Size in pixels to apply.
+ */
+fun QuadRoundedCornerShape(size: Float) = QuadRoundedCornerShape(CornerSize(size))
+
+/**
+ * Creates [QuadRoundedCornerShape] with the same size applied for all four corners.
+ * @param percent Size in percents to apply.
+ */
+fun QuadRoundedCornerShape(percent: Int) =
+    QuadRoundedCornerShape(CornerSize(percent))
+
+/**
+ * Creates [QuadRoundedCornerShape] with sizes defined in [Dp].
+ */
+fun QuadRoundedCornerShape(
+    topStart: Dp = 0.dp,
+    topEnd: Dp = 0.dp,
+    bottomEnd: Dp = 0.dp,
+    bottomStart: Dp = 0.dp
+) = QuadRoundedCornerShape(
+    topStart = CornerSize(topStart),
+    topEnd = CornerSize(topEnd),
+    bottomEnd = CornerSize(bottomEnd),
+    bottomStart = CornerSize(bottomStart)
+)
+
+/**
+ * Creates [QuadRoundedCornerShape] with sizes defined in pixels.
+ */
+fun QuadRoundedCornerShape(
+    topStart: Float = 0.0f,
+    topEnd: Float = 0.0f,
+    bottomEnd: Float = 0.0f,
+    bottomStart: Float = 0.0f
+) = QuadRoundedCornerShape(
+    topStart = CornerSize(topStart),
+    topEnd = CornerSize(topEnd),
+    bottomEnd = CornerSize(bottomEnd),
+    bottomStart = CornerSize(bottomStart)
+)
+
+/**
+ * Creates [QuadRoundedCornerShape] with sizes defined in percents of the shape's smaller side.
+ *
+ * @param topStartPercent The top start corner radius as a percentage of the smaller side, with a
+ * range of 0 - 100.
+ * @param topEndPercent The top end corner radius as a percentage of the smaller side, with a
+ * range of 0 - 100.
+ * @param bottomEndPercent The bottom end corner radius as a percentage of the smaller side,
+ * with a range of 0 - 100.
+ * @param bottomStartPercent The bottom start corner radius as a percentage of the smaller side,
+ * with a range of 0 - 100.
+ */
+fun QuadRoundedCornerShape(
+    /*@IntRange(from = 0, to = 100)*/
+    topStartPercent: Int = 0,
+    /*@IntRange(from = 0, to = 100)*/
+    topEndPercent: Int = 0,
+    /*@IntRange(from = 0, to = 100)*/
+    bottomEndPercent: Int = 0,
+    /*@IntRange(from = 0, to = 100)*/
+    bottomStartPercent: Int = 0
+) = QuadRoundedCornerShape(
+    topStart = CornerSize(topStartPercent),
+    topEnd = CornerSize(topEndPercent),
+    bottomEnd = CornerSize(bottomEndPercent),
+    bottomStart = CornerSize(bottomStartPercent)
+)
+
+fun Path.addQuadRoundRect(roundRect: RoundRect) {
+    val rrect = roundRect.normalized()
+    moveTo(rrect.right - rrect.topRightCornerRadius.x, rrect.top)
+    quadraticBezierTo(rrect.right, rrect.top, rrect.right, rrect.top + rrect.topRightCornerRadius.y)
+    lineTo(rrect.right, rrect.bottom - rrect.bottomRightCornerRadius.y)
+    quadraticBezierTo(rrect.right, rrect.bottom, rrect.right - rrect.bottomRightCornerRadius.x, rrect.bottom)
+    lineTo(rrect.left + rrect.bottomLeftCornerRadius.x, rrect.bottom)
+    quadraticBezierTo(rrect.left, rrect.bottom, rrect.left, rrect.bottom - rrect.bottomLeftCornerRadius.y)
+    lineTo(rrect.left, rrect.top + rrect.topLeftCornerRadius.y)
+    quadraticBezierTo(rrect.left, rrect.top, rrect.left + rrect.topLeftCornerRadius.x, rrect.top)
+    close()
+}
+
+fun Path.toData(): String = buildString {
+    var index = 0
+    val path = this@toData.asSkiaPath()
+    path.verbs.forEach {
+        when (it) {
+            PathVerb.MOVE -> append("M ${path.points[index]?.x} ${path.points[index]?.y} ")
+            PathVerb.LINE -> append("L ${path.points[index]?.x} ${path.points[index]?.y} ")
+            PathVerb.QUAD, PathVerb.CONIC -> {
+                append("Q ${path.points[index]?.x} ${path.points[index]?.y} ")
+                index++
+                append(",${path.points[index]?.x} ${path.points[index]?.y} ")
+            }
+            PathVerb.CUBIC -> {
+                append("C ${path.points[index]?.x} ${path.points[index]?.y} ")
+                index++
+                append(",${path.points[index]?.x} ${path.points[index]?.y} ")
+                index++
+                append(",${path.points[index]?.x} ${path.points[index]?.y} ")
+            }
+            PathVerb.CLOSE -> {
+                append("Z")
+                index--
+            }
+            PathVerb.DONE -> TODO()
+            null -> TODO()
+        }
+        index++
+    }
+}
+
+private fun RoundRect.normalized(): RoundRect = copy(
+    topRightCornerRadius = topRightCornerRadius.normalized(this),
+    topLeftCornerRadius = topLeftCornerRadius.normalized(this),
+    bottomRightCornerRadius = bottomRightCornerRadius.normalized(this),
+    bottomLeftCornerRadius = bottomLeftCornerRadius.normalized(this)
+)
+
+private fun CornerRadius.normalized(roundRect: RoundRect): CornerRadius = copy(
+    x = max(min(x, roundRect.width / 2), 0f),
+    y = max(min(y, roundRect.height / 2), 0f)
+)

--- a/themes/darcula/darcula-standalone/src/main/kotlin/org/jetbrains/jewel/themes/darcula/standalone/MetricsExtensions.kt
+++ b/themes/darcula/darcula-standalone/src/main/kotlin/org/jetbrains/jewel/themes/darcula/standalone/MetricsExtensions.kt
@@ -10,7 +10,7 @@ import org.jetbrains.jewel.util.isMacOs
 val IntelliJMetrics.Button.Companion.default
     get() = IntelliJMetrics.Button(
         strokeWidth = 1.dp,
-        arc = CornerSize(2.5.dp),
+        arc = CornerSize(3.dp),
         padding = PaddingValues(horizontal = 14.dp, vertical = 4.dp)
     )
 


### PR DESCRIPTION
This PR support the border alignments, you can use the new order DSL to draw outside border easily.

<img width="212" alt="截屏2023-01-24 01 29 15" src="https://user-images.githubusercontent.com/9367842/214108242-506542ff-1d2f-458d-bbdf-931d438a8c34.png">


**Reference to Sketch's article, there have been 3 main approaches:**
1. Outline the borders: turn them into filled-in shapes rather than lines.
2. Switch to centered borders, but create a mask to hide the inner or outer half.
3. Switch to centered borders, then manually reposition the points in the path yourself (easy for basic shapes, time-consuming for curved or combined shapes).

**This is how I implement it:**

Rect:
1. Inside: Option 3
2. Center: Native support
3. Outside: Option 3

Rounded Rect:  
1. Inside: Option 3
2. Center: Native support, Option 1 for the 0-radius rounded rect 
3. Outside: Option 3

Generic:
1. Inside: Option 2
2. Center: Native support
3. Outside: Option 2

This PR also provides a `QuadRoundedCornerShape` drawn using the Quad function for consistency with how IJ inner borders are drawn.