### PR TITLE
Integration fixes

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -7,4 +7,5 @@ plugins {
 dependencies {
     api(projects.composeUtils)
     api(projects.foundation)
+    api(compose.desktop.common)
 }

--- a/core/src/main/kotlin/org/jetbrains/jewel/Icon.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/Icon.kt
@@ -246,8 +246,3 @@ class RawJarResourceLoader(private val jars: List<String>) : ResourceLoader {
             extractFileFromJar(jarPath, resourcePath)
         }.firstOrNull() ?: error("Resource $resourcePath not found in jars $jars")
 }
-
-
-
-
-

--- a/core/src/main/kotlin/org/jetbrains/jewel/IntelliJTheme.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/IntelliJTheme.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.text.TextStyle
 
+@ExperimentalJewelApi
 interface IntelliJTheme {
 
     val colors: IntelliJColors
@@ -140,6 +141,7 @@ interface IntelliJTheme {
     }
 }
 
+@ExperimentalJewelApi
 @Composable
 fun IntelliJTheme(theme: IntelliJTheme, content: @Composable () -> Unit) {
     CompositionLocalProvider(

--- a/core/src/main/kotlin/org/jetbrains/jewel/IntelliJTree.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/IntelliJTree.kt
@@ -19,6 +19,7 @@ import org.jetbrains.jewel.foundation.tree.TreeState
 import org.jetbrains.jewel.foundation.tree.TreeView
 import org.jetbrains.jewel.foundation.tree.rememberTreeState
 
+@ExperimentalJewelApi
 @Composable
 fun <T> IntelliJTree(
     modifier: Modifier = Modifier,

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/ExperimentalJewelApi.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/ExperimentalJewelApi.kt
@@ -1,0 +1,12 @@
+package org.jetbrains.jewel
+
+@RequiresOptIn(
+    level = RequiresOptIn.Level.WARNING,
+    message = "This is an experimental API for Jewel and is likely to change before becoming " +
+        "stable."
+)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION
+)
+annotation class ExperimentalJewelApi

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/SelectableLazyListScope.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/SelectableLazyListScope.kt
@@ -94,11 +94,17 @@ internal class SelectableLazyListScopeContainer(
                 }
             }
             .focusable()
-            .pointerInput(Unit) {
+            .pointerInput(key) {
                 awaitPointerEventScope {
                     while (true) {
                         awaitFirstDown(false)
-                        if (!isFocused) key.focusRequester.requestFocus()
+                        if (!isFocused)
+                            key.focusRequester
+                                .runCatching { requestFocus() }.onSuccess {
+                                    println("focus requested with success on single item-> ${state.keys.indexOf(key)}")
+                                }.onFailure {
+                                    println("focus requested with failure on single item-> ${state.keys.indexOf(key)}")
+                                }
                         Log.d("focus requested on single item-> ${state.keys.indexOf(key)}")
                     }
                 }

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/SelectableLazyListScope.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/SelectableLazyListScope.kt
@@ -98,14 +98,14 @@ internal class SelectableLazyListScopeContainer(
                 awaitPointerEventScope {
                     while (true) {
                         awaitFirstDown(false)
-                        if (!isFocused)
+                        if (!isFocused) {
                             key.focusRequester
                                 .runCatching { requestFocus() }.onSuccess {
-                                    println("focus requested with success on single item-> ${state.keys.indexOf(key)}")
+                                    Log.d("focus requested with success on single item-> ${state.keys.indexOf(key)}")
                                 }.onFailure {
-                                    println("focus requested with failure on single item-> ${state.keys.indexOf(key)}")
+                                    Log.d("focus requested with failure on single item-> ${state.keys.indexOf(key)}")
                                 }
-                        Log.d("focus requested on single item-> ${state.keys.indexOf(key)}")
+                        }
                     }
                 }
             }

--- a/themes/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/themes/intui/standalone/IntUITreeDefaults.kt
+++ b/themes/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/themes/intui/standalone/IntUITreeDefaults.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.LocalResourceLoader
 import org.jetbrains.jewel.TreeDefaults
 
 abstract class IntUITreeDefaults : TreeDefaults {
@@ -19,5 +20,5 @@ abstract class IntUITreeDefaults : TreeDefaults {
     override fun indentPadding(): Dp = 8.dp
 
     @Composable
-    override fun dropDownArrowIconPainter(): Painter = painterResource("intui/chevronRight.svg")
+    override fun dropDownArrowIconPainter(): Painter = painterResource("intui/chevronRight.svg", LocalResourceLoader.current)
 }


### PR DESCRIPTION
Starting to integrate Jewel into the IDE, I encountered some issues that need to be addressed.
1 - In the IDE, managing the focus of SelectableLazyColumn causes an exception that we believed was resolved with an uninitialized FocusRequester. Since it is a non-critical operation, it has been caught in a catch block.
2 - The ResourceLoader.Default system was failing to load resources in the IDE. Therefore, thanks to @lamba92  we created and made available the ability to customize the ResourceLoader by providing some convenience functions
3 - Minor fixes.