### PR TITLE
Improve outlines in bridge

### DIFF
--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/BridgeGlobalMetrics.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/BridgeGlobalMetrics.kt
@@ -2,7 +2,9 @@ package org.jetbrains.jewel.bridge
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
 import com.intellij.ide.ui.laf.darcula.DarculaUIUtil
+import com.intellij.util.ui.UIUtil
 import org.jetbrains.jewel.GlobalMetrics
 
 @Immutable
@@ -28,8 +30,13 @@ internal class BridgeGlobalMetrics(
 
     companion object {
 
-        fun readFromLaF() = BridgeGlobalMetrics(
-            outlineWidth = DarculaUIUtil.BW.dp,
-        )
+        fun readFromLaF(): BridgeGlobalMetrics {
+            // Copied from DarculaUIUtil.doPaint(java.awt.Graphics2D, int, int, float, float, boolean)
+            // except that scaling is all moved into the .dp operation below
+            val f = if (UIUtil.isRetina()) 0.5f else 1.0f
+            val lw = if (UIUtil.isUnderDefaultMacTheme()) f else DarculaUIUtil.LW.unscaled
+
+            return BridgeGlobalMetrics(outlineWidth = (DarculaUIUtil.BW.unscaled + lw).dp)
+        }
     }
 }


### PR DESCRIPTION
They were too thin — now that's better. Not 100% the same yet, but I suspect it's mostly down to rounding.