### PR TITLE
Add condition for rendering dropdown icon

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/jewel/Dropdown.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/Dropdown.kt
@@ -132,11 +132,13 @@ fun Dropdown(
                     contentAlignment = Alignment.Center,
                 ) {
                     val chevronIcon by style.icons.chevronDown.getPainter(resourceLoader, dropdownState)
-                    Icon(
-                        painter = chevronIcon,
-                        contentDescription = null,
-                        tint = colors.iconTintFor(dropdownState).value,
-                    )
+                    if (enabled) {
+                        Icon(
+                            painter = chevronIcon,
+                            contentDescription = null,
+                            tint = colors.iconTintFor(dropdownState).value,
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
Added a conditional check to render the dropdown chevron icon only when the input field is enabled. This prevents the chevron from being displayed and potentially misleading the user when the dropdown is not selectable.