### PR TITLE
Refine 'addComposeTab' to include closeable option

### DIFF
--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/ComposePanel.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/ComposePanel.kt
@@ -7,7 +7,13 @@ import com.intellij.openapi.wm.ToolWindow
 fun ToolWindow.addComposeTab(
     tabDisplayName: String,
     isLockable: Boolean = true,
+    isCloseable: Boolean = false,
     content: @Composable () -> Unit,
-) = ComposePanel()
-    .apply { setContent(content) }
-    .also { contentManager.addContent(contentManager.factory.createContent(it, tabDisplayName, isLockable)) }
+) {
+    System.setProperty("compose.swing.render.on.graphics", "true")
+    val composePanel = ComposePanel()
+    composePanel.setContent(content)
+    val tabContent = contentManager.factory.createContent(composePanel, tabDisplayName, isLockable)
+    tabContent.isCloseable = isCloseable
+    contentManager.addContent(tabContent)
+}


### PR DESCRIPTION
Introduced 'isCloseable' parameter in 'addComposeTab' function to enable flexibility in controlling behavior of tabs. This option allows programmatically defining whether a tab can be closed or not. Default value set to false to maintain existing function calls.