### PR TITLE
Fix various components

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/jewel/Checkbox.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/Checkbox.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.triStateToggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -284,25 +285,32 @@ private fun CheckboxImpl(
     )
 
     val checkBoxImageModifier = Modifier.size(metrics.checkboxSize)
+    val outlineModifier = Modifier.size(metrics.outlineSize)
+        .offset(metrics.outlineOffset.x, metrics.outlineOffset.y)
         .outline(
             state = checkboxState,
             outline = outline,
             outlineShape = RoundedCornerShape(metrics.checkboxCornerSize),
             alignment = Stroke.Alignment.Center,
-            outlineWidth = metrics.outlineWidth,
         )
 
     val checkboxPainter by icons.checkbox.getPainter(resourceLoader, checkboxState)
 
     if (content == null) {
-        CheckBoxImage(wrapperModifier, checkboxPainter, checkBoxImageModifier)
+        Box(contentAlignment = Alignment.TopStart) {
+            CheckBoxImage(wrapperModifier, checkboxPainter, checkBoxImageModifier)
+            Box(outlineModifier)
+        }
     } else {
         Row(
             wrapperModifier,
             horizontalArrangement = Arrangement.spacedBy(metrics.iconContentGap),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            CheckBoxImage(Modifier, checkboxPainter, checkBoxImageModifier)
+            Box(contentAlignment = Alignment.TopStart) {
+                CheckBoxImage(Modifier, checkboxPainter, checkBoxImageModifier)
+                Box(outlineModifier)
+            }
 
             val contentColor by colors.contentFor(checkboxState)
             CompositionLocalProvider(

--- a/core/src/main/kotlin/org/jetbrains/jewel/DisabledColorFilter.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/DisabledColorFilter.kt
@@ -8,13 +8,12 @@ import androidx.compose.ui.graphics.ColorMatrix
 private val disabledColorMatrixGammaEncoded = ColorMatrix().apply {
     val saturation = .5f
 
-    // We use NTSC luminance weights like Swing does as it's gamma-encoded RGB
-    val redFactor = .299f * saturation
-    val greenFactor = .587f * saturation
-    val blueFactor = .114f * saturation
-
-    // TODO we should also be scaling the brightness but it's not possible
-    //  with a matrix transformation as far as I can tell
+    // We use NTSC luminance weights like Swing does as it's gamma-encoded RGB,
+    // and add some brightness to emulate Swing's "brighter" approach, which is
+    // not representable with a ColorMatrix alone as it's a non-linear op.
+    val redFactor = .299f * saturation + .25f
+    val greenFactor = .587f * saturation + .25f
+    val blueFactor = .114f * saturation + .25f
     this[0, 0] = redFactor
     this[0, 1] = greenFactor
     this[0, 2] = blueFactor

--- a/core/src/main/kotlin/org/jetbrains/jewel/Dropdown.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/Dropdown.kt
@@ -45,6 +45,7 @@ import org.jetbrains.jewel.foundation.border
 import org.jetbrains.jewel.styling.DropdownStyle
 import org.jetbrains.jewel.styling.LocalMenuStyle
 import org.jetbrains.jewel.styling.MenuStyle
+import org.jetbrains.jewel.util.appendIf
 
 @Composable
 fun Dropdown(
@@ -93,6 +94,10 @@ fun Dropdown(
         val arrowMinSize = style.metrics.arrowMinSize
         val borderColor by colors.borderFor(dropdownState)
 
+        val outlineState = remember(dropdownState, expanded) {
+            dropdownState.copy(focused = dropdownState.isFocused || expanded)
+        }
+
         Box(
             modifier.clickable(
                 onClick = {
@@ -109,7 +114,8 @@ fun Dropdown(
             )
                 .background(colors.backgroundFor(dropdownState).value, shape)
                 .border(Stroke.Alignment.Center, style.metrics.borderWidth, borderColor, shape)
-                .outline(dropdownState, outline, shape)
+                .appendIf(outline == Outline.None) { focusOutline(outlineState, shape) }
+                .outline(outlineState, outline, shape)
                 .defaultMinSize(minSize.width, minSize.height.coerceAtLeast(arrowMinSize.height)),
             contentAlignment = Alignment.CenterStart,
         ) {
@@ -262,15 +268,11 @@ value class DropdownState(val state: ULong) : FocusableComponentState {
             hovered: Boolean = false,
             active: Boolean = false,
         ) = DropdownState(
-            if (enabled) {
-                Enabled
-            } else {
-                0UL or
-                    (if (focused) Focused else 0UL) or
-                    (if (pressed) Pressed else 0UL) or
-                    (if (hovered) Hovered else 0UL) or
-                    (if (active) Active else 0UL)
-            },
+            (if (enabled) Enabled else 0UL) or
+                (if (focused) Focused else 0UL) or
+                (if (hovered) Hovered else 0UL) or
+                (if (pressed) Pressed else 0UL) or
+                (if (active) Active else 0UL),
         )
     }
 }

--- a/core/src/main/kotlin/org/jetbrains/jewel/InputField.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/InputField.kt
@@ -93,7 +93,7 @@ internal fun InputField(
         value = value,
         modifier = modifier.then(backgroundModifier)
             .then(borderModifier)
-            .focusOutline(inputState, shape)
+            .appendIf(!undecorated) { focusOutline(inputState, shape) }
             .outline(inputState, outline, shape),
         onValueChange = onValueChange,
         enabled = enabled,

--- a/core/src/main/kotlin/org/jetbrains/jewel/InputField.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/InputField.kt
@@ -22,6 +22,11 @@ import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
+import org.jetbrains.jewel.CommonStateBitMask.Active
+import org.jetbrains.jewel.CommonStateBitMask.Enabled
+import org.jetbrains.jewel.CommonStateBitMask.Focused
+import org.jetbrains.jewel.CommonStateBitMask.Hovered
+import org.jetbrains.jewel.CommonStateBitMask.Pressed
 import org.jetbrains.jewel.foundation.Stroke
 import org.jetbrains.jewel.foundation.border
 import org.jetbrains.jewel.styling.InputFieldStyle
@@ -114,23 +119,23 @@ value class InputFieldState(val state: ULong) : FocusableComponentState {
 
     @Stable
     override val isActive: Boolean
-        get() = state and CommonStateBitMask.Active != 0UL
+        get() = state and Active != 0UL
 
     @Stable
     override val isEnabled: Boolean
-        get() = state and CommonStateBitMask.Enabled != 0UL
+        get() = state and Enabled != 0UL
 
     @Stable
     override val isFocused: Boolean
-        get() = state and CommonStateBitMask.Focused != 0UL
+        get() = state and Focused != 0UL
 
     @Stable
     override val isHovered: Boolean
-        get() = state and CommonStateBitMask.Hovered != 0UL
+        get() = state and Hovered != 0UL
 
     @Stable
     override val isPressed: Boolean
-        get() = state and CommonStateBitMask.Pressed != 0UL
+        get() = state and Pressed != 0UL
 
     fun copy(
         enabled: Boolean = isEnabled,
@@ -159,11 +164,11 @@ value class InputFieldState(val state: ULong) : FocusableComponentState {
             hovered: Boolean = false,
             active: Boolean = false,
         ) = InputFieldState(
-            state = (if (enabled) CommonStateBitMask.Enabled else 0UL) or
-                (if (focused) CommonStateBitMask.Focused else 0UL) or
-                (if (hovered) CommonStateBitMask.Hovered else 0UL) or
-                (if (pressed) CommonStateBitMask.Pressed else 0UL) or
-                (if (active) CommonStateBitMask.Active else 0UL),
+            state = (if (enabled) Enabled else 0UL) or
+                (if (focused) Focused else 0UL) or
+                (if (hovered) Hovered else 0UL) or
+                (if (pressed) Pressed else 0UL) or
+                (if (active) Active else 0UL),
         )
     }
 }

--- a/core/src/main/kotlin/org/jetbrains/jewel/Link.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/Link.kt
@@ -42,8 +42,6 @@ import org.jetbrains.jewel.CommonStateBitMask.Focused
 import org.jetbrains.jewel.CommonStateBitMask.Hovered
 import org.jetbrains.jewel.CommonStateBitMask.Pressed
 import org.jetbrains.jewel.IntelliJTheme.Companion.isSwingCompatMode
-import org.jetbrains.jewel.foundation.Stroke
-import org.jetbrains.jewel.foundation.border
 import org.jetbrains.jewel.foundation.onHover
 import org.jetbrains.jewel.styling.LinkStyle
 import org.jetbrains.jewel.styling.LocalLinkStyle
@@ -157,11 +155,8 @@ fun DropdownLink(
     var expanded by remember { mutableStateOf(false) }
     var hovered by remember { mutableStateOf(false) }
     var skipNextClick by remember { mutableStateOf(false) }
-    Box(
-        Modifier.onHover {
-            hovered = it
-        },
-    ) {
+
+    Box(Modifier.onHover { hovered = it }) {
         LinkImpl(
             text = text,
             onClick = {
@@ -198,7 +193,7 @@ fun DropdownLink(
                 },
                 modifier = menuModifier,
                 style = menuStyle,
-                horizontalAlignment = Alignment.Start, // TODO no idea what goes here
+                horizontalAlignment = Alignment.Start,
                 content = menuContent,
                 resourceLoader = resourceLoader,
             )
@@ -226,7 +221,7 @@ private fun LinkImpl(
     indication: Indication?,
     icon: PainterProvider<LinkState>?,
 ) {
-    var linkState by remember(interactionSource) {
+    var linkState by remember(interactionSource, enabled) {
         mutableStateOf(LinkState.of(enabled = enabled))
     }
     remember(enabled) {
@@ -248,9 +243,7 @@ private fun LinkImpl(
                     }
                 }
 
-                is FocusInteraction.Unfocus -> {
-                    linkState = linkState.copy(focused = false, pressed = false)
-                }
+                is FocusInteraction.Unfocus -> linkState = linkState.copy(focused = false, pressed = false)
             }
         }
     }
@@ -271,29 +264,20 @@ private fun LinkImpl(
             ),
         )
 
-    val clickable = Modifier.clickable(
-        onClick = {
-            linkState = linkState.copy(visited = true)
-            onClick()
-        },
-        enabled = enabled,
-        role = Role.Button,
-        interactionSource = interactionSource,
-        indication = indication,
-    )
-
-    val focusHaloModifier = Modifier.border(
-        alignment = Stroke.Alignment.Outside,
-        width = LocalGlobalMetrics.current.outlineWidth,
-        color = LocalGlobalColors.current.outlines.focused,
-        shape = RoundedCornerShape(style.metrics.focusHaloCornerSize),
-    )
-
     val pointerChangeModifier = Modifier.pointerHoverIcon(PointerIcon(Cursor(Cursor.HAND_CURSOR)))
 
     Row(
-        modifier = modifier.then(clickable)
-            .appendIf(linkState.isFocused) { focusHaloModifier }
+        modifier = modifier.clickable(
+            onClick = {
+                linkState = linkState.copy(visited = true)
+                onClick()
+            },
+            enabled = enabled,
+            role = Role.Button,
+            interactionSource = interactionSource,
+            indication = indication,
+        )
+            .focusOutline(linkState, RoundedCornerShape(style.metrics.focusHaloCornerSize))
             .appendIf(linkState.isEnabled) { pointerChangeModifier },
         horizontalArrangement = Arrangement.spacedBy(style.metrics.textIconGap),
         verticalAlignment = Alignment.CenterVertically,

--- a/core/src/main/kotlin/org/jetbrains/jewel/Link.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/Link.kt
@@ -259,18 +259,20 @@ private fun LinkImpl(
     val pointerChangeModifier = Modifier.pointerHoverIcon(PointerIcon(Cursor(Cursor.HAND_CURSOR)))
 
     Row(
-        modifier = modifier.clickable(
-            onClick = {
-                linkState = linkState.copy(visited = true)
-                onClick()
-            },
-            enabled = enabled,
-            role = Role.Button,
-            interactionSource = interactionSource,
-            indication = null,
-        )
-            .focusOutline(linkState, RoundedCornerShape(style.metrics.focusHaloCornerSize))
-            .appendIf(linkState.isEnabled) { pointerChangeModifier },
+        modifier = modifier
+            .appendIf(linkState.isEnabled) { pointerChangeModifier }
+            .clickable(
+                onClick = {
+                    linkState = linkState.copy(visited = true)
+                    println("clicked Link")
+                    onClick()
+                },
+                enabled = enabled,
+                role = Role.Button,
+                interactionSource = interactionSource,
+                indication = null,
+            )
+            .focusOutline(linkState, RoundedCornerShape(style.metrics.focusHaloCornerSize)),
         horizontalArrangement = Arrangement.spacedBy(style.metrics.textIconGap),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/core/src/main/kotlin/org/jetbrains/jewel/Link.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/Link.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.jewel
 
-import androidx.compose.foundation.Indication
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.HoverInteraction
@@ -67,7 +66,6 @@ fun Link(
     overflow: TextOverflow = TextOverflow.Clip,
     lineHeight: TextUnit = TextUnit.Unspecified,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    indication: Indication? = null,
     style: LinkStyle = LocalLinkStyle.current,
 ) {
     LinkImpl(
@@ -84,7 +82,6 @@ fun Link(
         overflow = overflow,
         lineHeight = lineHeight,
         interactionSource = interactionSource,
-        indication = indication,
         style = style,
         resourceLoader = resourceLoader,
         icon = null,
@@ -107,7 +104,6 @@ fun ExternalLink(
     overflow: TextOverflow = TextOverflow.Clip,
     lineHeight: TextUnit = TextUnit.Unspecified,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    indication: Indication? = null,
     style: LinkStyle = LocalLinkStyle.current,
 ) {
     LinkImpl(
@@ -124,7 +120,6 @@ fun ExternalLink(
         overflow = overflow,
         lineHeight = lineHeight,
         interactionSource = interactionSource,
-        indication = indication,
         style = style,
         resourceLoader = resourceLoader,
         icon = style.icons.externalLink,
@@ -146,7 +141,6 @@ fun DropdownLink(
     overflow: TextOverflow = TextOverflow.Clip,
     lineHeight: TextUnit = TextUnit.Unspecified,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    indication: Indication? = null,
     style: LinkStyle = LocalLinkStyle.current,
     menuModifier: Modifier = Modifier,
     menuStyle: MenuStyle = LocalMenuStyle.current,
@@ -176,7 +170,6 @@ fun DropdownLink(
             overflow = overflow,
             lineHeight = lineHeight,
             interactionSource = interactionSource,
-            indication = indication,
             style = style,
             icon = style.icons.dropdownChevron,
             resourceLoader = resourceLoader,
@@ -218,7 +211,6 @@ private fun LinkImpl(
     overflow: TextOverflow,
     lineHeight: TextUnit,
     interactionSource: MutableInteractionSource,
-    indication: Indication?,
     icon: PainterProvider<LinkState>?,
 ) {
     var linkState by remember(interactionSource, enabled) {
@@ -275,7 +267,7 @@ private fun LinkImpl(
             enabled = enabled,
             role = Role.Button,
             interactionSource = interactionSource,
-            indication = indication,
+            indication = null,
         )
             .focusOutline(linkState, RoundedCornerShape(style.metrics.focusHaloCornerSize))
             .appendIf(linkState.isEnabled) { pointerChangeModifier },

--- a/core/src/main/kotlin/org/jetbrains/jewel/Outline.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/Outline.kt
@@ -29,13 +29,14 @@ enum class Outline {
 fun Modifier.focusOutline(
     state: FocusableComponentState,
     outlineShape: Shape,
+    alignment: Stroke.Alignment = Stroke.Alignment.Outside,
     outlineWidth: Dp = IntelliJTheme.globalMetrics.outlineWidth,
 ): Modifier {
     val outlineColors = IntelliJTheme.globalColors.outlines
 
     return thenIf(state.isFocused) {
         val outlineColor = outlineColors.focused
-        border(Stroke.Alignment.Outside, outlineWidth, outlineColor, outlineShape)
+        border(alignment, outlineWidth, outlineColor, outlineShape)
     }
 }
 

--- a/core/src/main/kotlin/org/jetbrains/jewel/RadioButton.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/RadioButton.kt
@@ -34,6 +34,7 @@ import org.jetbrains.jewel.CommonStateBitMask.Enabled
 import org.jetbrains.jewel.CommonStateBitMask.Focused
 import org.jetbrains.jewel.CommonStateBitMask.Hovered
 import org.jetbrains.jewel.CommonStateBitMask.Pressed
+import org.jetbrains.jewel.foundation.Stroke
 import org.jetbrains.jewel.styling.RadioButtonStyle
 
 @Composable
@@ -164,8 +165,9 @@ private fun RadioButtonImpl(
 
     val colors = style.colors
     val metrics = style.metrics
-    val radioButtonModifier = Modifier.size(metrics.radioButtonSize)
-        .outline(radioButtonState, outline, outlineShape = CircleShape)
+    val radioButtonModifier = Modifier
+        .size(metrics.radioButtonSize)
+        .outline(radioButtonState, outline, outlineShape = CircleShape, alignment = Stroke.Alignment.Inside)
     val radioButtonPainter by style.icons.radioButton.getPainter(resourceLoader, radioButtonState)
 
     if (content == null) {

--- a/core/src/main/kotlin/org/jetbrains/jewel/styling/CheckboxStyling.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/styling/CheckboxStyling.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpSize
 import org.jetbrains.jewel.CheckboxState
 
@@ -55,7 +56,8 @@ interface CheckboxMetrics {
 
     val checkboxSize: DpSize
     val checkboxCornerSize: CornerSize
-    val outlineWidth: Dp
+    val outlineSize: DpSize
+    val outlineOffset: DpOffset
     val iconContentGap: Dp
 }
 

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/IntUiBridge.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/IntUiBridge.kt
@@ -262,7 +262,8 @@ private fun readCheckboxStyle(iconData: IntelliJThemeIconData, svgLoader: SvgLoa
         metrics = IntUiCheckboxMetrics(
             checkboxSize = DarculaCheckBoxUI().defaultIcon.let { DpSize(it.iconWidth.dp, it.iconHeight.dp) },
             checkboxCornerSize = CornerSize(3.dp), // See DarculaCheckBoxUI#drawCheckIcon
-            outlineWidth = 3.dp, // See DarculaCheckBoxUI#drawCheckIcon
+            outlineSize = DpSize(15.dp, 15.dp), // Extrapolated from SVG
+            outlineOffset = DpOffset(2.5.dp, 1.5.dp), // Extrapolated from SVG
             iconContentGap = 5.dp, // See DarculaCheckBoxUI#textIconGap
         ),
         icons = IntUiCheckboxIcons(

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/themes/intui/standalone/styling/IntUiCheckboxStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/themes/intui/standalone/styling/IntUiCheckboxStyling.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import org.jetbrains.jewel.CheckboxState
@@ -97,9 +98,10 @@ data class IntUiCheckboxColors(
 
 @Immutable
 data class IntUiCheckboxMetrics(
-    override val checkboxSize: DpSize = DpSize(20.dp, 20.dp),
+    override val checkboxSize: DpSize = DpSize(19.dp, 19.dp),
     override val checkboxCornerSize: CornerSize = CornerSize(3.dp),
-    override val outlineWidth: Dp = 3.dp,
+    override val outlineSize: DpSize = DpSize(15.dp, 15.dp),
+    override val outlineOffset: DpOffset = DpOffset(2.5.dp, 1.5.dp),
     override val iconContentGap: Dp = 4.dp,
 ) : CheckboxMetrics
 

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/themes/intui/standalone/styling/IntUiCheckboxStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/themes/intui/standalone/styling/IntUiCheckboxStyling.kt
@@ -102,7 +102,7 @@ data class IntUiCheckboxMetrics(
     override val checkboxCornerSize: CornerSize = CornerSize(3.dp),
     override val outlineSize: DpSize = DpSize(15.dp, 15.dp),
     override val outlineOffset: DpOffset = DpOffset(2.5.dp, 1.5.dp),
-    override val iconContentGap: Dp = 4.dp,
+    override val iconContentGap: Dp = 5.dp,
 ) : CheckboxMetrics
 
 @Immutable

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/themes/intui/standalone/styling/IntUiDropdownStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/themes/intui/standalone/styling/IntUiDropdownStyling.kt
@@ -176,10 +176,10 @@ data class IntUiDropdownColors(
 
 @Stable
 data class IntUiDropdownMetrics(
-    override val arrowMinSize: DpSize = DpSize((23 + 3).dp, (24 + 6).dp),
-    override val minSize: DpSize = DpSize((49 + 23 + 6).dp, (24 + 6).dp),
+    override val arrowMinSize: DpSize = DpSize((23 + 3).dp, 24.dp),
+    override val minSize: DpSize = DpSize((49 + 23 + 6).dp, 24.dp),
     override val cornerSize: CornerSize = CornerSize(4.dp),
-    override val contentPadding: PaddingValues = PaddingValues(3.dp),
+    override val contentPadding: PaddingValues = PaddingValues(horizontal = 6.dp, vertical = 3.dp),
     override val borderWidth: Dp = 1.dp,
 ) : DropdownMetrics
 


### PR DESCRIPTION
This PR fixes a number of issues with various components:
1. Link
   * Disabled icons look closer to Swing
   * Use focusOutline modifier instead of custom implementation
   * Remove indication — it must always be null
2. Checkbox
   * Fix outlines size and position to match the SVGs
   * Use global outline size
   * Tweak standalone metric iconTextGap
3. Radio Button
   * Fix outlines to match the SVGs
4. Dropdown
   * State mutation was broken (no focus, etc.)
   * Min size and padding are closer to Swing now
   * Focus ring was missing
   * Now we pretend it's focused when the menu is open (like Swing does)
5. InputField (TextFields and TextAreas)
   * Only show focus outline when undecorated = false

Plus some minor cleanup.