### PR TITLE
No indication by default in Jewel

### DIFF
--- a/int-ui/int-ui-core/src/main/kotlin/org/jetbrains/jewel/intui/core/BaseIntUiTheme.kt
+++ b/int-ui/int-ui-core/src/main/kotlin/org/jetbrains/jewel/intui/core/BaseIntUiTheme.kt
@@ -1,10 +1,15 @@
 package org.jetbrains.jewel.intui.core
 
+import androidx.compose.foundation.Indication
+import androidx.compose.foundation.IndicationInstance
 import androidx.compose.foundation.LocalContextMenuRepresentation
+import androidx.compose.foundation.LocalIndication
+import androidx.compose.foundation.interaction.InteractionSource
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import androidx.compose.ui.text.TextStyle
 import org.jetbrains.jewel.GlobalColors
 import org.jetbrains.jewel.GlobalMetrics
@@ -215,7 +220,22 @@ fun BaseIntUiTheme(
         LocalTextFieldStyle provides componentStyling.textFieldStyle,
         LocalDefaultTabStyle provides componentStyling.defaultTabStyle,
         LocalEditorTabStyle provides componentStyling.editorTabStyle,
+        LocalIndication provides NoIndication,
     ) {
         IntelliJTheme(theme, swingCompatMode, content)
     }
+}
+
+private object NoIndication : Indication {
+
+    private object NoIndicationInstance : IndicationInstance {
+
+        override fun ContentDrawScope.drawIndication() {
+            drawContent()
+        }
+    }
+
+    @Composable
+    override fun rememberUpdatedInstance(interactionSource: InteractionSource): IndicationInstance =
+        NoIndicationInstance
 }


### PR DESCRIPTION
Indication is not compatible with how Int UI handles state, so we need to disable it by default.