### PR TITLE
Implement tree traversal methods in Tree class

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/jewel/foundation/tree/Tree.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/foundation/tree/Tree.kt
@@ -1,13 +1,35 @@
 package org.jetbrains.jewel.foundation.tree
 
+import org.jetbrains.jewel.foundation.tree.Tree.Element.Node
+
 @Suppress("UNCHECKED_CAST")
 fun <T> emptyTree() = Tree.EMPTY as Tree<T>
 
-class Tree<T> internal constructor(internal val roots: List<Element<T>>) {
+class Tree<T> internal constructor(val roots: List<Element<T>>) {
 
     companion object {
         internal val EMPTY = Tree(roots = emptyList<Element<Any?>>())
     }
+
+    fun isEmpty() = roots.isEmpty()
+
+    private fun walk(breathFirst: Boolean) = sequence {
+        val queue = roots.toMutableList()
+        while (queue.isNotEmpty()) {
+            val next = queue.removeFirst()
+            yield(next)
+            if (next is Node) {
+                next.open()
+                if (breathFirst)
+                    queue.addAll(next.children ?: emptyList())
+                else
+                    queue.addAll(0, next.children ?: emptyList())
+            }
+        }
+    }
+
+    fun walkBreadthFirst() = walk(true)
+    fun walkDepthFirst() = walk(false)
 
     sealed interface Element<T> {
 


### PR DESCRIPTION
Enhanced the Tree class in the jewel foundation by adding two new methods for performing tree traversal: 'walkBreadthFirst' and 'walkDepthFirst'. These enhancements provide flexibility in tree exploration based on the application needs. Modifying the 'roots' variable from 'internal' to 'val' to facilitate tree manipulation.