### PR TITLE
Update Compose for Desktop to 1.5.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeDesktop = "1.5.1"
+composeDesktop = "1.5.2"
 coroutines = "1.7.3"
 detekt = "1.23.1"
 idea = "232.8660.185"


### PR DESCRIPTION
It contains an urgent hotfix — on 1.5.1, if users use a touch screen, it will crash the app on the first click.