### PR TITLE
Exclude Material dependency again

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -6,5 +6,7 @@ plugins {
 }
 
 dependencies {
-    api(compose.desktop.currentOs)
+    api(compose.desktop.currentOs) {
+        exclude(group = "org.jetbrains.compose.material")
+    }
 }


### PR DESCRIPTION
Exclusion was lost in the removal of compose-util module