### PR TITLE
Include only foundation-desktop in the published library

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.compose.ComposeBuildConfig
+
 plugins {
     jewel
     `jewel-publish`
@@ -5,8 +7,8 @@ plugins {
     alias(libs.plugins.kotlinSerialization)
 }
 
+private val composeVersion get() = ComposeBuildConfig.composeVersion
+
 dependencies {
-    api(compose.desktop.currentOs) {
-        exclude(group = "org.jetbrains.compose.material")
-    }
+    api("org.jetbrains.compose.foundation:foundation-desktop:$composeVersion")
 }

--- a/ide-laf-bridge/build.gradle.kts
+++ b/ide-laf-bridge/build.gradle.kts
@@ -9,4 +9,7 @@ dependencies {
     compileOnly(libs.bundles.idea)
 
     testImplementation(compose.desktop.uiTestJUnit4)
+    testImplementation(compose.desktop.currentOs) {
+        exclude(group = "org.jetbrains.compose.material")
+    }
 }

--- a/samples/ide-plugin/build.gradle.kts
+++ b/samples/ide-plugin/build.gradle.kts
@@ -22,4 +22,7 @@ repositories {
 
 dependencies {
     implementation(projects.ideLafBridge)
+    implementation(compose.desktop.currentOs) {
+        exclude(group = "org.jetbrains.compose.material")
+    }
 }

--- a/samples/standalone/build.gradle.kts
+++ b/samples/standalone/build.gradle.kts
@@ -9,6 +9,9 @@ plugins {
 
 dependencies {
     implementation(projects.intUi.intUiStandalone)
+    implementation(compose.desktop.currentOs) {
+        exclude(group = "org.jetbrains.compose.material")
+    }
 }
 
 compose.desktop {


### PR DESCRIPTION
Common layout for Compose for Desktop libraries should be that "library" part depends only on needed foundation/material/ui parts and "sample" part depends on `compose.desktop.currentOs`, so dependency on skiko runtime will be provided for these samples.