### PR TITLE
Fix tooltip styling

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/jewel/Tooltip.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/Tooltip.kt
@@ -11,6 +11,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import org.jetbrains.jewel.styling.TooltipStyle
@@ -32,14 +34,23 @@ import org.jetbrains.jewel.styling.TooltipStyle
                 LocalContentColor provides style.colors.content,
             ) {
                 Box(
-                    modifier = Modifier.background(
-                        color = style.colors.background,
-                        shape = RoundedCornerShape(style.metrics.cornerSize),
-                    ).border(
-                        width = style.metrics.borderWidth,
-                        color = style.colors.border,
-                        shape = RoundedCornerShape(style.metrics.cornerSize),
-                    ).padding(style.metrics.contentPadding),
+                    modifier = Modifier
+                        .shadow(
+                            elevation = style.metrics.shadowSize,
+                            shape = RoundedCornerShape(style.metrics.cornerSize),
+                            ambientColor = style.colors.shadow,
+                            spotColor = Color.Transparent,
+                        )
+                        .background(
+                            color = style.colors.background,
+                            shape = RoundedCornerShape(style.metrics.cornerSize),
+                        )
+                        .border(
+                            width = style.metrics.borderWidth,
+                            color = style.colors.border,
+                            shape = RoundedCornerShape(style.metrics.cornerSize),
+                        )
+                        .padding(style.metrics.contentPadding),
                 ) {
                     tooltip()
                 }

--- a/core/src/main/kotlin/org/jetbrains/jewel/styling/TooltipStyling.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/styling/TooltipStyling.kt
@@ -21,6 +21,7 @@ interface TooltipColors {
     val background: Color
     val content: Color
     val border: Color
+    val shadow: Color
 }
 
 @Stable
@@ -30,6 +31,7 @@ interface TooltipMetrics {
     val showDelay: Duration
     val cornerSize: CornerSize
     val borderWidth: Dp
+    val shadowSize: Dp
 }
 
 val LocalTooltipStyle = staticCompositionLocalOf<TooltipStyle> {

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/IntUiBridge.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/IntUiBridge.kt
@@ -167,7 +167,7 @@ internal fun createSwingIntUiComponentStyling(
         scrollbarStyle = readScrollbarStyle(theme.isDark),
         textAreaStyle = readTextAreaStyle(textAreaTextStyle, textFieldStyle.metrics),
         circularProgressStyle = readCircularProgressStyle(theme.isDark),
-        tooltipStyle = readTooltipStyle(theme.isDark),
+        tooltipStyle = readTooltipStyle(),
         textFieldStyle = textFieldStyle,
     )
 }
@@ -899,19 +899,16 @@ private fun readCircularProgressStyle(
             ?: if (isDark) Color(0xFF6F737A) else Color(0xFFA8ADBD),
     )
 
-private fun readTooltipStyle(
-    isDark: Boolean,
-): IntUiTooltipStyle {
-    val background =
-        if (isDark) "Tooltip.background" else "ToolTip.background"
-    val content =
-        if (isDark) "Tooltip.foreground" else "ToolTip.foreground"
+private fun readTooltipStyle(): IntUiTooltipStyle {
+    val background = "ToolTip.background"
+    val content = "ToolTip.foreground"
     return IntUiTooltipStyle(
         metrics = IntUiTooltipMetrics(),
         colors = IntUiTooltipColors(
             content = retrieveColorOrUnspecified(content),
             background = retrieveColorOrUnspecified(background),
-            border = retrieveColorOrUnspecified("Tooltip.borderColor"),
+            border = retrieveColorOrUnspecified("ToolTip.borderColor"),
+            shadow = Color.Black.copy(alpha = .6f),
         ),
     )
 }

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/IntUiBridge.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/IntUiBridge.kt
@@ -900,13 +900,11 @@ private fun readCircularProgressStyle(
     )
 
 private fun readTooltipStyle(): IntUiTooltipStyle {
-    val background = "ToolTip.background"
-    val content = "ToolTip.foreground"
     return IntUiTooltipStyle(
         metrics = IntUiTooltipMetrics(),
         colors = IntUiTooltipColors(
-            content = retrieveColorOrUnspecified(content),
-            background = retrieveColorOrUnspecified(background),
+            content = retrieveColorOrUnspecified("ToolTip.foreground"),
+            background = retrieveColorOrUnspecified("ToolTip.background"),
             border = retrieveColorOrUnspecified("ToolTip.borderColor"),
             shadow = Color.Black.copy(alpha = .6f),
         ),

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTooltipStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTooltipStyling.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import org.jetbrains.jewel.IntelliJTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.styling.TooltipColors
@@ -49,6 +48,7 @@ data class IntUiTooltipColors(
     override val content: Color,
     override val background: Color,
     override val border: Color,
+    override val shadow: Color,
 ) : TooltipColors {
 
     companion object {
@@ -57,22 +57,25 @@ data class IntUiTooltipColors(
         fun light(
             contentColor: Color = IntUiLightTheme.colors.grey(12),
             backgroundColor: Color = IntUiLightTheme.colors.grey(2),
-            borderColor: Color = IntelliJTheme.globalColors.borders.normal,
-        ) = IntUiTooltipColors(contentColor, backgroundColor, borderColor)
+            borderColor: Color = backgroundColor,
+            shadow: Color = Color(0x78919191), // Not a palette color
+        ) = IntUiTooltipColors(contentColor, backgroundColor, borderColor, shadow)
 
         @Composable
         fun dark(
             contentColor: Color = IntUiDarkTheme.colors.grey(12),
             backgroundColor: Color = IntUiDarkTheme.colors.grey(2),
-            borderColor: Color = IntelliJTheme.globalColors.borders.normal,
-        ) = IntUiTooltipColors(contentColor, backgroundColor, borderColor)
+            shadow: Color = Color(0x66000000), // Not a palette color
+            borderColor: Color = IntUiDarkTheme.colors.grey(3),
+        ) = IntUiTooltipColors(contentColor, backgroundColor, borderColor, shadow)
     }
 }
 
 @Stable
 data class IntUiTooltipMetrics(
-    override val contentPadding: PaddingValues = PaddingValues(vertical = 8.dp, horizontal = 8.dp),
+    override val contentPadding: PaddingValues = PaddingValues(vertical = 9.dp, horizontal = 12.dp),
     override val showDelay: Duration = 0.milliseconds,
-    override val cornerSize: CornerSize = CornerSize(8.dp),
+    override val cornerSize: CornerSize = CornerSize(5.dp),
     override val borderWidth: Dp = 1.dp,
+    override val shadowSize: Dp = 12.dp,
 ) : TooltipMetrics


### PR DESCRIPTION
 Theme (New UI) | Swing | Jewel
 --- | --- | ---
 Dark | <img width="70" alt="image" src="https://github.com/JetBrains/jewel/assets/37424073/2e23a405-015f-4f03-b130-61ef428ac0fe"> | <img width="73" alt="image" src="https://github.com/JetBrains/jewel/assets/37424073/ccedd92b-21eb-47e0-9ea4-70e421ef7138"> 
Light | <img width="79" alt="image" src="https://github.com/JetBrains/jewel/assets/37424073/6d47314f-703f-476c-863c-31691f12b698"> | <img width="71" alt="image" src="https://github.com/JetBrains/jewel/assets/37424073/062018b1-4ca3-486a-a74e-1d927549b9f1">
Light (light header) | <img width="77" alt="image" src="https://github.com/JetBrains/jewel/assets/37424073/981be9d0-b5fd-4e6a-a58e-a6bd5a95e238"> | <img width="73" alt="image" src="https://github.com/JetBrains/jewel/assets/37424073/7fc8a8aa-1dcc-49a1-a311-84cba798c463">


Now they look the same to me 

Fixes #155 
