### PR TITLE
Support different IntelliJ versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         supported-ij-version:
           - 232
-          - 233
+#          - 233
 
     steps:
       - uses: actions/checkout@v3
@@ -35,7 +35,7 @@ jobs:
       matrix:
         supported-ij-version:
           - 232
-          - 233
+#          - 233
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,12 @@ jobs:
   assemble:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        supported-ij-version:
+          - 232
+          - 233
+
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 17
@@ -20,10 +26,16 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Run :assemble task
-        run: ./gradlew assemble
+        run: ./gradlew assemble -Psupported.ij.version=${{ matrix.supported-ij-version }}
 
   checks:
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        supported-ij-version:
+          - 232
+          - 233
 
     steps:
       - uses: actions/checkout@v3
@@ -39,11 +51,11 @@ jobs:
         run: chmod +x gradlew
 
       - name: Run :check task
-        run: ./gradlew check --continue
+        run: ./gradlew check -Psupported.ij.version=${{ matrix.supported-ij-version }} --continue
 
       - name: Merge SARIF reports
         # Necessary because upload-sarif only takes up to 15 SARIF files and we have more
-        run: ./gradlew :mergeSarifReports
+        run: ./gradlew :mergeSarifReports -Psupported.ij.version=${{ matrix.supported-ij-version }}
         if: ${{ always() }}
 
       - uses: github/codeql-action/upload-sarif@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,15 +5,9 @@ on:
   push:
     branches: [ main ]
 jobs:
-  publish:
-    name: Publish
+  publish-core:
+    name: Publish Jewel Core
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        supported-ij-version:
-          - 232
-#          - 233
 
     steps:
       - uses: actions/checkout@v3
@@ -23,13 +17,33 @@ jobs:
           java-version: 17
       - name: Setup Gradle
         run: chmod +x gradlew
-      - name: Run Jewel Core Publishing
+      - name: Run Gradle
         # supported.ij.version is needed here for project configuration and won't be used during publishing
-        run: ./gradlew publishMainPublicationsToSpaceRepository -Psupported.ij.version=${{ matrix.supported-ij-version }}
+        run: ./gradlew publishMainPublicationsToSpaceRepository -Psupported.ij.version=232
         env:
           MAVEN_SPACE_USERNAME: ${{secrets.MAVEN_SPACE_USERNAME}}
           MAVEN_SPACE_PASSWORD: ${{secrets.MAVEN_SPACE_PASSWORD}}
-      - name: Run Jewel IDE Publishing
+
+  publish-ide:
+    name: Publish Jewel IDE part
+    needs: publish-core
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        supported-ij-version:
+          - 232
+    #          - 233
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+      - name: Setup Gradle
+        run: chmod +x gradlew
+      - name: Run Gradle
         run: ./gradlew publishIdeMainPublicationsToSpaceRepository -Psupported.ij.version=${{ matrix.supported-ij-version }}
         env:
           MAVEN_SPACE_USERNAME: ${{secrets.MAVEN_SPACE_USERNAME}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,8 +23,13 @@ jobs:
           java-version: 17
       - name: Setup Gradle
         run: chmod +x gradlew
-      - name: Run Gradle
-        run: ./gradlew publishAllPublicationsToSpaceRepository -Psupported.ij.version=${{ matrix.supported-ij-version }}
+      - name: Run Jewel Core Publishing
+        run: ./gradlew publishMainPublicationsToSpaceRepository
+        env:
+          MAVEN_SPACE_USERNAME: ${{secrets.MAVEN_SPACE_USERNAME}}
+          MAVEN_SPACE_PASSWORD: ${{secrets.MAVEN_SPACE_PASSWORD}}
+      - name: Run Jewel IDE Publishing
+        run: ./gradlew publishIdeMainPublicationsToSpaceRepository -Psupported.ij.version=${{ matrix.supported-ij-version }}
         env:
           MAVEN_SPACE_USERNAME: ${{secrets.MAVEN_SPACE_USERNAME}}
           MAVEN_SPACE_PASSWORD: ${{secrets.MAVEN_SPACE_PASSWORD}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,13 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        supported-ij-version:
+          - 232
+#          - 233
+
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
@@ -17,7 +24,7 @@ jobs:
       - name: Setup Gradle
         run: chmod +x gradlew
       - name: Run Gradle
-        run: ./gradlew publishAllPublicationsToSpaceRepository
+        run: ./gradlew publishAllPublicationsToSpaceRepository -Psupported.ij.version=${{ matrix.supported-ij-version }}
         env:
           MAVEN_SPACE_USERNAME: ${{secrets.MAVEN_SPACE_USERNAME}}
           MAVEN_SPACE_PASSWORD: ${{secrets.MAVEN_SPACE_PASSWORD}}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Setup Gradle
         run: chmod +x gradlew
       - name: Run Jewel Core Publishing
-        run: ./gradlew publishMainPublicationsToSpaceRepository
+        # supported.ij.version is needed here for project configuration and won't be used during publishing
+        run: ./gradlew publishMainPublicationsToSpaceRepository -Psupported.ij.version=${{ matrix.supported-ij-version }}
         env:
           MAVEN_SPACE_USERNAME: ${{secrets.MAVEN_SPACE_USERNAME}}
           MAVEN_SPACE_PASSWORD: ${{secrets.MAVEN_SPACE_PASSWORD}}

--- a/buildSrc/src/main/kotlin/IdeaConfiguration.kt
+++ b/buildSrc/src/main/kotlin/IdeaConfiguration.kt
@@ -1,0 +1,25 @@
+import org.gradle.api.Project
+
+enum class SupportedIJVersion {
+    IJ_232,
+    IJ_233
+}
+
+fun Project.supportedIJVersion(): SupportedIJVersion {
+    val prop = localProperty("supported.ij.version")
+        ?: error(
+            "'supported.ij.version' gradle property is missing. " +
+                "Please, provide it using local.properties file or -Psupported.ij.version argument in CLI"
+        )
+
+    return when (prop) {
+        "232" -> SupportedIJVersion.IJ_232
+        "233" -> SupportedIJVersion.IJ_233
+        else -> {
+            error(
+                "Invalid 'supported.ij.version' with value '$prop' is provided. " +
+                    "It should be in set of these values: ('232', '233')"
+            )
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/IdeaConfiguration.kt
+++ b/buildSrc/src/main/kotlin/IdeaConfiguration.kt
@@ -7,6 +7,7 @@ enum class SupportedIJVersion {
 
 fun Project.supportedIJVersion(): SupportedIJVersion {
     val prop = localProperty("supported.ij.version")
+        ?: rootProject.property("supported.ij.version")
         ?: error(
             "'supported.ij.version' gradle property is missing. " +
                 "Please, provide it using local.properties file or -Psupported.ij.version argument in CLI"

--- a/buildSrc/src/main/kotlin/LocalProperties.kt
+++ b/buildSrc/src/main/kotlin/LocalProperties.kt
@@ -1,0 +1,12 @@
+import org.gradle.api.Project
+import java.util.Properties
+
+internal fun Project.localProperty(propertyName: String): String? {
+    val localPropertiesFile = rootProject.file("local.properties")
+    if (!localPropertiesFile.exists()) {
+        return null
+    }
+    val properties = Properties()
+    localPropertiesFile.inputStream().use { properties.load(it) }
+    return properties.getProperty(propertyName)
+}

--- a/buildSrc/src/main/kotlin/PublishConfiguration.kt
+++ b/buildSrc/src/main/kotlin/PublishConfiguration.kt
@@ -19,7 +19,7 @@ internal fun PublishingExtension.configureJewelRepositories() {
 
 internal fun MavenPom.configureJewelPom() {
     name = "Jewel"
-    description = "intelliJ theming system in for Compose."
+    description = "A theme for Compose for Desktop that implements the IntelliJ Platform look and feel."
     url = "https://github.com/JetBrains/jewel"
     licenses {
         license {

--- a/buildSrc/src/main/kotlin/PublishConfiguration.kt
+++ b/buildSrc/src/main/kotlin/PublishConfiguration.kt
@@ -1,0 +1,35 @@
+@file:Suppress("UnstableApiUsage")
+
+import org.gradle.api.publish.PublishingExtension
+import org.gradle.api.publish.maven.MavenPom
+import org.gradle.kotlin.dsl.assign
+import org.gradle.kotlin.dsl.maven
+
+internal fun PublishingExtension.configureJewelRepositories() {
+    repositories {
+        maven("https://packages.jetbrains.team/maven/p/kpm/public") {
+            name = "Space"
+            credentials {
+                username = System.getenv("MAVEN_SPACE_USERNAME")
+                password = System.getenv("MAVEN_SPACE_PASSWORD")
+            }
+        }
+    }
+}
+
+internal fun MavenPom.configureJewelPom() {
+    name = "Jewel"
+    description = "intelliJ theming system in for Compose."
+    url = "https://github.com/JetBrains/jewel"
+    licenses {
+        license {
+            name = "Apache License 2.0"
+            url = "http://www.apache.org/licenses/LICENSE-2.0.txt"
+        }
+    }
+    scm {
+        connection = "scm:git:https://github.com/JetBrains/jewel.git"
+        developerConnection = "scm:git:https://github.com/JetBrains/jewel.git"
+        url = "https://github.com/JetBrains/jewel"
+    }
+}

--- a/buildSrc/src/main/kotlin/jewel-ij-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/jewel-ij-publish.gradle.kts
@@ -1,5 +1,8 @@
 @file:Suppress("UnstableApiUsage")
 
+import SupportedIJVersion.IJ_232
+import SupportedIJVersion.IJ_233
+
 plugins {
     kotlin("jvm")
     `maven-publish`
@@ -22,11 +25,15 @@ publishing {
     configureJewelRepositories()
 
     publications {
-        register<MavenPublication>("main") {
+        register<MavenPublication>("IdeMain") {
             from(components["kotlin"])
             artifact(javadocJar)
             artifact(sourcesJar)
-            version = project.version.toString()
+            val ijVersionRaw = when (supportedIJVersion()) {
+                IJ_232 -> "232"
+                IJ_233 -> "233"
+            }
+            version = "${project.version}-ij-$ijVersionRaw"
             artifactId = "jewel-${project.name}"
             pom {
                 configureJewelPom()

--- a/buildSrc/src/main/kotlin/jewel-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/jewel-publish.gradle.kts
@@ -1,5 +1,8 @@
 @file:Suppress("UnstableApiUsage")
 
+import SupportedIJVersion.IJ_232
+import SupportedIJVersion.IJ_233
+
 plugins {
     kotlin("jvm")
     `maven-publish`
@@ -33,7 +36,11 @@ publishing {
             from(components["kotlin"])
             artifact(javadocJar)
             artifact(sourcesJar)
-            version = project.version.toString()
+            val ijVersionRaw = when (supportedIJVersion()) {
+                IJ_232 -> "232"
+                IJ_233 -> "233"
+            }
+            version = "${project.version}-ij-$ijVersionRaw"
             artifactId = "jewel-${project.name}"
             pom {
                 name = "Jewel"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,8 @@
 composeDesktop = "1.5.2"
 coroutines = "1.7.3"
 detekt = "1.23.1"
-idea = "232.8660.185"
+idea232 = "232.8660.185"
+idea233 = "233.9102.97-EAP-SNAPSHOT"
 ideaGradlePlugin = "1.15.0"
 javaSarif = "2.0"
 kotlinSarif = "0.4.0"
@@ -19,9 +20,14 @@ javaSarif = { module = "com.contrastsecurity:java-sarif", version.ref = "javaSar
 kotlinSarif = { module = "io.github.detekt.sarif4k:sarif4k", version.ref = "kotlinSarif" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
-ij-platform-ide-core = { module = "com.jetbrains.intellij.platform:ide-core", version.ref = "idea" }
-ij-platform-ide-impl = { module = "com.jetbrains.intellij.platform:ide-impl", version.ref = "idea" }
-ij-platform-core-ui = { module = "com.jetbrains.intellij.platform:core-ui", version.ref = "idea" }
+
+ij-platform-ide-core-232 = { module = "com.jetbrains.intellij.platform:ide-core", version.ref = "idea232" }
+ij-platform-ide-impl-232 = { module = "com.jetbrains.intellij.platform:ide-impl", version.ref = "idea232" }
+ij-platform-core-ui-232 = { module = "com.jetbrains.intellij.platform:core-ui", version.ref = "idea232" }
+
+ij-platform-ide-core-233 = { module = "com.jetbrains.intellij.platform:ide-core", version.ref = "idea233" }
+ij-platform-ide-impl-233 = { module = "com.jetbrains.intellij.platform:ide-impl", version.ref = "idea233" }
+ij-platform-core-ui-233 = { module = "com.jetbrains.intellij.platform:core-ui", version.ref = "idea233" }
 semVer = { module = "net.swiftzer.semver:semver", version.ref = "semVer" }
 simpleXml = { module = "org.simpleframework:simple-xml", version.ref = "simpleXml" }
 
@@ -33,7 +39,8 @@ dokka-gradlePlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", versi
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
 
 [bundles]
-idea = ["ij-platform-ide-core", "ij-platform-ide-impl", "ij-platform-core-ui"]
+idea232 = ["ij-platform-ide-core-232", "ij-platform-ide-impl-232", "ij-platform-core-ui-232"]
+idea233 = ["ij-platform-ide-core-233", "ij-platform-ide-impl-233", "ij-platform-core-ui-233"]
 
 [plugins]
 composeDesktop = { id = "org.jetbrains.compose", version.ref = "composeDesktop" }

--- a/ide-laf-bridge/build.gradle.kts
+++ b/ide-laf-bridge/build.gradle.kts
@@ -1,3 +1,5 @@
+import SupportedIJVersion.*
+
 plugins {
     jewel
     `jewel-publish`
@@ -8,7 +10,17 @@ dependencies {
     api(projects.intUi.intUiStandalone) {
         exclude(group = "org.jetbrains.kotlinx")
     }
-    compileOnly(libs.bundles.idea)
+    when (supportedIJVersion()) {
+        IJ_232 -> {
+            api(projects.ideLafBridge.ideLafBridge232)
+            compileOnly(libs.bundles.idea232)
+        }
+
+        IJ_233 -> {
+            api(projects.ideLafBridge.ideLafBridge233)
+            compileOnly(libs.bundles.idea233)
+        }
+    }
 
     testImplementation(compose.desktop.uiTestJUnit4)
     testImplementation(compose.desktop.currentOs) {

--- a/ide-laf-bridge/build.gradle.kts
+++ b/ide-laf-bridge/build.gradle.kts
@@ -2,7 +2,7 @@ import SupportedIJVersion.*
 
 plugins {
     jewel
-    `jewel-publish`
+    `jewel-ij-publish`
     alias(libs.plugins.composeDesktop)
 }
 

--- a/ide-laf-bridge/ide-laf-bridge-232/build.gradle.kts
+++ b/ide-laf-bridge/ide-laf-bridge-232/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     jewel
-    `jewel-publish`
+    `jewel-ij-publish`
     alias(libs.plugins.composeDesktop)
 }
 

--- a/ide-laf-bridge/ide-laf-bridge-232/build.gradle.kts
+++ b/ide-laf-bridge/ide-laf-bridge-232/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    jewel
+    `jewel-publish`
+    alias(libs.plugins.composeDesktop)
+}
+
+dependencies {
+    api(projects.intUi.intUiStandalone)
+    compileOnly(libs.bundles.idea232)
+}
+
+tasks.withType<AbstractPublishToMaven>().configureEach {
+    enabled = supportedIJVersion() == SupportedIJVersion.IJ_232
+}

--- a/ide-laf-bridge/ide-laf-bridge-232/build.gradle.kts
+++ b/ide-laf-bridge/ide-laf-bridge-232/build.gradle.kts
@@ -10,5 +10,6 @@ dependencies {
 }
 
 tasks.withType<AbstractPublishToMaven>().configureEach {
+    publication.artifactId = "jewel-ide-laf-bridge-platform-specific"
     enabled = supportedIJVersion() == SupportedIJVersion.IJ_232
 }

--- a/ide-laf-bridge/ide-laf-bridge-233/build.gradle.kts
+++ b/ide-laf-bridge/ide-laf-bridge-233/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    jewel
+    `jewel-publish`
+    alias(libs.plugins.composeDesktop)
+}
+
+dependencies {
+    api(projects.intUi.intUiStandalone)
+    compileOnly(libs.bundles.idea233)
+}
+
+tasks.withType<AbstractPublishToMaven>().configureEach {
+    enabled = supportedIJVersion() == SupportedIJVersion.IJ_233
+}

--- a/ide-laf-bridge/ide-laf-bridge-233/build.gradle.kts
+++ b/ide-laf-bridge/ide-laf-bridge-233/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     jewel
-    `jewel-publish`
+    `jewel-ij-publish`
     alias(libs.plugins.composeDesktop)
 }
 

--- a/ide-laf-bridge/ide-laf-bridge-233/build.gradle.kts
+++ b/ide-laf-bridge/ide-laf-bridge-233/build.gradle.kts
@@ -10,5 +10,6 @@ dependencies {
 }
 
 tasks.withType<AbstractPublishToMaven>().configureEach {
+    publication.artifactId = "jewel-ide-laf-bridge-platform-specific"
     enabled = supportedIJVersion() == SupportedIJVersion.IJ_233
 }

--- a/samples/ide-plugin/build.gradle.kts
+++ b/samples/ide-plugin/build.gradle.kts
@@ -1,3 +1,5 @@
+import SupportedIJVersion.*
+
 plugins {
     jewel
     alias(libs.plugins.composeDesktop)
@@ -8,7 +10,11 @@ plugins {
 intellij {
     pluginName.set("Jewel Demo")
     plugins.set(listOf("org.jetbrains.kotlin"))
-    version.set("2023.2.1")
+    val versionRaw = when (supportedIJVersion()) {
+        IJ_232 -> libs.versions.idea232.get()
+        IJ_233 -> libs.versions.idea233.get()
+    }
+    version.set(versionRaw)
 }
 
 // TODO remove this once the IJ Gradle plugin fixes their repositories bug

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -19,6 +19,7 @@ dependencyResolutionManagement {
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
         maven("https://androidx.dev/storage/compose-compiler/repository/")
         maven("https://www.jetbrains.com/intellij-repository/releases")
+        maven("https://www.jetbrains.com/intellij-repository/snapshots")
         maven("https://cache-redirector.jetbrains.com/intellij-dependencies")
         mavenCentral()
     }
@@ -27,6 +28,8 @@ dependencyResolutionManagement {
 include(
     ":core",
     ":ide-laf-bridge",
+    ":ide-laf-bridge:ide-laf-bridge-232",
+    ":ide-laf-bridge:ide-laf-bridge-233",
     ":samples:standalone",
     ":samples:ide-plugin",
     ":int-ui:int-ui-core",


### PR DESCRIPTION
This PR provides new modules ide-laf-bridge-232 and ide-laf-bridge-233 that will be used for platform specific parts that are changed during releases and cannot be used in common ide-laf-bridge.

ide-laf-bridge will depend on one of them depending on local property `supported.ij.version`

Publishing is also changed. Now all publications will have suffix `ij-$version` e.g. `0.7.1-ij-232`. When we support 233 we will have 2 publications e.g. `0.7.3-ij-233` and `0.7.3-ij-232` for all jewel parts.
In future it is better to split publishing process and publish everything except ide-laf-bridge with version without suffix and separately publish ide-laf-bridge and ide-laf-bridge-platform-specific with suffix depending on other parts without suffix