### PR TITLE
Make dropdown content alignable

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/jewel/Dropdown.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/Dropdown.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.input.InputModeManager
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalInputModeManager
-import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.ResourceLoader
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.window.Popup
@@ -129,17 +128,14 @@ fun Dropdown(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(style.metrics.contentPadding)
-                        .padding(
-                            end = minSize.height - style.metrics.contentPadding.calculateRightPadding(
-                                LocalLayoutDirection.current,
-                            ),
-                        ),
+                        .padding(end = minSize.height),
                     contentAlignment = Alignment.CenterStart,
                     content = content,
                 )
 
                 Box(
-                    modifier = Modifier.size(arrowMinSize).align(Alignment.CenterEnd),
+                    modifier = Modifier.size(arrowMinSize)
+                        .align(Alignment.CenterEnd),
                     contentAlignment = Alignment.Center,
                 ) {
                     val chevronIcon by style.icons.chevronDown.getPainter(resourceLoader, dropdownState)

--- a/core/src/main/kotlin/org/jetbrains/jewel/Dropdown.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/Dropdown.kt
@@ -6,13 +6,14 @@ import androidx.compose.foundation.interaction.FocusInteraction
 import androidx.compose.foundation.interaction.HoverInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -31,6 +32,7 @@ import androidx.compose.ui.input.InputModeManager
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalInputModeManager
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.ResourceLoader
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.window.Popup
@@ -57,7 +59,7 @@ fun Dropdown(
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     style: DropdownStyle = IntelliJTheme.dropdownStyle,
     menuContent: MenuScope.() -> Unit,
-    content: @Composable RowScope.() -> Unit,
+    content: @Composable BoxScope.() -> Unit,
 ) {
     Box {
         var expanded by remember { mutableStateOf(false) }
@@ -116,25 +118,28 @@ fun Dropdown(
                 .border(Stroke.Alignment.Center, style.metrics.borderWidth, borderColor, shape)
                 .appendIf(outline == Outline.None) { focusOutline(outlineState, shape) }
                 .outline(outlineState, outline, shape)
+                .width(IntrinsicSize.Max)
                 .defaultMinSize(minSize.width, minSize.height.coerceAtLeast(arrowMinSize.height)),
             contentAlignment = Alignment.CenterStart,
         ) {
             CompositionLocalProvider(
                 LocalContentColor provides colors.contentFor(dropdownState).value,
             ) {
-                Row(
-                    modifier = Modifier.padding(style.metrics.contentPadding)
-                        .padding(end = minSize.height),
-                    horizontalArrangement = Arrangement.Start,
-                    verticalAlignment = Alignment.CenterVertically,
-                    content = {
-                        content()
-                    },
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(style.metrics.contentPadding)
+                        .padding(
+                            end = minSize.height - style.metrics.contentPadding.calculateRightPadding(
+                                LocalLayoutDirection.current,
+                            ),
+                        ),
+                    contentAlignment = Alignment.CenterStart,
+                    content = content,
                 )
 
                 Box(
-                    modifier = Modifier.size(arrowMinSize)
-                        .align(Alignment.CenterEnd),
+                    modifier = Modifier.size(arrowMinSize).align(Alignment.CenterEnd),
                     contentAlignment = Alignment.Center,
                 ) {
                     val chevronIcon by style.icons.chevronDown.getPainter(resourceLoader, dropdownState)


### PR DESCRIPTION
Change dropdown content container from Row to Box, and users can use `Modifier.align` to align content