### PR TITLE
Improve error handling for missing 'supported.ij.version'

### DIFF
--- a/buildSrc/src/main/kotlin/IdeaConfiguration.kt
+++ b/buildSrc/src/main/kotlin/IdeaConfiguration.kt
@@ -1,3 +1,4 @@
+import java.util.concurrent.atomic.AtomicBoolean
 import org.gradle.api.Project
 
 enum class SupportedIJVersion {
@@ -5,22 +6,32 @@ enum class SupportedIJVersion {
     IJ_233
 }
 
+private var warned = AtomicBoolean(false)
+
 fun Project.supportedIJVersion(): SupportedIJVersion {
-    val prop = localProperty("supported.ij.version")
-        ?: rootProject.property("supported.ij.version")
-        ?: error(
-            "'supported.ij.version' gradle property is missing. " +
-                "Please, provide it using local.properties file or -Psupported.ij.version argument in CLI"
-        )
+    val prop = kotlin.runCatching {
+        localProperty("supported.ij.version")
+            ?: rootProject.property("supported.ij.version")?.toString()
+    }.getOrNull()
+
+    if (prop == null) {
+        if (!warned.getAndSet(true)) {
+            logger.warn(
+                """
+                    No 'supported.ij.version' property provided. Falling back to IJ 233.
+                    It is recommended to provide it to avoid unexpected behavior.
+                """.trimIndent()
+            )
+        }
+        return SupportedIJVersion.IJ_233
+    }
 
     return when (prop) {
         "232" -> SupportedIJVersion.IJ_232
         "233" -> SupportedIJVersion.IJ_233
-        else -> {
-            error(
-                "Invalid 'supported.ij.version' with value '$prop' is provided. " +
-                    "It should be in set of these values: ('232', '233')"
-            )
-        }
+        else -> error(
+            "Invalid 'supported.ij.version' with value '$prop' is provided. " +
+                "It should be in set of these values: ('232', '233')"
+        )
     }
 }

--- a/buildSrc/src/main/kotlin/IdeaConfiguration.kt
+++ b/buildSrc/src/main/kotlin/IdeaConfiguration.kt
@@ -19,7 +19,7 @@ fun Project.supportedIJVersion(): SupportedIJVersion {
             logger.warn(
                 """
                     No 'supported.ij.version' property provided. Falling back to IJ 233.
-                    It is recommended to provide it to avoid unexpected behavior.
+                    It is recommended to provide it using local.properties file or -Psupported.ij.version to avoid unexpected behavior.
                 """.trimIndent()
             )
         }


### PR DESCRIPTION
Updated 'supported.ij.version' property handling in IdeaConfiguration.kt to better manage cases when the property is not set. Instead of throwing an error, it now sets a default value and logs a warning message once, advising the user to provide the missing property.