### PR TITLE
Handle SVG loading exceptions and path patching issues

### DIFF
--- a/core/src/main/kotlin/org/jetbrains/jewel/JewelSvgLoader.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/JewelSvgLoader.kt
@@ -3,6 +3,8 @@ package org.jetbrains.jewel
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.ResourceLoader
@@ -37,8 +39,20 @@ class JewelSvgLoader(private val svgPatcher: SvgPatcher) : SvgLoader {
     ): Painter {
         val density = LocalDensity.current
 
-        val painter = useResource(resourcePath, loader) {
-            loadSvgPainter(it.patchColors(resourcePath), density)
+        val painter = try {
+            useResource(resourcePath, loader) {
+                loadSvgPainter(it.patchColors(resourcePath), density)
+            }
+        } catch (ex: IllegalArgumentException) {
+            System.err.println(
+                buildString {
+                    appendLine("Unable to load SVG resource $resourcePath")
+                    appendLine(ex.stackTraceToString())
+                },
+            )
+            return remember(resourcePath, density, loader) {
+                ColorPainter(Color.Magenta)
+            }
         }
         return remember(resourcePath, density, loader) { painter }
     }


### PR DESCRIPTION
This commit adds error handling to SVG loading in the JewelSvgLoader, returning a default ColorPainter when the specified SVG resource cannot be loaded. It also addresses a breaking change in 233 EAP 4's path patching logic where it now returns a "reflective path". The change includes code that transforms this path back into the original path.