### PR TITLE
The big refactor — step 1: prep work

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,11 @@
 name: Publish artifacts in Space
+
 on:
   release:
     types: [ published ]
   push:
     branches: [ main ]
+
 jobs:
   publish-core:
     name: Publish Jewel Core

--- a/.idea/runConfigurations/Reformat_project.xml
+++ b/.idea/runConfigurations/Reformat_project.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Run checks" type="GradleRunConfiguration" factoryName="Gradle">
+  <configuration default="false" name="Reformat project" type="GradleRunConfiguration" factoryName="Gradle">
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -10,7 +10,7 @@
       </option>
       <option name="taskNames">
         <list>
-          <option value="check" />
+          <option value="formatKotlin" />
         </list>
       </option>
       <option name="vmOptions" />

--- a/.idea/runConfigurations/Run_checks__IJ_23_2_.xml
+++ b/.idea/runConfigurations/Run_checks__IJ_23_2_.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run checks (IJ 23.2)" type="GradleRunConfiguration" factoryName="Gradle" folderName="Checks">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-Psupported.ij.version=232" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="check" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Update_API_signatures.xml
+++ b/.idea/runConfigurations/Update_API_signatures.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Update API signatures" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="apiDump" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
     `kotlin-dsl`
-    alias(libs.plugins.kotlinSerialization)
+    alias(libs.plugins.kotlinx.serialization)
 }
 
 gradlePlugin {
@@ -27,13 +27,16 @@ kotlin {
 }
 
 dependencies {
-    implementation(libs.kotlin.gradlePlugin)
-    implementation(libs.kotlinter.gradlePlugin)
     implementation(libs.detekt.gradlePlugin)
-    implementation(libs.kotlinSarif)
     implementation(libs.dokka.gradlePlugin)
+    implementation(libs.kotlin.gradlePlugin)
+    implementation(libs.kotlinSarif)
     implementation(libs.kotlinpoet)
+    implementation(libs.kotlinter.gradlePlugin)
+    implementation(libs.kotlinx.binaryCompatValidator.gradlePlugin)
     implementation(libs.kotlinx.serialization.json)
+    implementation(libs.poko.gradlePlugin)
+
     // Enables using type-safe accessors to reference plugins from the [plugins] block defined in version catalogs.
     // Context: https://github.com/gradle/gradle/issues/15383#issuecomment-779893192
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))

--- a/buildSrc/src/main/kotlin/IdeaConfiguration.kt
+++ b/buildSrc/src/main/kotlin/IdeaConfiguration.kt
@@ -10,7 +10,7 @@ private var warned = AtomicBoolean(false)
 
 fun Project.supportedIJVersion(): SupportedIJVersion {
     val prop = kotlin.runCatching {
-        rootProject.property("supported.ij.version")?.toString() ?:
+        rootProject.findProperty("supported.ij.version")?.toString() ?:
             localProperty("supported.ij.version")
     }.getOrNull()
 

--- a/buildSrc/src/main/kotlin/IdeaConfiguration.kt
+++ b/buildSrc/src/main/kotlin/IdeaConfiguration.kt
@@ -10,8 +10,8 @@ private var warned = AtomicBoolean(false)
 
 fun Project.supportedIJVersion(): SupportedIJVersion {
     val prop = kotlin.runCatching {
-        localProperty("supported.ij.version")
-            ?: rootProject.property("supported.ij.version")?.toString()
+        rootProject.property("supported.ij.version")?.toString() ?:
+            localProperty("supported.ij.version")
     }.getOrNull()
 
     if (prop == null) {

--- a/buildSrc/src/main/kotlin/MergeSarifTask.kt
+++ b/buildSrc/src/main/kotlin/MergeSarifTask.kt
@@ -3,15 +3,9 @@ import io.github.detekt.sarif4k.Version
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
 import kotlinx.serialization.json.encodeToStream
-import org.gradle.api.file.FileTree
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.CacheableTask
-import org.gradle.api.tasks.IgnoreEmptyDirectories
-import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
-import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
 

--- a/buildSrc/src/main/kotlin/ValidatePublicApiTask.kt
+++ b/buildSrc/src/main/kotlin/ValidatePublicApiTask.kt
@@ -1,0 +1,97 @@
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.SourceTask
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+import java.util.Stack
+
+@CacheableTask
+open class ValidatePublicApiTask : SourceTask() {
+
+    init {
+        group = "verification"
+    }
+
+    private val classFqnRegex = "public (?:\\w+ )*class (\\S+)\\b".toRegex()
+
+    @Suppress("ConvertToStringTemplate") // The odd concatenation is needed because of $; escapes get confused
+    private val copyMethodRegex = ("public static synthetic fun copy(-\\w+)" + "\\$" + "default\\b").toRegex()
+
+    @TaskAction
+    fun validatePublicApi() {
+        logger.info("Validating ${source.files.size} API file(s)...")
+
+        val violations = mutableMapOf<File, Set<String>>()
+        inputs.files.forEach { apiFile ->
+            logger.lifecycle("Validating public API from file ${apiFile.path}")
+
+            apiFile.useLines { lines ->
+                val actualDataClasses = findDataClasses(lines)
+
+                if (actualDataClasses.isNotEmpty()) {
+                    violations[apiFile] = actualDataClasses
+                }
+            }
+        }
+
+        if (violations.isNotEmpty()) {
+            val message = buildString {
+                appendLine("Data classes found in public API.")
+                appendLine()
+
+                for ((file, dataClasses) in violations.entries) {
+                    appendLine("In file ${file.path}:")
+                    for (dataClass in dataClasses) {
+                        appendLine(" * ${dataClass.replace("/", ".")}")
+                    }
+                    appendLine()
+                }
+            }
+
+            throw GradleException(message)
+        } else {
+            logger.lifecycle("No public API violations found.")
+        }
+    }
+
+    private fun findDataClasses(lines: Sequence<String>): Set<String> {
+        val currentClassStack = Stack<String>()
+        val dataClasses = mutableMapOf<String, DataClassInfo>()
+
+        for (line in lines) {
+            if (line.isBlank()) continue
+
+            val matchResult = classFqnRegex.find(line)
+            if (matchResult != null) {
+                val classFqn = matchResult.groupValues[1]
+                currentClassStack.push(classFqn)
+                continue
+            }
+
+            if (line.contains("}")) {
+                currentClassStack.pop()
+                continue
+            }
+
+            val fqn = currentClassStack.peek()
+            if (copyMethodRegex.find(line) != null) {
+                val info = dataClasses.getOrPut(fqn) { DataClassInfo(fqn) }
+                info.hasCopyMethod = true
+            } else if (line.contains("public static final synthetic fun box-impl")) {
+                val info = dataClasses.getOrPut(fqn) { DataClassInfo(fqn) }
+                info.isLikelyValueClass = true
+            }
+        }
+
+        val actualDataClasses = dataClasses.filterValues { it.hasCopyMethod && !it.isLikelyValueClass }
+            .keys
+        return actualDataClasses
+    }
+}
+
+@Suppress("DataClassShouldBeImmutable") // Only used in a loop, saves memory and is faster
+private data class DataClassInfo(
+    val fqn: String,
+    var hasCopyMethod: Boolean = false,
+    var isLikelyValueClass: Boolean = false,
+)

--- a/buildSrc/src/main/kotlin/jewel-check-public-api.gradle.kts
+++ b/buildSrc/src/main/kotlin/jewel-check-public-api.gradle.kts
@@ -12,6 +12,10 @@ apiValidation {
     nonPublicMarkers.add("org.jetbrains.jewel.InternalJewelApi")
 }
 
+poko {
+    pokoAnnotation.set("org.jetbrains.jewel.GenerateDataFunctions")
+}
+
 tasks {
     val validatePublicApi = register<ValidatePublicApiTask>("validatePublicApi") {
         include { it.file.extension == "api" }

--- a/buildSrc/src/main/kotlin/jewel-check-public-api.gradle.kts
+++ b/buildSrc/src/main/kotlin/jewel-check-public-api.gradle.kts
@@ -16,6 +16,7 @@ tasks {
     val validatePublicApi = register<ValidatePublicApiTask>("validatePublicApi") {
         include { it.file.extension == "api" }
         source(project.fileTree("api"))
+        dependsOn(named("apiCheck"))
     }
 
     named("check") {

--- a/buildSrc/src/main/kotlin/jewel-check-public-api.gradle.kts
+++ b/buildSrc/src/main/kotlin/jewel-check-public-api.gradle.kts
@@ -1,0 +1,24 @@
+plugins {
+    id("org.jetbrains.kotlinx.binary-compatibility-validator")
+    id("dev.drewhamilton.poko")
+}
+
+apiValidation {
+    /**
+     * Set of annotations that exclude API from being public. Typically, it is
+     * all kinds of `@InternalApi` annotations that mark effectively private
+     * API that cannot be actually private for technical reasons.
+     */
+    nonPublicMarkers.add("org.jetbrains.jewel.InternalJewelApi")
+}
+
+tasks {
+    val validatePublicApi = register<ValidatePublicApiTask>("validatePublicApi") {
+        include { it.file.extension == "api" }
+        source(project.fileTree("api"))
+    }
+
+    named("check") {
+        dependsOn(validatePublicApi)
+    }
+}

--- a/buildSrc/src/main/kotlin/jewel.gradle.kts
+++ b/buildSrc/src/main/kotlin/jewel.gradle.kts
@@ -48,7 +48,7 @@ detekt {
     buildUponDefaultConfig = true
 }
 
-val sarif by configurations.creating {
+val sarif: Configuration by configurations.creating {
     isCanBeConsumed = true
     attributes {
         attribute(Usage.USAGE_ATTRIBUTE, objects.named("sarif"))

--- a/buildSrc/src/main/kotlin/jewel.gradle.kts
+++ b/buildSrc/src/main/kotlin/jewel.gradle.kts
@@ -2,6 +2,7 @@
 
 import io.gitlab.arturbosch.detekt.Detekt
 import org.gradle.api.attributes.Usage
+import org.jmailen.gradle.kotlinter.tasks.FormatTask
 import org.jmailen.gradle.kotlinter.tasks.LintTask
 
 plugins {
@@ -69,6 +70,11 @@ tasks {
             }
         }
     }
+
+    withType<FormatTask> {
+        exclude { it.file.absolutePath.contains("build/generated") }
+    }
+
     withType<LintTask> {
         exclude { it.file.absolutePath.contains("build/generated") }
 

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1,0 +1,2334 @@
+public abstract interface class org/jetbrains/jewel/BorderColors {
+	public abstract fun getDisabled-0d7_KjU ()J
+	public abstract fun getFocused-0d7_KjU ()J
+	public abstract fun getNormal-0d7_KjU ()J
+}
+
+public final class org/jetbrains/jewel/ButtonKt {
+	public static final fun DefaultButton (Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;ZLandroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/styling/ButtonStyle;Landroidx/compose/ui/text/TextStyle;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public static final fun OutlinedButton (Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;ZLandroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/styling/ButtonStyle;Landroidx/compose/ui/text/TextStyle;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class org/jetbrains/jewel/ButtonState : org/jetbrains/jewel/FocusableComponentState {
+	public static final field Companion Lorg/jetbrains/jewel/ButtonState$Companion;
+	public static final synthetic fun box-impl (J)Lorg/jetbrains/jewel/ButtonState;
+	public fun chooseValue (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+	public static fun chooseValue-impl (JLjava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+	public static fun constructor-impl (J)J
+	public static final fun copy-b10xpbw (JZZZZZ)J
+	public static synthetic fun copy-b10xpbw$default (JZZZZZILjava/lang/Object;)J
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getState-s-VKNKU ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun isActive ()Z
+	public static fun isActive-impl (J)Z
+	public fun isEnabled ()Z
+	public static fun isEnabled-impl (J)Z
+	public fun isFocused ()Z
+	public static fun isFocused-impl (J)Z
+	public fun isHovered ()Z
+	public static fun isHovered-impl (J)Z
+	public fun isPressed ()Z
+	public static fun isPressed-impl (J)Z
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public final class org/jetbrains/jewel/ButtonState$Companion {
+	public final fun of-b10xpbw (ZZZZZ)J
+	public static synthetic fun of-b10xpbw$default (Lorg/jetbrains/jewel/ButtonState$Companion;ZZZZZILjava/lang/Object;)J
+}
+
+public final class org/jetbrains/jewel/CheckboxKt {
+	public static final fun Checkbox (ZLkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;ZLorg/jetbrains/jewel/Outline;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/styling/CheckboxColors;Lorg/jetbrains/jewel/styling/CheckboxMetrics;Lorg/jetbrains/jewel/styling/CheckboxIcons;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)V
+	public static final fun CheckboxRow (Ljava/lang/String;ZLkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;ZLorg/jetbrains/jewel/Outline;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/styling/CheckboxColors;Lorg/jetbrains/jewel/styling/CheckboxMetrics;Lorg/jetbrains/jewel/styling/CheckboxIcons;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;III)V
+	public static final fun CheckboxRow (ZLkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;ZLorg/jetbrains/jewel/Outline;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/styling/CheckboxColors;Lorg/jetbrains/jewel/styling/CheckboxMetrics;Lorg/jetbrains/jewel/styling/CheckboxIcons;Landroidx/compose/ui/text/TextStyle;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
+	public static final fun TriStateCheckbox (Landroidx/compose/ui/state/ToggleableState;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;ZLorg/jetbrains/jewel/Outline;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/styling/CheckboxColors;Lorg/jetbrains/jewel/styling/CheckboxMetrics;Lorg/jetbrains/jewel/styling/CheckboxIcons;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)V
+	public static final fun TriStateCheckboxRow (Landroidx/compose/ui/state/ToggleableState;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;ZLorg/jetbrains/jewel/Outline;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/styling/CheckboxColors;Lorg/jetbrains/jewel/styling/CheckboxMetrics;Lorg/jetbrains/jewel/styling/CheckboxIcons;Landroidx/compose/ui/text/TextStyle;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
+	public static final fun TriStateCheckboxRow (Ljava/lang/String;Landroidx/compose/ui/state/ToggleableState;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;ZLorg/jetbrains/jewel/Outline;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/styling/CheckboxColors;Lorg/jetbrains/jewel/styling/CheckboxMetrics;Lorg/jetbrains/jewel/styling/CheckboxIcons;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;III)V
+}
+
+public final class org/jetbrains/jewel/CheckboxState : org/jetbrains/jewel/ToggleableComponentState {
+	public static final field Companion Lorg/jetbrains/jewel/CheckboxState$Companion;
+	public static final synthetic fun box-impl (J)Lorg/jetbrains/jewel/CheckboxState;
+	public fun chooseValue (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+	public static fun chooseValue-impl (JLjava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+	public static fun constructor-impl (J)J
+	public static final fun copy-PjUgVWY (JLandroidx/compose/ui/state/ToggleableState;ZZZZZ)J
+	public static synthetic fun copy-PjUgVWY$default (JLandroidx/compose/ui/state/ToggleableState;ZZZZZILjava/lang/Object;)J
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public fun getToggleableState ()Landroidx/compose/ui/state/ToggleableState;
+	public static fun getToggleableState-impl (J)Landroidx/compose/ui/state/ToggleableState;
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun isActive ()Z
+	public static fun isActive-impl (J)Z
+	public fun isEnabled ()Z
+	public static fun isEnabled-impl (J)Z
+	public fun isFocused ()Z
+	public static fun isFocused-impl (J)Z
+	public fun isHovered ()Z
+	public static fun isHovered-impl (J)Z
+	public fun isPressed ()Z
+	public static fun isPressed-impl (J)Z
+	public fun isSelected ()Z
+	public static fun isSelected-impl (J)Z
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public final class org/jetbrains/jewel/CheckboxState$Companion {
+	public final fun of-PjUgVWY (Landroidx/compose/ui/state/ToggleableState;ZZZZZ)J
+	public static synthetic fun of-PjUgVWY$default (Lorg/jetbrains/jewel/CheckboxState$Companion;Landroidx/compose/ui/state/ToggleableState;ZZZZZILjava/lang/Object;)J
+}
+
+public final class org/jetbrains/jewel/ChipKt {
+	public static final fun Chip (Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/interaction/MutableInteractionSource;ZZLorg/jetbrains/jewel/styling/ChipStyle;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun RadioButtonChip (ZLkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/interaction/MutableInteractionSource;ZLorg/jetbrains/jewel/styling/ChipStyle;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun ToggleableChip (ZLkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/interaction/MutableInteractionSource;ZLorg/jetbrains/jewel/styling/ChipStyle;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class org/jetbrains/jewel/ChipState : org/jetbrains/jewel/FocusableComponentState, org/jetbrains/jewel/SelectableComponentState {
+	public static final field Companion Lorg/jetbrains/jewel/ChipState$Companion;
+	public static final synthetic fun box-impl (J)Lorg/jetbrains/jewel/ChipState;
+	public fun chooseValue (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+	public static fun chooseValue-impl (JLjava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+	public static fun constructor-impl (J)J
+	public static final fun copy-Dtzntvw (JZZZZZZ)J
+	public static synthetic fun copy-Dtzntvw$default (JZZZZZZILjava/lang/Object;)J
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getState-s-VKNKU ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun isActive ()Z
+	public static fun isActive-impl (J)Z
+	public fun isEnabled ()Z
+	public static fun isEnabled-impl (J)Z
+	public fun isFocused ()Z
+	public static fun isFocused-impl (J)Z
+	public fun isHovered ()Z
+	public static fun isHovered-impl (J)Z
+	public fun isPressed ()Z
+	public static fun isPressed-impl (J)Z
+	public fun isSelected ()Z
+	public static fun isSelected-impl (J)Z
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public final class org/jetbrains/jewel/ChipState$Companion {
+	public final fun of-Dtzntvw (ZZZZZZ)J
+	public static synthetic fun of-Dtzntvw$default (Lorg/jetbrains/jewel/ChipState$Companion;ZZZZZZILjava/lang/Object;)J
+}
+
+public final class org/jetbrains/jewel/CircularProgressIndicatorKt {
+	public static final fun CircularProgressIndicator (Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/styling/CircularProgressStyle;Landroidx/compose/runtime/Composer;II)V
+	public static final fun CircularProgressIndicatorBig (Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/styling/CircularProgressStyle;Landroidx/compose/runtime/Composer;II)V
+}
+
+public abstract interface class org/jetbrains/jewel/ClassLoaderProvider {
+	public abstract fun getClassLoaders ()Ljava/util/List;
+}
+
+public final class org/jetbrains/jewel/ComposableSingletons$MenuKt {
+	public static final field INSTANCE Lorg/jetbrains/jewel/ComposableSingletons$MenuKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$core ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class org/jetbrains/jewel/ContextMenuDivider : androidx/compose/foundation/ContextMenuItem {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/ContextMenuDivider;
+}
+
+public final class org/jetbrains/jewel/ContextSubmenu : androidx/compose/foundation/ContextMenuItem {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public final fun getSubmenu ()Lkotlin/jvm/functions/Function0;
+}
+
+public final class org/jetbrains/jewel/DisabledColorFilterKt {
+	public static final fun disabled (Landroidx/compose/ui/graphics/ColorFilter$Companion;)Landroidx/compose/ui/graphics/ColorFilter;
+}
+
+public final class org/jetbrains/jewel/DividerKt {
+	public static final fun Divider-RLL6an4 (Lorg/jetbrains/jewel/Orientation;Landroidx/compose/ui/Modifier;JFFLorg/jetbrains/jewel/styling/DividerStyle;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class org/jetbrains/jewel/DropdownKt {
+	public static final fun Dropdown (Landroidx/compose/ui/Modifier;ZLandroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/Outline;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/styling/DropdownStyle;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class org/jetbrains/jewel/DropdownState : org/jetbrains/jewel/FocusableComponentState {
+	public static final field Companion Lorg/jetbrains/jewel/DropdownState$Companion;
+	public static final synthetic fun box-impl (J)Lorg/jetbrains/jewel/DropdownState;
+	public fun chooseValue (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+	public static fun chooseValue-impl (JLjava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+	public static fun constructor-impl (J)J
+	public static final fun copy-eyYTm3Q (JZZZZZ)J
+	public static synthetic fun copy-eyYTm3Q$default (JZZZZZILjava/lang/Object;)J
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getState-s-VKNKU ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun isActive ()Z
+	public static fun isActive-impl (J)Z
+	public fun isEnabled ()Z
+	public static fun isEnabled-impl (J)Z
+	public fun isFocused ()Z
+	public static fun isFocused-impl (J)Z
+	public fun isHovered ()Z
+	public static fun isHovered-impl (J)Z
+	public fun isPressed ()Z
+	public static fun isPressed-impl (J)Z
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public final class org/jetbrains/jewel/DropdownState$Companion {
+	public final fun of-eyYTm3Q (ZZZZZ)J
+	public static synthetic fun of-eyYTm3Q$default (Lorg/jetbrains/jewel/DropdownState$Companion;ZZZZZILjava/lang/Object;)J
+}
+
+public final class org/jetbrains/jewel/EmptyThemeColorPalette : org/jetbrains/jewel/IntelliJThemeColorPalette {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/EmptyThemeColorPalette;
+	public fun getRawMap ()Ljava/util/Map;
+	public fun lookup-ijrfgN4 (Ljava/lang/String;)Landroidx/compose/ui/graphics/Color;
+}
+
+public final class org/jetbrains/jewel/EmptyThemeIconData : org/jetbrains/jewel/IntelliJThemeIconData {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/EmptyThemeIconData;
+	public fun getColorPalette ()Ljava/util/Map;
+	public fun getIconOverrides ()Ljava/util/Map;
+	public fun getSelectionColorPalette ()Ljava/util/Map;
+	public fun selectionColorMapping ()Ljava/util/Map;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface annotation class org/jetbrains/jewel/ExperimentalJewelApi : java/lang/annotation/Annotation {
+}
+
+public abstract interface class org/jetbrains/jewel/FocusableComponentState : org/jetbrains/jewel/InteractiveComponentState {
+	public abstract fun chooseValue (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+	public abstract fun isFocused ()Z
+}
+
+public final class org/jetbrains/jewel/FocusableComponentState$DefaultImpls {
+	public static fun chooseValue (Lorg/jetbrains/jewel/FocusableComponentState;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+}
+
+public abstract interface class org/jetbrains/jewel/GlobalColors {
+	public abstract fun getBorders ()Lorg/jetbrains/jewel/BorderColors;
+	public abstract fun getInfoContent-0d7_KjU ()J
+	public abstract fun getOutlines ()Lorg/jetbrains/jewel/OutlineColors;
+	public abstract fun getPaneBackground-0d7_KjU ()J
+}
+
+public final class org/jetbrains/jewel/GlobalColorsKt {
+	public static final fun getLocalGlobalColors ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class org/jetbrains/jewel/GlobalMetrics {
+	public abstract fun getOutlineWidth-D9Ej5fM ()F
+	public abstract fun getRowHeight-D9Ej5fM ()F
+}
+
+public final class org/jetbrains/jewel/GlobalMetricsKt {
+	public static final fun getLocalGlobalMetrics ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public final class org/jetbrains/jewel/GroupHeaderKt {
+	public static final fun GroupHeader-cf5BqRc (Ljava/lang/String;Landroidx/compose/ui/Modifier;JLorg/jetbrains/jewel/styling/GroupHeaderStyle;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class org/jetbrains/jewel/IconButtonKt {
+	public static final fun IconButton (Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;ZLorg/jetbrains/jewel/styling/IconButtonStyle;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class org/jetbrains/jewel/IconKt {
+	public static final fun Icon (Landroidx/compose/ui/graphics/painter/Painter;Ljava/lang/String;Landroidx/compose/ui/graphics/ColorFilter;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+	public static final fun Icon (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Class;Landroidx/compose/ui/graphics/ColorFilter;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+	public static final fun Icon-ww6aTOc (Landroidx/compose/ui/graphics/ImageBitmap;Ljava/lang/String;Landroidx/compose/ui/Modifier;JLandroidx/compose/runtime/Composer;II)V
+	public static final fun Icon-ww6aTOc (Landroidx/compose/ui/graphics/painter/Painter;Ljava/lang/String;Landroidx/compose/ui/Modifier;JLandroidx/compose/runtime/Composer;II)V
+	public static final fun Icon-ww6aTOc (Landroidx/compose/ui/graphics/vector/ImageVector;Ljava/lang/String;Landroidx/compose/ui/Modifier;JLandroidx/compose/runtime/Composer;II)V
+	public static final fun Icon-yrwZFoE (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Class;Landroidx/compose/ui/Modifier;JLandroidx/compose/runtime/Composer;II)V
+	public static final fun painterResource (Ljava/lang/String;Landroidx/compose/ui/res/ResourceLoader;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/graphics/painter/Painter;
+}
+
+public final class org/jetbrains/jewel/InputFieldState : org/jetbrains/jewel/FocusableComponentState {
+	public static final field Companion Lorg/jetbrains/jewel/InputFieldState$Companion;
+	public static final synthetic fun box-impl (J)Lorg/jetbrains/jewel/InputFieldState;
+	public fun chooseValue (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+	public static fun chooseValue-impl (JLjava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+	public static fun constructor-impl (J)J
+	public static final fun copy-uqjUvac (JZZZZZ)J
+	public static synthetic fun copy-uqjUvac$default (JZZZZZILjava/lang/Object;)J
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getState-s-VKNKU ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun isActive ()Z
+	public static fun isActive-impl (J)Z
+	public fun isEnabled ()Z
+	public static fun isEnabled-impl (J)Z
+	public fun isFocused ()Z
+	public static fun isFocused-impl (J)Z
+	public fun isHovered ()Z
+	public static fun isHovered-impl (J)Z
+	public fun isPressed ()Z
+	public static fun isPressed-impl (J)Z
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public final class org/jetbrains/jewel/InputFieldState$Companion {
+	public final fun of-uqjUvac (ZZZZZ)J
+	public static synthetic fun of-uqjUvac$default (Lorg/jetbrains/jewel/InputFieldState$Companion;ZZZZZILjava/lang/Object;)J
+}
+
+public final class org/jetbrains/jewel/IntelliJComponentStyling {
+	public static final field $stable I
+	public fun <init> (Lorg/jetbrains/jewel/styling/CheckboxStyle;Lorg/jetbrains/jewel/styling/ChipStyle;Lorg/jetbrains/jewel/styling/ButtonStyle;Lorg/jetbrains/jewel/styling/TabStyle;Lorg/jetbrains/jewel/styling/DividerStyle;Lorg/jetbrains/jewel/styling/DropdownStyle;Lorg/jetbrains/jewel/styling/TabStyle;Lorg/jetbrains/jewel/styling/GroupHeaderStyle;Lorg/jetbrains/jewel/styling/HorizontalProgressBarStyle;Lorg/jetbrains/jewel/styling/LabelledTextFieldStyle;Lorg/jetbrains/jewel/styling/LazyTreeStyle;Lorg/jetbrains/jewel/styling/LinkStyle;Lorg/jetbrains/jewel/styling/MenuStyle;Lorg/jetbrains/jewel/styling/ButtonStyle;Lorg/jetbrains/jewel/styling/RadioButtonStyle;Lorg/jetbrains/jewel/styling/ScrollbarStyle;Lorg/jetbrains/jewel/styling/TextAreaStyle;Lorg/jetbrains/jewel/styling/TextFieldStyle;Lorg/jetbrains/jewel/styling/CircularProgressStyle;Lorg/jetbrains/jewel/styling/TooltipStyle;Lorg/jetbrains/jewel/styling/IconButtonStyle;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCheckboxStyle ()Lorg/jetbrains/jewel/styling/CheckboxStyle;
+	public final fun getChipStyle ()Lorg/jetbrains/jewel/styling/ChipStyle;
+	public final fun getCircularProgressStyle ()Lorg/jetbrains/jewel/styling/CircularProgressStyle;
+	public final fun getDefaultButtonStyle ()Lorg/jetbrains/jewel/styling/ButtonStyle;
+	public final fun getDefaultTabStyle ()Lorg/jetbrains/jewel/styling/TabStyle;
+	public final fun getDividerStyle ()Lorg/jetbrains/jewel/styling/DividerStyle;
+	public final fun getDropdownStyle ()Lorg/jetbrains/jewel/styling/DropdownStyle;
+	public final fun getEditorTabStyle ()Lorg/jetbrains/jewel/styling/TabStyle;
+	public final fun getGroupHeaderStyle ()Lorg/jetbrains/jewel/styling/GroupHeaderStyle;
+	public final fun getHorizontalProgressBarStyle ()Lorg/jetbrains/jewel/styling/HorizontalProgressBarStyle;
+	public final fun getIconButtonStyle ()Lorg/jetbrains/jewel/styling/IconButtonStyle;
+	public final fun getLabelledTextFieldStyle ()Lorg/jetbrains/jewel/styling/LabelledTextFieldStyle;
+	public final fun getLazyTreeStyle ()Lorg/jetbrains/jewel/styling/LazyTreeStyle;
+	public final fun getLinkStyle ()Lorg/jetbrains/jewel/styling/LinkStyle;
+	public final fun getMenuStyle ()Lorg/jetbrains/jewel/styling/MenuStyle;
+	public final fun getOutlinedButtonStyle ()Lorg/jetbrains/jewel/styling/ButtonStyle;
+	public final fun getRadioButtonStyle ()Lorg/jetbrains/jewel/styling/RadioButtonStyle;
+	public final fun getScrollbarStyle ()Lorg/jetbrains/jewel/styling/ScrollbarStyle;
+	public final fun getTextAreaStyle ()Lorg/jetbrains/jewel/styling/TextAreaStyle;
+	public final fun getTextFieldStyle ()Lorg/jetbrains/jewel/styling/TextFieldStyle;
+	public final fun getTooltipStyle ()Lorg/jetbrains/jewel/styling/TooltipStyle;
+	public fun hashCode ()I
+	public final fun providedStyles (Landroidx/compose/runtime/Composer;I)[Landroidx/compose/runtime/ProvidedValue;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/IntelliJContextMenuRepresentation : androidx/compose/foundation/ContextMenuRepresentation {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/IntelliJContextMenuRepresentation;
+	public fun Representation (Landroidx/compose/foundation/ContextMenuState;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+}
+
+public abstract interface class org/jetbrains/jewel/IntelliJTheme {
+	public static final field Companion Lorg/jetbrains/jewel/IntelliJTheme$Companion;
+}
+
+public final class org/jetbrains/jewel/IntelliJTheme$Companion {
+	public final fun getCheckboxStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/CheckboxStyle;
+	public final fun getChipStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/ChipStyle;
+	public final fun getCircularProgressStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/CircularProgressStyle;
+	public final fun getColorPalette (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/IntelliJThemeColorPalette;
+	public final fun getContentColor (Landroidx/compose/runtime/Composer;I)J
+	public final fun getDefaultButtonStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/ButtonStyle;
+	public final fun getDefaultTabStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/TabStyle;
+	public final fun getDividerStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/DividerStyle;
+	public final fun getDropdownStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/DropdownStyle;
+	public final fun getEditorTabStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/TabStyle;
+	public final fun getGlobalColors (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/GlobalColors;
+	public final fun getGlobalMetrics (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/GlobalMetrics;
+	public final fun getGroupHeaderStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/GroupHeaderStyle;
+	public final fun getHorizontalProgressBarStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/HorizontalProgressBarStyle;
+	public final fun getIconButtonStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/IconButtonStyle;
+	public final fun getIconData (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/IntelliJThemeIconData;
+	public final fun getLabelledTextFieldStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/LabelledTextFieldStyle;
+	public final fun getLinkStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/LinkStyle;
+	public final fun getMenuStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/MenuStyle;
+	public final fun getOutlinedButtonStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/ButtonStyle;
+	public final fun getRadioButtonStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/RadioButtonStyle;
+	public final fun getScrollbarStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/ScrollbarStyle;
+	public final fun getTextAreaStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/TextAreaStyle;
+	public final fun getTextFieldStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/TextFieldStyle;
+	public final fun getTextStyle (Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/text/TextStyle;
+	public final fun getTooltipStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/TooltipStyle;
+	public final fun getTreeStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/LazyTreeStyle;
+	public final fun isDark (Landroidx/compose/runtime/Composer;I)Z
+	public final fun isSwingCompatMode (Landroidx/compose/runtime/Composer;I)Z
+}
+
+public abstract interface class org/jetbrains/jewel/IntelliJThemeColorPalette {
+	public abstract fun getRawMap ()Ljava/util/Map;
+	public abstract fun lookup-ijrfgN4 (Ljava/lang/String;)Landroidx/compose/ui/graphics/Color;
+}
+
+public final class org/jetbrains/jewel/IntelliJThemeColorPalette$DefaultImpls {
+	public static fun lookup-ijrfgN4 (Lorg/jetbrains/jewel/IntelliJThemeColorPalette;Ljava/lang/String;)Landroidx/compose/ui/graphics/Color;
+}
+
+public abstract interface class org/jetbrains/jewel/IntelliJThemeDefinition {
+	public abstract fun getColorPalette ()Lorg/jetbrains/jewel/IntelliJThemeColorPalette;
+	public abstract fun getContentColor-0d7_KjU ()J
+	public abstract fun getDefaultTextStyle ()Landroidx/compose/ui/text/TextStyle;
+	public abstract fun getGlobalColors ()Lorg/jetbrains/jewel/GlobalColors;
+	public abstract fun getGlobalMetrics ()Lorg/jetbrains/jewel/GlobalMetrics;
+	public abstract fun getIconData ()Lorg/jetbrains/jewel/IntelliJThemeIconData;
+	public abstract fun isDark ()Z
+}
+
+public abstract interface class org/jetbrains/jewel/IntelliJThemeDescriptor {
+	public abstract fun getColors ()Lorg/jetbrains/jewel/IntelliJThemeColorPalette;
+	public abstract fun getIcons ()Lorg/jetbrains/jewel/IntelliJThemeIconData;
+	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun isDark ()Z
+}
+
+public abstract interface class org/jetbrains/jewel/IntelliJThemeIconData {
+	public abstract fun getColorPalette ()Ljava/util/Map;
+	public abstract fun getIconOverrides ()Ljava/util/Map;
+	public abstract fun getSelectionColorPalette ()Ljava/util/Map;
+	public abstract fun selectionColorMapping ()Ljava/util/Map;
+}
+
+public final class org/jetbrains/jewel/IntelliJThemeIconData$DefaultImpls {
+	public static fun selectionColorMapping (Lorg/jetbrains/jewel/IntelliJThemeIconData;)Ljava/util/Map;
+}
+
+public final class org/jetbrains/jewel/IntelliJThemeKt {
+	public static final fun IntelliJTheme (Lorg/jetbrains/jewel/IntelliJThemeDefinition;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+	public static final fun IntelliJTheme (Lorg/jetbrains/jewel/IntelliJThemeDefinition;ZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+	public static final fun OverrideDarkMode (ZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+	public static final fun getLocalColorPalette ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+	public static final fun getLocalIconData ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public final class org/jetbrains/jewel/IntellijTooltipPlacement : androidx/compose/foundation/TooltipPlacement {
+	public static final field $stable I
+	public synthetic fun <init> (JLandroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/ui/unit/Density;FILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLandroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/ui/unit/Density;FLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun positionProvider (Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/window/PopupPositionProvider;
+	public fun positionProvider-9KIMszo (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/ui/window/PopupPositionProvider;
+}
+
+public abstract interface class org/jetbrains/jewel/InteractiveComponentState {
+	public abstract fun isActive ()Z
+	public abstract fun isEnabled ()Z
+	public abstract fun isHovered ()Z
+	public abstract fun isPressed ()Z
+}
+
+public abstract interface annotation class org/jetbrains/jewel/InternalJewelApi : java/lang/annotation/Annotation {
+}
+
+public final class org/jetbrains/jewel/LabelledTextFieldKt {
+	public static final fun LabelledTextField (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;ZZLorg/jetbrains/jewel/Outline;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZLandroidx/compose/ui/text/input/VisualTransformation;Landroidx/compose/foundation/text/KeyboardOptions;Landroidx/compose/foundation/text/KeyboardActions;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/jewel/styling/LabelledTextFieldStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/runtime/Composer;III)V
+	public static final fun LabelledTextField (Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/text/input/TextFieldValue;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;ZZLorg/jetbrains/jewel/Outline;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZLandroidx/compose/ui/text/input/VisualTransformation;Landroidx/compose/foundation/text/KeyboardOptions;Landroidx/compose/foundation/text/KeyboardActions;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/jewel/styling/LabelledTextFieldStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/runtime/Composer;III)V
+}
+
+public final class org/jetbrains/jewel/LazyTreeKt {
+	public static final fun LazyTree (Lorg/jetbrains/jewel/foundation/tree/Tree;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/jewel/foundation/tree/TreeState;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/jewel/foundation/tree/KeyBindingActions;Lorg/jetbrains/jewel/styling/LazyTreeStyle;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class org/jetbrains/jewel/LinearProgressBarKt {
+	public static final fun HorizontalProgressBar (FLandroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/styling/HorizontalProgressBarStyle;Landroidx/compose/runtime/Composer;II)V
+	public static final fun IndeterminateHorizontalProgressBar (Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/styling/HorizontalProgressBarStyle;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class org/jetbrains/jewel/LinkKt {
+	public static final fun DropdownLink-fG7obvk (Ljava/lang/String;Landroidx/compose/ui/Modifier;ZJLandroidx/compose/ui/text/font/FontStyle;Landroidx/compose/ui/text/font/FontWeight;Landroidx/compose/ui/text/font/FontFamily;JLandroidx/compose/ui/text/style/TextAlign;IJLandroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/styling/LinkStyle;Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/styling/MenuStyle;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)V
+	public static final fun ExternalLink-Bx0nqJE (Ljava/lang/String;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;ZJLandroidx/compose/ui/text/font/FontStyle;Landroidx/compose/ui/text/font/FontWeight;Landroidx/compose/ui/text/font/FontFamily;JLandroidx/compose/ui/text/style/TextAlign;IJLandroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/styling/LinkStyle;Landroidx/compose/runtime/Composer;III)V
+	public static final fun Link-Bx0nqJE (Ljava/lang/String;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;ZJLandroidx/compose/ui/text/font/FontStyle;Landroidx/compose/ui/text/font/FontWeight;Landroidx/compose/ui/text/font/FontFamily;JLandroidx/compose/ui/text/style/TextAlign;IJLandroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/styling/LinkStyle;Landroidx/compose/runtime/Composer;III)V
+}
+
+public final class org/jetbrains/jewel/LinkState : org/jetbrains/jewel/FocusableComponentState {
+	public static final field Companion Lorg/jetbrains/jewel/LinkState$Companion;
+	public static final synthetic fun box-impl (J)Lorg/jetbrains/jewel/LinkState;
+	public fun chooseValue (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+	public static fun chooseValue-impl (JLjava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+	public static final fun chooseValueWithVisited-impl (JLjava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+	public static fun constructor-impl (J)J
+	public static final fun copy-dcSyc74 (JZZZZZZ)J
+	public static synthetic fun copy-dcSyc74$default (JZZZZZZILjava/lang/Object;)J
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getState-s-VKNKU ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun isActive ()Z
+	public static fun isActive-impl (J)Z
+	public fun isEnabled ()Z
+	public static fun isEnabled-impl (J)Z
+	public fun isFocused ()Z
+	public static fun isFocused-impl (J)Z
+	public fun isHovered ()Z
+	public static fun isHovered-impl (J)Z
+	public fun isPressed ()Z
+	public static fun isPressed-impl (J)Z
+	public static final fun isVisited-impl (J)Z
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public final class org/jetbrains/jewel/LinkState$Companion {
+	public final fun of-dcSyc74 (ZZZZZZ)J
+	public static synthetic fun of-dcSyc74$default (Lorg/jetbrains/jewel/LinkState$Companion;ZZZZZZILjava/lang/Object;)J
+}
+
+public final class org/jetbrains/jewel/MenuItemState : org/jetbrains/jewel/SelectableComponentState {
+	public static final field Companion Lorg/jetbrains/jewel/MenuItemState$Companion;
+	public static final synthetic fun box-impl (J)Lorg/jetbrains/jewel/MenuItemState;
+	public fun chooseValue (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+	public static fun chooseValue-impl (JLjava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+	public static fun constructor-impl (J)J
+	public static final fun copy-b3WktiI (JZZZZZZ)J
+	public static synthetic fun copy-b3WktiI$default (JZZZZZZILjava/lang/Object;)J
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getState-s-VKNKU ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun isActive ()Z
+	public static fun isActive-impl (J)Z
+	public fun isEnabled ()Z
+	public static fun isEnabled-impl (J)Z
+	public fun isFocused ()Z
+	public static fun isFocused-impl (J)Z
+	public fun isHovered ()Z
+	public static fun isHovered-impl (J)Z
+	public fun isPressed ()Z
+	public static fun isPressed-impl (J)Z
+	public fun isSelected ()Z
+	public static fun isSelected-impl (J)Z
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public final class org/jetbrains/jewel/MenuItemState$Companion {
+	public final fun of-b3WktiI (ZZZZZZ)J
+	public static synthetic fun of-b3WktiI$default (Lorg/jetbrains/jewel/MenuItemState$Companion;ZZZZZZILjava/lang/Object;)J
+}
+
+public final class org/jetbrains/jewel/MenuKt {
+	public static final fun MenuItem (ZLkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;ZLandroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/styling/MenuStyle;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun MenuSeparator (Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/styling/MenuItemMetrics;Lorg/jetbrains/jewel/styling/MenuItemColors;Landroidx/compose/runtime/Composer;II)V
+	public static final fun MenuSubmenuItem (Landroidx/compose/ui/Modifier;ZLandroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/styling/MenuStyle;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun PopupMenu (Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/styling/MenuStyle;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun items (Lorg/jetbrains/jewel/MenuScope;ILkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;)V
+	public static final fun items (Lorg/jetbrains/jewel/MenuScope;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;)V
+	public static final fun separator (Lorg/jetbrains/jewel/MenuScope;)V
+}
+
+public final class org/jetbrains/jewel/MenuManager {
+	public static final field $stable I
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lorg/jetbrains/jewel/MenuManager;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;Lorg/jetbrains/jewel/MenuManager;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun close-iuPiT84 (I)Z
+	public final fun closeAll-HMVJIwE (IZ)V
+	public final fun getOnDismissRequest ()Lkotlin/jvm/functions/Function1;
+	public final fun isRootMenu ()Z
+	public final fun isSubmenu ()Z
+	public final fun submenuManager (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/jewel/MenuManager;
+}
+
+public final class org/jetbrains/jewel/MenuManagerKt {
+	public static final fun getLocalMenuManager ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class org/jetbrains/jewel/MenuScope {
+	public abstract fun passiveItem (Lkotlin/jvm/functions/Function2;)V
+	public abstract fun selectableItem (ZLkotlin/jvm/functions/Function0;ZLkotlin/jvm/functions/Function2;)V
+	public abstract fun submenu (ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)V
+}
+
+public final class org/jetbrains/jewel/MenuScope$DefaultImpls {
+	public static synthetic fun selectableItem$default (Lorg/jetbrains/jewel/MenuScope;ZLkotlin/jvm/functions/Function0;ZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public static synthetic fun submenu$default (Lorg/jetbrains/jewel/MenuScope;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+}
+
+public final class org/jetbrains/jewel/NoIndication : androidx/compose/foundation/Indication {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/NoIndication;
+	public fun rememberUpdatedInstance (Landroidx/compose/foundation/interaction/InteractionSource;Landroidx/compose/runtime/Composer;I)Landroidx/compose/foundation/IndicationInstance;
+}
+
+public final class org/jetbrains/jewel/Orientation : java/lang/Enum {
+	public static final field Horizontal Lorg/jetbrains/jewel/Orientation;
+	public static final field Vertical Lorg/jetbrains/jewel/Orientation;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/jewel/Orientation;
+	public static fun values ()[Lorg/jetbrains/jewel/Orientation;
+}
+
+public final class org/jetbrains/jewel/Outline : java/lang/Enum {
+	public static final field Companion Lorg/jetbrains/jewel/Outline$Companion;
+	public static final field Error Lorg/jetbrains/jewel/Outline;
+	public static final field None Lorg/jetbrains/jewel/Outline;
+	public static final field Warning Lorg/jetbrains/jewel/Outline;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/jewel/Outline;
+	public static fun values ()[Lorg/jetbrains/jewel/Outline;
+}
+
+public final class org/jetbrains/jewel/Outline$Companion {
+	public final fun of (ZZ)Lorg/jetbrains/jewel/Outline;
+}
+
+public abstract interface class org/jetbrains/jewel/OutlineColors {
+	public abstract fun getError-0d7_KjU ()J
+	public abstract fun getFocused-0d7_KjU ()J
+	public abstract fun getFocusedError-0d7_KjU ()J
+	public abstract fun getFocusedWarning-0d7_KjU ()J
+	public abstract fun getWarning-0d7_KjU ()J
+}
+
+public final class org/jetbrains/jewel/OutlineKt {
+	public static final fun focusOutline-FJfuzF0 (Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/FocusableComponentState;Landroidx/compose/ui/graphics/Shape;Lorg/jetbrains/jewel/foundation/Stroke$Alignment;FLandroidx/compose/runtime/Composer;II)Landroidx/compose/ui/Modifier;
+	public static final fun outline-HYR8e34 (Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/FocusableComponentState;Lorg/jetbrains/jewel/Outline;Landroidx/compose/ui/graphics/Shape;Lorg/jetbrains/jewel/foundation/Stroke$Alignment;FLandroidx/compose/runtime/Composer;II)Landroidx/compose/ui/Modifier;
+}
+
+public final class org/jetbrains/jewel/RadioButtonKt {
+	public static final fun RadioButton (ZLkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;ZLorg/jetbrains/jewel/Outline;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/styling/RadioButtonStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)V
+	public static final fun RadioButtonRow (Ljava/lang/String;ZLkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;ZLorg/jetbrains/jewel/Outline;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/styling/RadioButtonStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)V
+	public static final fun RadioButtonRow (ZLkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;ZLorg/jetbrains/jewel/Outline;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/styling/RadioButtonStyle;Landroidx/compose/ui/text/TextStyle;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class org/jetbrains/jewel/RadioButtonState : org/jetbrains/jewel/SelectableComponentState {
+	public static final field Companion Lorg/jetbrains/jewel/RadioButtonState$Companion;
+	public static final synthetic fun box-impl (J)Lorg/jetbrains/jewel/RadioButtonState;
+	public fun chooseValue (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+	public static fun chooseValue-impl (JLjava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+	public static fun constructor-impl (J)J
+	public static final fun copy-BIdLuzo (JZZZZZZ)J
+	public static synthetic fun copy-BIdLuzo$default (JZZZZZZILjava/lang/Object;)J
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getState-s-VKNKU ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun isActive ()Z
+	public static fun isActive-impl (J)Z
+	public fun isEnabled ()Z
+	public static fun isEnabled-impl (J)Z
+	public fun isFocused ()Z
+	public static fun isFocused-impl (J)Z
+	public fun isHovered ()Z
+	public static fun isHovered-impl (J)Z
+	public fun isPressed ()Z
+	public static fun isPressed-impl (J)Z
+	public fun isSelected ()Z
+	public static fun isSelected-impl (J)Z
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public final class org/jetbrains/jewel/RadioButtonState$Companion {
+	public final fun of-BIdLuzo (ZZZZZZ)J
+	public static synthetic fun of-BIdLuzo$default (Lorg/jetbrains/jewel/RadioButtonState$Companion;ZZZZZZILjava/lang/Object;)J
+}
+
+public final class org/jetbrains/jewel/ScrollbarsKt {
+	public static final fun HorizontalScrollbar (Landroidx/compose/foundation/v2/ScrollbarAdapter;Landroidx/compose/ui/Modifier;ZLandroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/styling/ScrollbarStyle;Landroidx/compose/runtime/Composer;II)V
+	public static final fun TabStripHorizontalScrollbar (Landroidx/compose/foundation/v2/ScrollbarAdapter;Landroidx/compose/ui/Modifier;ZLandroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/styling/ScrollbarStyle;Landroidx/compose/runtime/Composer;II)V
+	public static final fun VerticalScrollbar (Landroidx/compose/foundation/v2/ScrollbarAdapter;Landroidx/compose/ui/Modifier;ZLandroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/styling/ScrollbarStyle;Landroidx/compose/runtime/Composer;II)V
+}
+
+public abstract interface class org/jetbrains/jewel/SelectableComponentState : org/jetbrains/jewel/FocusableComponentState {
+	public abstract fun isSelected ()Z
+}
+
+public final class org/jetbrains/jewel/SelectableComponentState$DefaultImpls {
+	public static fun chooseValue (Lorg/jetbrains/jewel/SelectableComponentState;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+}
+
+public final class org/jetbrains/jewel/SpinnerProgressIconGenerator {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/SpinnerProgressIconGenerator;
+}
+
+public final class org/jetbrains/jewel/SpinnerProgressIconGenerator$Big {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/SpinnerProgressIconGenerator$Big;
+	public final fun generateSvgFrames (Ljava/lang/String;)Ljava/util/List;
+}
+
+public final class org/jetbrains/jewel/SpinnerProgressIconGenerator$Small {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/SpinnerProgressIconGenerator$Small;
+	public final fun generateSvgFrames (Ljava/lang/String;)Ljava/util/List;
+}
+
+public final class org/jetbrains/jewel/SplitLayoutKt {
+	public static final fun HorizontalSplitLayout-BssWTFQ (Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Landroidx/compose/ui/Modifier;JFFFFFFLandroidx/compose/runtime/Composer;II)V
+	public static final fun VerticalSplitLayout-BssWTFQ (Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Landroidx/compose/ui/Modifier;JFFFFFFLandroidx/compose/runtime/Composer;II)V
+}
+
+public abstract class org/jetbrains/jewel/TabData {
+	public static final field $stable I
+	public abstract fun getClosable ()Z
+	public abstract fun getIcon ()Landroidx/compose/ui/graphics/painter/Painter;
+	public abstract fun getLabel ()Ljava/lang/String;
+	public abstract fun getOnClick ()Lkotlin/jvm/functions/Function0;
+	public abstract fun getOnClose ()Lkotlin/jvm/functions/Function0;
+	public abstract fun getSelected ()Z
+}
+
+public final class org/jetbrains/jewel/TabData$Default : org/jetbrains/jewel/TabData {
+	public static final field $stable I
+	public fun <init> (ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getClosable ()Z
+	public fun getIcon ()Landroidx/compose/ui/graphics/painter/Painter;
+	public fun getLabel ()Ljava/lang/String;
+	public fun getOnClick ()Lkotlin/jvm/functions/Function0;
+	public fun getOnClose ()Lkotlin/jvm/functions/Function0;
+	public fun getSelected ()Z
+	public fun hashCode ()I
+}
+
+public final class org/jetbrains/jewel/TabData$Editor : org/jetbrains/jewel/TabData {
+	public static final field $stable I
+	public fun <init> (ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getClosable ()Z
+	public fun getIcon ()Landroidx/compose/ui/graphics/painter/Painter;
+	public fun getLabel ()Ljava/lang/String;
+	public fun getOnClick ()Lkotlin/jvm/functions/Function0;
+	public fun getOnClose ()Lkotlin/jvm/functions/Function0;
+	public fun getSelected ()Z
+	public fun hashCode ()I
+}
+
+public final class org/jetbrains/jewel/TabState : org/jetbrains/jewel/SelectableComponentState {
+	public static final field Companion Lorg/jetbrains/jewel/TabState$Companion;
+	public static final synthetic fun box-impl (J)Lorg/jetbrains/jewel/TabState;
+	public fun chooseValue (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+	public static fun chooseValue-impl (JLjava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+	public static fun constructor-impl (J)J
+	public static final fun copy-3ML_DI8 (JZZZZZZ)J
+	public static synthetic fun copy-3ML_DI8$default (JZZZZZZILjava/lang/Object;)J
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getState-s-VKNKU ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun isActive ()Z
+	public static fun isActive-impl (J)Z
+	public fun isEnabled ()Z
+	public static fun isEnabled-impl (J)Z
+	public fun isFocused ()Z
+	public static fun isFocused-impl (J)Z
+	public fun isHovered ()Z
+	public static fun isHovered-impl (J)Z
+	public fun isPressed ()Z
+	public static fun isPressed-impl (J)Z
+	public fun isSelected ()Z
+	public static fun isSelected-impl (J)Z
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public final class org/jetbrains/jewel/TabState$Companion {
+	public final fun of-3ML_DI8 (ZZZZZZ)J
+	public static synthetic fun of-3ML_DI8$default (Lorg/jetbrains/jewel/TabState$Companion;ZZZZZZILjava/lang/Object;)J
+}
+
+public final class org/jetbrains/jewel/TabStripKt {
+	public static final fun TabStrip (Ljava/util/List;Landroidx/compose/ui/Modifier;ZLandroidx/compose/runtime/Composer;II)V
+}
+
+public final class org/jetbrains/jewel/TabStripState : org/jetbrains/jewel/FocusableComponentState {
+	public static final field Companion Lorg/jetbrains/jewel/TabStripState$Companion;
+	public static final synthetic fun box-impl (J)Lorg/jetbrains/jewel/TabStripState;
+	public fun chooseValue (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+	public static fun chooseValue-impl (JLjava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+	public static fun constructor-impl (J)J
+	public static final fun copy-S1RedFw (JZZZZZ)J
+	public static synthetic fun copy-S1RedFw$default (JZZZZZILjava/lang/Object;)J
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getState-s-VKNKU ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun isActive ()Z
+	public static fun isActive-impl (J)Z
+	public fun isEnabled ()Z
+	public static fun isEnabled-impl (J)Z
+	public fun isFocused ()Z
+	public static fun isFocused-impl (J)Z
+	public fun isHovered ()Z
+	public static fun isHovered-impl (J)Z
+	public fun isPressed ()Z
+	public static fun isPressed-impl (J)Z
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public final class org/jetbrains/jewel/TabStripState$Companion {
+	public final fun of-S1RedFw (ZZZZZ)J
+	public static synthetic fun of-S1RedFw$default (Lorg/jetbrains/jewel/TabStripState$Companion;ZZZZZILjava/lang/Object;)J
+}
+
+public final class org/jetbrains/jewel/TextAreaKt {
+	public static final fun TextArea (Landroidx/compose/ui/text/input/TextFieldValue;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;ZZLkotlin/jvm/functions/Function2;ZLorg/jetbrains/jewel/Outline;Landroidx/compose/ui/text/input/VisualTransformation;Landroidx/compose/foundation/text/KeyboardOptions;Landroidx/compose/foundation/text/KeyboardActions;ILkotlin/jvm/functions/Function1;Lorg/jetbrains/jewel/styling/TextAreaStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/runtime/Composer;III)V
+	public static final fun TextArea (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;ZZLorg/jetbrains/jewel/Outline;Lkotlin/jvm/functions/Function2;ZLandroidx/compose/ui/text/input/VisualTransformation;Landroidx/compose/foundation/text/KeyboardOptions;Landroidx/compose/foundation/text/KeyboardActions;ILkotlin/jvm/functions/Function1;Lorg/jetbrains/jewel/styling/TextAreaStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/runtime/Composer;III)V
+}
+
+public final class org/jetbrains/jewel/TextFieldKt {
+	public static final fun TextField (Landroidx/compose/ui/text/input/TextFieldValue;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;ZZLorg/jetbrains/jewel/Outline;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZLandroidx/compose/ui/text/input/VisualTransformation;Landroidx/compose/foundation/text/KeyboardOptions;Landroidx/compose/foundation/text/KeyboardActions;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/jewel/styling/TextFieldStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/runtime/Composer;III)V
+	public static final fun TextField (Ljava/lang/String;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;ZZLorg/jetbrains/jewel/Outline;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ZLandroidx/compose/ui/text/input/VisualTransformation;Landroidx/compose/foundation/text/KeyboardOptions;Landroidx/compose/foundation/text/KeyboardActions;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/jewel/styling/TextFieldStyle;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/runtime/Composer;III)V
+}
+
+public final class org/jetbrains/jewel/TextKt {
+	public static final fun Text--4IGK_g (Landroidx/compose/ui/text/AnnotatedString;Landroidx/compose/ui/Modifier;JJLandroidx/compose/ui/text/font/FontStyle;Landroidx/compose/ui/text/font/FontWeight;Landroidx/compose/ui/text/font/FontFamily;JLandroidx/compose/ui/text/style/TextDecoration;Landroidx/compose/ui/text/style/TextAlign;JIZILjava/util/Map;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;III)V
+	public static final fun Text-fLXpl1I (Ljava/lang/String;Landroidx/compose/ui/Modifier;JJLandroidx/compose/ui/text/font/FontStyle;Landroidx/compose/ui/text/font/FontWeight;Landroidx/compose/ui/text/font/FontFamily;JLandroidx/compose/ui/text/style/TextDecoration;Landroidx/compose/ui/text/style/TextAlign;JIZILkotlin/jvm/functions/Function1;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;III)V
+	public static final fun getLocalContentColor ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+	public static final fun getLocalTextStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class org/jetbrains/jewel/ToggleableComponentState : org/jetbrains/jewel/SelectableComponentState {
+	public static final field Companion Lorg/jetbrains/jewel/ToggleableComponentState$Companion;
+	public abstract fun getToggleableState ()Landroidx/compose/ui/state/ToggleableState;
+}
+
+public final class org/jetbrains/jewel/ToggleableComponentState$Companion {
+	public final fun readToggleableState-VKZWuLQ (J)Landroidx/compose/ui/state/ToggleableState;
+}
+
+public final class org/jetbrains/jewel/ToggleableComponentState$DefaultImpls {
+	public static fun chooseValue (Lorg/jetbrains/jewel/ToggleableComponentState;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+}
+
+public final class org/jetbrains/jewel/TooltipKt {
+	public static final fun Tooltip (Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/styling/TooltipStyle;Landroidx/compose/foundation/TooltipPlacement;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class org/jetbrains/jewel/foundation/BorderKt {
+	public static final fun border (Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/foundation/Stroke;Landroidx/compose/ui/graphics/Shape;)Landroidx/compose/ui/Modifier;
+	public static final fun border-AkepmR4 (Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/foundation/Stroke$Alignment;FLandroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Shape;F)Landroidx/compose/ui/Modifier;
+	public static synthetic fun border-AkepmR4$default (Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/foundation/Stroke$Alignment;FLandroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Shape;FILjava/lang/Object;)Landroidx/compose/ui/Modifier;
+	public static final fun border-QWjY48E (Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/foundation/Stroke$Alignment;FJLandroidx/compose/ui/graphics/Shape;F)Landroidx/compose/ui/Modifier;
+	public static synthetic fun border-QWjY48E$default (Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/foundation/Stroke$Alignment;FJLandroidx/compose/ui/graphics/Shape;FILjava/lang/Object;)Landroidx/compose/ui/Modifier;
+}
+
+public final class org/jetbrains/jewel/foundation/CompatibilityKt {
+	public static final fun enableNewSwingCompositing ()V
+}
+
+public final class org/jetbrains/jewel/foundation/PointerInputKt {
+	public static final fun onHover (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;)Landroidx/compose/ui/Modifier;
+}
+
+public abstract class org/jetbrains/jewel/foundation/Stroke {
+	public static final field $stable I
+}
+
+public final class org/jetbrains/jewel/foundation/Stroke$Alignment : java/lang/Enum {
+	public static final field Center Lorg/jetbrains/jewel/foundation/Stroke$Alignment;
+	public static final field Inside Lorg/jetbrains/jewel/foundation/Stroke$Alignment;
+	public static final field Outside Lorg/jetbrains/jewel/foundation/Stroke$Alignment;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/jewel/foundation/Stroke$Alignment;
+	public static fun values ()[Lorg/jetbrains/jewel/foundation/Stroke$Alignment;
+}
+
+public final class org/jetbrains/jewel/foundation/Stroke$Brush : org/jetbrains/jewel/foundation/Stroke {
+	public static final field $stable I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlignment ()Lorg/jetbrains/jewel/foundation/Stroke$Alignment;
+	public final fun getBrush ()Landroidx/compose/ui/graphics/Brush;
+	public final fun getExpand-D9Ej5fM ()F
+	public final fun getWidth-D9Ej5fM ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/foundation/Stroke$None : org/jetbrains/jewel/foundation/Stroke {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/foundation/Stroke$None;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/foundation/Stroke$Solid : org/jetbrains/jewel/foundation/Stroke {
+	public static final field $stable I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlignment ()Lorg/jetbrains/jewel/foundation/Stroke$Alignment;
+	public final fun getColor-0d7_KjU ()J
+	public final fun getExpand-D9Ej5fM ()F
+	public final fun getWidth-D9Ej5fM ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/foundation/StrokeKt {
+	public static final fun Stroke-Ke5fDM4 (FLandroidx/compose/ui/graphics/Brush;Lorg/jetbrains/jewel/foundation/Stroke$Alignment;F)Lorg/jetbrains/jewel/foundation/Stroke;
+	public static synthetic fun Stroke-Ke5fDM4$default (FLandroidx/compose/ui/graphics/Brush;Lorg/jetbrains/jewel/foundation/Stroke$Alignment;FILjava/lang/Object;)Lorg/jetbrains/jewel/foundation/Stroke;
+	public static final fun Stroke-nMwvq1g (FJLorg/jetbrains/jewel/foundation/Stroke$Alignment;F)Lorg/jetbrains/jewel/foundation/Stroke;
+	public static synthetic fun Stroke-nMwvq1g$default (FJLorg/jetbrains/jewel/foundation/Stroke$Alignment;FILjava/lang/Object;)Lorg/jetbrains/jewel/foundation/Stroke;
+}
+
+public class org/jetbrains/jewel/foundation/lazy/DefaultSelectableColumnKeybindings : org/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/foundation/lazy/DefaultSelectableColumnKeybindings$Companion;
+	public fun <init> ()V
+	public fun edit-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public fun extendSelectionToFirstItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public fun extendSelectionToLastItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public fun extendSelectionWithNextItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public fun extendSelectionWithPreviousItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public fun isKeyboardCtrlMetaKeyPressed-ZmokQxo (Ljava/lang/Object;)Z
+	public fun isKeyboardMultiSelectionKeyPressed-5xRPYO0 (I)Z
+	public fun isKeyboardMultiSelectionKeyPressed-ZmokQxo (Ljava/lang/Object;)Z
+	public fun scrollPageDownAndExtendSelection-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public fun scrollPageDownAndSelectItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public fun scrollPageUpAndExtendSelection-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public fun scrollPageUpAndSelectItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public fun selectAll-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public fun selectFirstItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public fun selectLastItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public fun selectNextItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public fun selectPreviousItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+}
+
+public final class org/jetbrains/jewel/foundation/lazy/DefaultSelectableColumnKeybindings$Companion : org/jetbrains/jewel/foundation/lazy/DefaultSelectableColumnKeybindings {
+}
+
+public class org/jetbrains/jewel/foundation/lazy/DefaultSelectableOnKeyEvent : org/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/foundation/lazy/DefaultSelectableOnKeyEvent$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;)V
+	public fun getKeybindings ()Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;
+	public fun onEdit ()V
+	public fun onExtendSelectionToFirst (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onExtendSelectionToLastItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onExtendSelectionWithNextItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onExtendSelectionWithPreviousItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onScrollPageDownAndExtendSelection (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onScrollPageDownAndSelectItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onScrollPageUpAndExtendSelection (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onScrollPageUpAndSelectItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onSelectAll (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onSelectFirstItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onSelectLastItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onSelectNextItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onSelectPreviousItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+}
+
+public final class org/jetbrains/jewel/foundation/lazy/DefaultSelectableOnKeyEvent$Companion : org/jetbrains/jewel/foundation/lazy/DefaultSelectableOnKeyEvent {
+}
+
+public abstract interface class org/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings {
+	public abstract fun edit-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public abstract fun extendSelectionToFirstItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public abstract fun extendSelectionToLastItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public abstract fun extendSelectionWithNextItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public abstract fun extendSelectionWithPreviousItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public abstract fun isKeyboardCtrlMetaKeyPressed-ZmokQxo (Ljava/lang/Object;)Z
+	public abstract fun isKeyboardMultiSelectionKeyPressed-5xRPYO0 (I)Z
+	public abstract fun isKeyboardMultiSelectionKeyPressed-ZmokQxo (Ljava/lang/Object;)Z
+	public abstract fun scrollPageDownAndExtendSelection-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public abstract fun scrollPageDownAndSelectItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public abstract fun scrollPageUpAndExtendSelection-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public abstract fun scrollPageUpAndSelectItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public abstract fun selectAll-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public abstract fun selectFirstItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public abstract fun selectLastItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public abstract fun selectNextItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public abstract fun selectPreviousItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+}
+
+public final class org/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings$DefaultImpls {
+	public static fun isKeyboardCtrlMetaKeyPressed-ZmokQxo (Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;Ljava/lang/Object;)Z
+	public static fun isKeyboardMultiSelectionKeyPressed-5xRPYO0 (Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;I)Z
+	public static fun isKeyboardMultiSelectionKeyPressed-ZmokQxo (Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;Ljava/lang/Object;)Z
+}
+
+public abstract interface class org/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent {
+	public abstract fun getKeybindings ()Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;
+	public abstract fun onEdit ()V
+	public abstract fun onExtendSelectionToFirst (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public abstract fun onExtendSelectionToLastItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public abstract fun onExtendSelectionWithNextItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public abstract fun onExtendSelectionWithPreviousItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public abstract fun onScrollPageDownAndExtendSelection (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public abstract fun onScrollPageDownAndSelectItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public abstract fun onScrollPageUpAndExtendSelection (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public abstract fun onScrollPageUpAndSelectItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public abstract fun onSelectAll (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public abstract fun onSelectFirstItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public abstract fun onSelectLastItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public abstract fun onSelectNextItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public abstract fun onSelectPreviousItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+}
+
+public final class org/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent$DefaultImpls {
+	public static fun onEdit (Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent;)V
+	public static fun onExtendSelectionToFirst (Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public static fun onExtendSelectionToLastItem (Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public static fun onExtendSelectionWithNextItem (Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public static fun onExtendSelectionWithPreviousItem (Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public static fun onScrollPageDownAndExtendSelection (Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public static fun onScrollPageDownAndSelectItem (Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public static fun onScrollPageUpAndExtendSelection (Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public static fun onScrollPageUpAndSelectItem (Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public static fun onSelectAll (Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public static fun onSelectFirstItem (Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public static fun onSelectLastItem (Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public static fun onSelectNextItem (Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public static fun onSelectPreviousItem (Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+}
+
+public final class org/jetbrains/jewel/foundation/lazy/SelectableLazyColumnKt {
+	public static final fun SelectableLazyColumn (Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Landroidx/compose/foundation/layout/PaddingValues;ZLkotlin/jvm/functions/Function1;Landroidx/compose/foundation/layout/Arrangement$Vertical;Landroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/foundation/gestures/FlingBehavior;Lorg/jetbrains/jewel/foundation/tree/KeyBindingActions;Lorg/jetbrains/jewel/foundation/tree/PointerEventActions;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)V
+}
+
+public abstract interface class org/jetbrains/jewel/foundation/lazy/SelectableLazyItemScope : androidx/compose/foundation/lazy/LazyItemScope {
+	public abstract fun isActive ()Z
+	public abstract fun isSelected ()Z
+}
+
+public abstract class org/jetbrains/jewel/foundation/lazy/SelectableLazyListKey {
+	public static final field $stable I
+	public fun equals (Ljava/lang/Object;)Z
+	public abstract fun getKey ()Ljava/lang/Object;
+	public fun hashCode ()I
+}
+
+public final class org/jetbrains/jewel/foundation/lazy/SelectableLazyListKey$NotSelectable : org/jetbrains/jewel/foundation/lazy/SelectableLazyListKey {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/Object;)V
+	public fun getKey ()Ljava/lang/Object;
+}
+
+public final class org/jetbrains/jewel/foundation/lazy/SelectableLazyListKey$Selectable : org/jetbrains/jewel/foundation/lazy/SelectableLazyListKey {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/Object;)V
+	public fun getKey ()Ljava/lang/Object;
+}
+
+public abstract interface class org/jetbrains/jewel/foundation/lazy/SelectableLazyListScope {
+	public abstract fun item (Ljava/lang/Object;Ljava/lang/Object;ZLkotlin/jvm/functions/Function3;)V
+	public abstract fun items (ILkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;)V
+	public abstract fun stickyHeader (Ljava/lang/Object;Ljava/lang/Object;ZLkotlin/jvm/functions/Function3;)V
+}
+
+public final class org/jetbrains/jewel/foundation/lazy/SelectableLazyListScope$DefaultImpls {
+	public static synthetic fun item$default (Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListScope;Ljava/lang/Object;Ljava/lang/Object;ZLkotlin/jvm/functions/Function3;ILjava/lang/Object;)V
+	public static synthetic fun items$default (Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListScope;ILkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;ILjava/lang/Object;)V
+	public static synthetic fun stickyHeader$default (Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListScope;Ljava/lang/Object;Ljava/lang/Object;ZLkotlin/jvm/functions/Function3;ILjava/lang/Object;)V
+}
+
+public final class org/jetbrains/jewel/foundation/lazy/SelectableLazyListScopeKt {
+	public static final fun SelectableLazyItemScope (Landroidx/compose/foundation/lazy/LazyItemScope;ZZLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyItemScope;
+	public static final fun items (Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListScope;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;)V
+	public static synthetic fun items$default (Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListScope;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;ILjava/lang/Object;)V
+	public static final fun itemsIndexed (Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListScope;Ljava/util/List;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function5;)V
+	public static synthetic fun itemsIndexed$default (Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListScope;Ljava/util/List;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function5;ILjava/lang/Object;)V
+}
+
+public final class org/jetbrains/jewel/foundation/lazy/SelectableLazyListState : androidx/compose/foundation/gestures/ScrollableState, org/jetbrains/jewel/foundation/lazy/SelectableScope {
+	public static final field $stable I
+	public fun <init> (Landroidx/compose/foundation/lazy/LazyListState;)V
+	public fun dispatchRawDelta (F)F
+	public fun getCanScrollBackward ()Z
+	public fun getCanScrollForward ()Z
+	public final fun getFirstVisibleItemIndex ()I
+	public final fun getFirstVisibleItemScrollOffset ()I
+	public final fun getInteractionSource ()Landroidx/compose/foundation/interaction/InteractionSource;
+	public final fun getLayoutInfo ()Landroidx/compose/foundation/lazy/LazyListLayoutInfo;
+	public final fun getLazyListState ()Landroidx/compose/foundation/lazy/LazyListState;
+	public fun getSelectedKeys ()Ljava/util/List;
+	public fun isScrollInProgress ()Z
+	public fun scroll (Landroidx/compose/foundation/MutatePriority;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun scrollToItem (IZILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun scrollToItem$default (Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;IZILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun setSelectedKeys (Ljava/util/List;)V
+}
+
+public final class org/jetbrains/jewel/foundation/lazy/SelectableLazyListStateKt {
+	public static final fun getVisibleItemsRange (Landroidx/compose/foundation/lazy/LazyListState;)Lkotlin/ranges/IntRange;
+	public static final fun getVisibleItemsRange (Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)Lkotlin/ranges/IntRange;
+	public static final fun rememberSelectableLazyListState (IILandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;
+}
+
+public abstract interface class org/jetbrains/jewel/foundation/lazy/SelectableScope {
+	public abstract fun getSelectedKeys ()Ljava/util/List;
+	public abstract fun setSelectedKeys (Ljava/util/List;)V
+}
+
+public final class org/jetbrains/jewel/foundation/lazy/SelectionMode : java/lang/Enum {
+	public static final field Multiple Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;
+	public static final field None Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;
+	public static final field Single Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;
+	public static fun values ()[Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;
+}
+
+public final class org/jetbrains/jewel/foundation/tree/BasicLazyTreeKt {
+	public static final fun BasicLazyTree-orM9XXQ (Lorg/jetbrains/jewel/foundation/tree/Tree;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;Lkotlin/jvm/functions/Function1;JJJFLandroidx/compose/foundation/shape/CornerSize;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/foundation/layout/PaddingValues;FFLorg/jetbrains/jewel/foundation/tree/TreeState;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;JLorg/jetbrains/jewel/foundation/tree/KeyBindingActions;Lorg/jetbrains/jewel/foundation/tree/PointerEventActions;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;IIII)V
+}
+
+public final class org/jetbrains/jewel/foundation/tree/BuildTreeKt {
+	public static final fun asTree (Ljava/io/File;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/jewel/foundation/tree/Tree;
+	public static final fun asTree (Ljava/nio/file/Path;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/jewel/foundation/tree/Tree;
+	public static synthetic fun asTree$default (Ljava/io/File;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/jewel/foundation/tree/Tree;
+	public static synthetic fun asTree$default (Ljava/nio/file/Path;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/jewel/foundation/tree/Tree;
+	public static final fun buildTree (Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/jewel/foundation/tree/Tree;
+}
+
+public final class org/jetbrains/jewel/foundation/tree/ChildrenGeneratorScope : org/jetbrains/jewel/foundation/tree/TreeGeneratorScope {
+	public static final field $stable I
+	public fun <init> (Lorg/jetbrains/jewel/foundation/tree/Tree$Element$Node;)V
+	public fun add (Lorg/jetbrains/jewel/foundation/tree/TreeBuilder$Element;)V
+	public fun addLeaf (Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun addNode (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)V
+	public final fun getParent ()Lorg/jetbrains/jewel/foundation/tree/ChildrenGeneratorScope$ParentInfo;
+}
+
+public final class org/jetbrains/jewel/foundation/tree/ChildrenGeneratorScope$ParentInfo {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/Object;II)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun copy (Ljava/lang/Object;II)Lorg/jetbrains/jewel/foundation/tree/ChildrenGeneratorScope$ParentInfo;
+	public static synthetic fun copy$default (Lorg/jetbrains/jewel/foundation/tree/ChildrenGeneratorScope$ParentInfo;Ljava/lang/Object;IIILjava/lang/Object;)Lorg/jetbrains/jewel/foundation/tree/ChildrenGeneratorScope$ParentInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Ljava/lang/Object;
+	public final fun getDepth ()I
+	public final fun getIndex ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public class org/jetbrains/jewel/foundation/tree/DefaultMacOsTreeColumnKeybindings : org/jetbrains/jewel/foundation/tree/DefaultTreeViewKeybindings {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/foundation/tree/DefaultMacOsTreeColumnKeybindings$Companion;
+	public fun <init> ()V
+	public fun isKeyboardMultiSelectionKeyPressed-5xRPYO0 (I)Z
+	public fun isKeyboardMultiSelectionKeyPressed-ZmokQxo (Ljava/lang/Object;)Z
+}
+
+public final class org/jetbrains/jewel/foundation/tree/DefaultMacOsTreeColumnKeybindings$Companion : org/jetbrains/jewel/foundation/tree/DefaultMacOsTreeColumnKeybindings {
+}
+
+public final class org/jetbrains/jewel/foundation/tree/DefaultSelectableLazyColumnEventAction : org/jetbrains/jewel/foundation/tree/PointerEventActions {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun handlePointerEventPress (Landroidx/compose/ui/input/pointer/PointerEvent;Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;Ljava/util/List;Ljava/lang/Object;)V
+	public fun onExtendSelectionToKey (Ljava/lang/Object;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;)V
+	public fun toggleKeySelection (Ljava/lang/Object;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+}
+
+public class org/jetbrains/jewel/foundation/tree/DefaultSelectableLazyColumnKeyActions : org/jetbrains/jewel/foundation/tree/KeyBindingActions {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun getActions ()Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent;
+	public fun getKeybindings ()Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;
+	public fun handleOnKeyEvent-jhbQyNo (Ljava/lang/Object;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;)Lkotlin/jvm/functions/Function1;
+}
+
+public final class org/jetbrains/jewel/foundation/tree/DefaultTreeViewKeyActions : org/jetbrains/jewel/foundation/tree/DefaultSelectableLazyColumnKeyActions {
+	public static final field $stable I
+	public fun <init> (Lorg/jetbrains/jewel/foundation/tree/TreeState;)V
+	public synthetic fun getActions ()Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent;
+	public fun getActions ()Lorg/jetbrains/jewel/foundation/tree/DefaultTreeViewOnKeyEvent;
+	public synthetic fun getKeybindings ()Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;
+	public fun getKeybindings ()Lorg/jetbrains/jewel/foundation/tree/TreeViewKeybindings;
+	public fun handleOnKeyEvent-jhbQyNo (Ljava/lang/Object;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;)Lkotlin/jvm/functions/Function1;
+}
+
+public class org/jetbrains/jewel/foundation/tree/DefaultTreeViewKeybindings : org/jetbrains/jewel/foundation/lazy/DefaultSelectableColumnKeybindings, org/jetbrains/jewel/foundation/tree/TreeViewKeybindings {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/foundation/tree/DefaultTreeViewKeybindings$Companion;
+	public fun <init> ()V
+	public fun edit-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public fun extendSelectionToChild-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public fun extendSelectionToParent-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public fun selectChild-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public synthetic fun selectNextSibling-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public fun selectNextSibling-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Void;
+	public fun selectParent-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public synthetic fun selectPreviousSibling-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public fun selectPreviousSibling-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Void;
+}
+
+public final class org/jetbrains/jewel/foundation/tree/DefaultTreeViewKeybindings$Companion : org/jetbrains/jewel/foundation/tree/DefaultTreeViewKeybindings {
+}
+
+public final class org/jetbrains/jewel/foundation/tree/DefaultTreeViewKeybindingsKt {
+	public static final fun getDefaultWindowsTreeViewClickModifierHandler ()Lkotlin/jvm/functions/Function1;
+}
+
+public class org/jetbrains/jewel/foundation/tree/DefaultTreeViewOnKeyEvent : org/jetbrains/jewel/foundation/tree/TreeViewOnKeyEvent {
+	public static final field $stable I
+	public fun <init> (Lorg/jetbrains/jewel/foundation/tree/TreeViewKeybindings;Lorg/jetbrains/jewel/foundation/tree/TreeState;)V
+	public synthetic fun getKeybindings ()Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;
+	public fun getKeybindings ()Lorg/jetbrains/jewel/foundation/tree/TreeViewKeybindings;
+	public fun onEdit ()V
+	public fun onExtendSelectionToFirst (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onExtendSelectionToLastItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onExtendSelectionWithNextItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onExtendSelectionWithPreviousItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onScrollPageDownAndExtendSelection (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onScrollPageDownAndSelectItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onScrollPageUpAndExtendSelection (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onScrollPageUpAndSelectItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onSelectAll (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onSelectChild (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onSelectFirstItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onSelectLastItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onSelectNextItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onSelectParent (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun onSelectPreviousItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+}
+
+public final class org/jetbrains/jewel/foundation/tree/DefaultTreeViewPointerEventAction : org/jetbrains/jewel/foundation/tree/PointerEventActions {
+	public static final field $stable I
+	public fun <init> (Lorg/jetbrains/jewel/foundation/tree/TreeState;)V
+	public fun handlePointerEventPress (Landroidx/compose/ui/input/pointer/PointerEvent;Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;Ljava/util/List;Ljava/lang/Object;)V
+	public fun onExtendSelectionToKey (Ljava/lang/Object;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;)V
+	public fun toggleKeySelection (Ljava/lang/Object;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+}
+
+public abstract interface class org/jetbrains/jewel/foundation/tree/KeyBindingActions {
+	public abstract fun getActions ()Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent;
+	public abstract fun getKeybindings ()Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;
+	public abstract fun handleOnKeyEvent-jhbQyNo (Ljava/lang/Object;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;)Lkotlin/jvm/functions/Function1;
+}
+
+public abstract interface class org/jetbrains/jewel/foundation/tree/PointerEventActions {
+	public abstract fun handlePointerEventPress (Landroidx/compose/ui/input/pointer/PointerEvent;Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;Ljava/util/List;Ljava/lang/Object;)V
+	public abstract fun onExtendSelectionToKey (Ljava/lang/Object;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;)V
+	public abstract fun toggleKeySelection (Ljava/lang/Object;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+}
+
+public final class org/jetbrains/jewel/foundation/tree/PointerEventActions$DefaultImpls {
+	public static fun handlePointerEventPress (Lorg/jetbrains/jewel/foundation/tree/PointerEventActions;Landroidx/compose/ui/input/pointer/PointerEvent;Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;Ljava/util/List;Ljava/lang/Object;)V
+	public static fun onExtendSelectionToKey (Lorg/jetbrains/jewel/foundation/tree/PointerEventActions;Ljava/lang/Object;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;)V
+	public static fun toggleKeySelection (Lorg/jetbrains/jewel/foundation/tree/PointerEventActions;Ljava/lang/Object;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+}
+
+public final class org/jetbrains/jewel/foundation/tree/Tree {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/foundation/tree/Tree$Companion;
+	public final fun getRoots ()Ljava/util/List;
+	public final fun isEmpty ()Z
+	public final fun walkBreadthFirst ()Lkotlin/sequences/Sequence;
+	public final fun walkDepthFirst ()Lkotlin/sequences/Sequence;
+}
+
+public final class org/jetbrains/jewel/foundation/tree/Tree$Companion {
+}
+
+public abstract interface class org/jetbrains/jewel/foundation/tree/Tree$Element {
+	public abstract fun getChildIndex ()I
+	public abstract fun getData ()Ljava/lang/Object;
+	public abstract fun getDepth ()I
+	public abstract fun getId ()Ljava/lang/Object;
+	public abstract fun getNext ()Lorg/jetbrains/jewel/foundation/tree/Tree$Element;
+	public abstract fun getParent ()Lorg/jetbrains/jewel/foundation/tree/Tree$Element;
+	public abstract fun getPrevious ()Lorg/jetbrains/jewel/foundation/tree/Tree$Element;
+	public abstract fun nextElementsIterable ()Ljava/lang/Iterable;
+	public abstract fun path ()Ljava/util/List;
+	public abstract fun previousElementsIterable ()Ljava/lang/Iterable;
+	public abstract fun setNext (Lorg/jetbrains/jewel/foundation/tree/Tree$Element;)V
+	public abstract fun setPrevious (Lorg/jetbrains/jewel/foundation/tree/Tree$Element;)V
+}
+
+public final class org/jetbrains/jewel/foundation/tree/Tree$Element$DefaultImpls {
+	public static fun nextElementsIterable (Lorg/jetbrains/jewel/foundation/tree/Tree$Element;)Ljava/lang/Iterable;
+	public static fun path (Lorg/jetbrains/jewel/foundation/tree/Tree$Element;)Ljava/util/List;
+	public static fun previousElementsIterable (Lorg/jetbrains/jewel/foundation/tree/Tree$Element;)Ljava/lang/Iterable;
+}
+
+public final class org/jetbrains/jewel/foundation/tree/Tree$Element$Leaf : org/jetbrains/jewel/foundation/tree/Tree$Element {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/Object;IILorg/jetbrains/jewel/foundation/tree/Tree$Element;Lorg/jetbrains/jewel/foundation/tree/Tree$Element;Lorg/jetbrains/jewel/foundation/tree/Tree$Element;Ljava/lang/Object;)V
+	public fun getChildIndex ()I
+	public fun getData ()Ljava/lang/Object;
+	public fun getDepth ()I
+	public fun getId ()Ljava/lang/Object;
+	public fun getNext ()Lorg/jetbrains/jewel/foundation/tree/Tree$Element;
+	public fun getParent ()Lorg/jetbrains/jewel/foundation/tree/Tree$Element;
+	public fun getPrevious ()Lorg/jetbrains/jewel/foundation/tree/Tree$Element;
+	public fun nextElementsIterable ()Ljava/lang/Iterable;
+	public fun path ()Ljava/util/List;
+	public fun previousElementsIterable ()Ljava/lang/Iterable;
+	public fun setNext (Lorg/jetbrains/jewel/foundation/tree/Tree$Element;)V
+	public fun setPrevious (Lorg/jetbrains/jewel/foundation/tree/Tree$Element;)V
+}
+
+public final class org/jetbrains/jewel/foundation/tree/Tree$Element$Node : org/jetbrains/jewel/foundation/tree/Tree$Element {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/Object;IILorg/jetbrains/jewel/foundation/tree/Tree$Element;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/jewel/foundation/tree/Tree$Element;Lorg/jetbrains/jewel/foundation/tree/Tree$Element;Ljava/lang/Object;)V
+	public final fun close ()V
+	public fun getChildIndex ()I
+	public final fun getChildren ()Ljava/util/List;
+	public fun getData ()Ljava/lang/Object;
+	public fun getDepth ()I
+	public fun getId ()Ljava/lang/Object;
+	public fun getNext ()Lorg/jetbrains/jewel/foundation/tree/Tree$Element;
+	public fun getParent ()Lorg/jetbrains/jewel/foundation/tree/Tree$Element;
+	public fun getPrevious ()Lorg/jetbrains/jewel/foundation/tree/Tree$Element;
+	public fun nextElementsIterable ()Ljava/lang/Iterable;
+	public final fun open (Z)V
+	public static synthetic fun open$default (Lorg/jetbrains/jewel/foundation/tree/Tree$Element$Node;ZILjava/lang/Object;)V
+	public fun path ()Ljava/util/List;
+	public fun previousElementsIterable ()Ljava/lang/Iterable;
+	public fun setNext (Lorg/jetbrains/jewel/foundation/tree/Tree$Element;)V
+	public fun setPrevious (Lorg/jetbrains/jewel/foundation/tree/Tree$Element;)V
+}
+
+public final class org/jetbrains/jewel/foundation/tree/TreeBuilder : org/jetbrains/jewel/foundation/tree/TreeGeneratorScope {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun add (Lorg/jetbrains/jewel/foundation/tree/TreeBuilder$Element;)V
+	public fun addLeaf (Ljava/lang/Object;Ljava/lang/Object;)V
+	public fun addNode (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)V
+	public final fun build ()Lorg/jetbrains/jewel/foundation/tree/Tree;
+}
+
+public abstract class org/jetbrains/jewel/foundation/tree/TreeBuilder$Element {
+	public static final field $stable I
+	public abstract fun getId ()Ljava/lang/Object;
+}
+
+public final class org/jetbrains/jewel/foundation/tree/TreeBuilder$Element$Leaf : org/jetbrains/jewel/foundation/tree/TreeBuilder$Element {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Object;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun copy (Ljava/lang/Object;Ljava/lang/Object;)Lorg/jetbrains/jewel/foundation/tree/TreeBuilder$Element$Leaf;
+	public static synthetic fun copy$default (Lorg/jetbrains/jewel/foundation/tree/TreeBuilder$Element$Leaf;Ljava/lang/Object;Ljava/lang/Object;ILjava/lang/Object;)Lorg/jetbrains/jewel/foundation/tree/TreeBuilder$Element$Leaf;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Ljava/lang/Object;
+	public fun getId ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/foundation/tree/TreeBuilder$Element$Node : org/jetbrains/jewel/foundation/tree/TreeBuilder$Element {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)V
+	public final fun component1 ()Ljava/lang/Object;
+	public final fun component2 ()Ljava/lang/Object;
+	public final fun component3 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)Lorg/jetbrains/jewel/foundation/tree/TreeBuilder$Element$Node;
+	public static synthetic fun copy$default (Lorg/jetbrains/jewel/foundation/tree/TreeBuilder$Element$Node;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/jetbrains/jewel/foundation/tree/TreeBuilder$Element$Node;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChildrenGenerator ()Lkotlin/jvm/functions/Function1;
+	public final fun getData ()Ljava/lang/Object;
+	public fun getId ()Ljava/lang/Object;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/foundation/tree/TreeElementState : org/jetbrains/jewel/InteractiveComponentState, org/jetbrains/jewel/SelectableComponentState {
+	public static final field Companion Lorg/jetbrains/jewel/foundation/tree/TreeElementState$Companion;
+	public static final synthetic fun box-impl (J)Lorg/jetbrains/jewel/foundation/tree/TreeElementState;
+	public fun chooseValue (Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+	public static fun chooseValue-impl (JLjava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
+	public static fun constructor-impl (J)J
+	public static final fun copy-ZVebPRw (JZZZZZZZ)J
+	public static synthetic fun copy-ZVebPRw$default (JZZZZZZZILjava/lang/Object;)J
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getState-s-VKNKU ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public fun isActive ()Z
+	public static fun isActive-impl (J)Z
+	public fun isEnabled ()Z
+	public static fun isEnabled-impl (J)Z
+	public static final fun isExpanded-impl (J)Z
+	public fun isFocused ()Z
+	public static fun isFocused-impl (J)Z
+	public fun isHovered ()Z
+	public static fun isHovered-impl (J)Z
+	public fun isPressed ()Z
+	public static fun isPressed-impl (J)Z
+	public fun isSelected ()Z
+	public static fun isSelected-impl (J)Z
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public final class org/jetbrains/jewel/foundation/tree/TreeElementState$Companion {
+	public final fun of-ZVebPRw (ZZZZZZZ)J
+	public static synthetic fun of-ZVebPRw$default (Lorg/jetbrains/jewel/foundation/tree/TreeElementState$Companion;ZZZZZZZILjava/lang/Object;)J
+}
+
+public abstract interface class org/jetbrains/jewel/foundation/tree/TreeGeneratorScope {
+	public abstract fun add (Lorg/jetbrains/jewel/foundation/tree/TreeBuilder$Element;)V
+	public abstract fun addLeaf (Ljava/lang/Object;Ljava/lang/Object;)V
+	public abstract fun addNode (Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class org/jetbrains/jewel/foundation/tree/TreeGeneratorScope$DefaultImpls {
+	public static synthetic fun addLeaf$default (Lorg/jetbrains/jewel/foundation/tree/TreeGeneratorScope;Ljava/lang/Object;Ljava/lang/Object;ILjava/lang/Object;)V
+	public static synthetic fun addNode$default (Lorg/jetbrains/jewel/foundation/tree/TreeGeneratorScope;Ljava/lang/Object;Ljava/lang/Object;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+}
+
+public final class org/jetbrains/jewel/foundation/tree/TreeKt {
+	public static final fun emptyTree ()Lorg/jetbrains/jewel/foundation/tree/Tree;
+}
+
+public final class org/jetbrains/jewel/foundation/tree/TreeState : androidx/compose/foundation/gestures/ScrollableState, org/jetbrains/jewel/foundation/lazy/SelectableScope {
+	public static final field $stable I
+	public fun <init> (Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public fun dispatchRawDelta (F)F
+	public fun getCanScrollBackward ()Z
+	public fun getCanScrollForward ()Z
+	public final fun getOpenNodes ()Ljava/util/Set;
+	public fun getSelectedKeys ()Ljava/util/List;
+	public fun isScrollInProgress ()Z
+	public final fun openNodes (Ljava/util/List;)V
+	public fun scroll (Landroidx/compose/foundation/MutatePriority;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setOpenNodes (Ljava/util/Set;)V
+	public fun setSelectedKeys (Ljava/util/List;)V
+	public final fun toggleNode (Ljava/lang/Object;)V
+}
+
+public final class org/jetbrains/jewel/foundation/tree/TreeStateKt {
+	public static final fun rememberTreeState (Landroidx/compose/foundation/lazy/LazyListState;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/foundation/tree/TreeState;
+}
+
+public abstract interface class org/jetbrains/jewel/foundation/tree/TreeViewKeybindings : org/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings {
+	public abstract fun extendSelectionToChild-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public abstract fun extendSelectionToParent-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public abstract fun selectChild-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public abstract fun selectNextSibling-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public abstract fun selectParent-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public abstract fun selectPreviousSibling-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+}
+
+public final class org/jetbrains/jewel/foundation/tree/TreeViewKeybindings$DefaultImpls {
+	public static fun isKeyboardCtrlMetaKeyPressed-ZmokQxo (Lorg/jetbrains/jewel/foundation/tree/TreeViewKeybindings;Ljava/lang/Object;)Z
+	public static fun isKeyboardMultiSelectionKeyPressed-5xRPYO0 (Lorg/jetbrains/jewel/foundation/tree/TreeViewKeybindings;I)Z
+	public static fun isKeyboardMultiSelectionKeyPressed-ZmokQxo (Lorg/jetbrains/jewel/foundation/tree/TreeViewKeybindings;Ljava/lang/Object;)Z
+}
+
+public abstract interface class org/jetbrains/jewel/foundation/tree/TreeViewOnKeyEvent : org/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent {
+	public abstract fun onSelectChild (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public abstract fun onSelectParent (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+}
+
+public final class org/jetbrains/jewel/foundation/tree/TreeViewOnKeyEvent$DefaultImpls {
+	public static fun onEdit (Lorg/jetbrains/jewel/foundation/tree/TreeViewOnKeyEvent;)V
+	public static fun onExtendSelectionToFirst (Lorg/jetbrains/jewel/foundation/tree/TreeViewOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public static fun onExtendSelectionToLastItem (Lorg/jetbrains/jewel/foundation/tree/TreeViewOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public static fun onExtendSelectionWithNextItem (Lorg/jetbrains/jewel/foundation/tree/TreeViewOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public static fun onExtendSelectionWithPreviousItem (Lorg/jetbrains/jewel/foundation/tree/TreeViewOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public static fun onScrollPageDownAndExtendSelection (Lorg/jetbrains/jewel/foundation/tree/TreeViewOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public static fun onScrollPageDownAndSelectItem (Lorg/jetbrains/jewel/foundation/tree/TreeViewOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public static fun onScrollPageUpAndExtendSelection (Lorg/jetbrains/jewel/foundation/tree/TreeViewOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public static fun onScrollPageUpAndSelectItem (Lorg/jetbrains/jewel/foundation/tree/TreeViewOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public static fun onSelectAll (Lorg/jetbrains/jewel/foundation/tree/TreeViewOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public static fun onSelectFirstItem (Lorg/jetbrains/jewel/foundation/tree/TreeViewOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public static fun onSelectLastItem (Lorg/jetbrains/jewel/foundation/tree/TreeViewOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public static fun onSelectNextItem (Lorg/jetbrains/jewel/foundation/tree/TreeViewOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+	public static fun onSelectPreviousItem (Lorg/jetbrains/jewel/foundation/tree/TreeViewOnKeyEvent;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
+}
+
+public final class org/jetbrains/jewel/foundation/utils/LoggerKt {
+	public static final fun main ()V
+	public static synthetic fun main ([Ljava/lang/String;)V
+}
+
+public final class org/jetbrains/jewel/foundation/utils/ModifierExtensionsKt {
+	public static final fun thenIf (Landroidx/compose/ui/Modifier;ZLkotlin/jvm/functions/Function1;)Landroidx/compose/ui/Modifier;
+}
+
+public final class org/jetbrains/jewel/painter/DarkPainterHintsProvider : org/jetbrains/jewel/painter/PainterHintsProvider {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/painter/DarkPainterHintsProvider;
+	public fun hints (Ljava/lang/String;Landroidx/compose/runtime/Composer;I)Ljava/util/List;
+}
+
+public abstract interface class org/jetbrains/jewel/painter/PainterHint {
+	public static final field None Lorg/jetbrains/jewel/painter/PainterHint$None;
+}
+
+public final class org/jetbrains/jewel/painter/PainterHint$None : org/jetbrains/jewel/painter/PainterHint {
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class org/jetbrains/jewel/painter/PainterHintsProvider {
+	public abstract fun hints (Ljava/lang/String;Landroidx/compose/runtime/Composer;I)Ljava/util/List;
+}
+
+public final class org/jetbrains/jewel/painter/PainterHintsProviderKt {
+	public static final fun getLocalPainterHintsProvider ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class org/jetbrains/jewel/painter/PainterPathHint : org/jetbrains/jewel/painter/PainterHint {
+	public abstract fun patch (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public abstract class org/jetbrains/jewel/painter/PainterPrefixHint : org/jetbrains/jewel/painter/PainterPathHint {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun patch (Ljava/lang/String;)Ljava/lang/String;
+	public abstract fun prefix ()Ljava/lang/String;
+}
+
+public abstract interface class org/jetbrains/jewel/painter/PainterProvider {
+	public abstract fun getPainter ([Lorg/jetbrains/jewel/painter/PainterHint;Landroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public abstract interface class org/jetbrains/jewel/painter/PainterResourcePathHint : org/jetbrains/jewel/painter/PainterHint {
+	public abstract fun patch (Ljava/lang/String;Ljava/util/List;)Ljava/lang/String;
+}
+
+public abstract class org/jetbrains/jewel/painter/PainterSuffixHint : org/jetbrains/jewel/painter/PainterPathHint {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun patch (Ljava/lang/String;)Ljava/lang/String;
+	public abstract fun suffix ()Ljava/lang/String;
+}
+
+public abstract interface class org/jetbrains/jewel/painter/PainterSvgPatchHint : org/jetbrains/jewel/painter/PainterHint {
+	public abstract fun patch (Lorg/w3c/dom/Element;)V
+}
+
+public final class org/jetbrains/jewel/painter/ResourcePainterProvider : org/jetbrains/jewel/painter/PainterProvider {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;[Ljava/lang/ClassLoader;)V
+	public fun getPainter ([Lorg/jetbrains/jewel/painter/PainterHint;Landroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public final class org/jetbrains/jewel/painter/ResourcePainterProviderKt {
+	public static final fun rememberResourcePainterProvider (Ljava/lang/String;Ljava/lang/Class;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/painter/PainterProvider;
+}
+
+public final class org/jetbrains/jewel/painter/hints/DarkKt {
+	public static final fun Dark (Z)Lorg/jetbrains/jewel/painter/PainterHint;
+	public static synthetic fun Dark$default (ZILjava/lang/Object;)Lorg/jetbrains/jewel/painter/PainterHint;
+}
+
+public final class org/jetbrains/jewel/painter/hints/OverrideKt {
+	public static final fun Override (Ljava/util/Map;)Lorg/jetbrains/jewel/painter/PainterHint;
+}
+
+public final class org/jetbrains/jewel/painter/hints/PaletteKt {
+	public static final fun Palette (Ljava/util/Map;)Lorg/jetbrains/jewel/painter/PainterHint;
+}
+
+public final class org/jetbrains/jewel/painter/hints/SelectedKt {
+	public static final fun Selected (Lorg/jetbrains/jewel/SelectableComponentState;)Lorg/jetbrains/jewel/painter/PainterHint;
+	public static final fun Selected (Z)Lorg/jetbrains/jewel/painter/PainterHint;
+	public static synthetic fun Selected$default (ZILjava/lang/Object;)Lorg/jetbrains/jewel/painter/PainterHint;
+}
+
+public final class org/jetbrains/jewel/painter/hints/SizeKt {
+	public static final fun Size (II)Lorg/jetbrains/jewel/painter/PainterHint;
+	public static final fun Size (Ljava/lang/String;)Lorg/jetbrains/jewel/painter/PainterHint;
+}
+
+public final class org/jetbrains/jewel/painter/hints/StatefulKt {
+	public static final fun Stateful (Lorg/jetbrains/jewel/InteractiveComponentState;)Lorg/jetbrains/jewel/painter/PainterHint;
+}
+
+public final class org/jetbrains/jewel/painter/hints/StrokeKt {
+	public static final fun Stroke (Z)Lorg/jetbrains/jewel/painter/PainterHint;
+	public static synthetic fun Stroke$default (ZILjava/lang/Object;)Lorg/jetbrains/jewel/painter/PainterHint;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/ButtonColors {
+	public abstract fun backgroundFor-RO59lCw (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun borderFor-RO59lCw (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun contentFor-RO59lCw (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun getBackground ()Landroidx/compose/ui/graphics/Brush;
+	public abstract fun getBackgroundDisabled ()Landroidx/compose/ui/graphics/Brush;
+	public abstract fun getBackgroundFocused ()Landroidx/compose/ui/graphics/Brush;
+	public abstract fun getBackgroundHovered ()Landroidx/compose/ui/graphics/Brush;
+	public abstract fun getBackgroundPressed ()Landroidx/compose/ui/graphics/Brush;
+	public abstract fun getBorder ()Landroidx/compose/ui/graphics/Brush;
+	public abstract fun getBorderDisabled ()Landroidx/compose/ui/graphics/Brush;
+	public abstract fun getBorderFocused ()Landroidx/compose/ui/graphics/Brush;
+	public abstract fun getBorderHovered ()Landroidx/compose/ui/graphics/Brush;
+	public abstract fun getBorderPressed ()Landroidx/compose/ui/graphics/Brush;
+	public abstract fun getContent-0d7_KjU ()J
+	public abstract fun getContentDisabled-0d7_KjU ()J
+	public abstract fun getContentFocused-0d7_KjU ()J
+	public abstract fun getContentHovered-0d7_KjU ()J
+	public abstract fun getContentPressed-0d7_KjU ()J
+}
+
+public final class org/jetbrains/jewel/styling/ButtonColors$DefaultImpls {
+	public static fun backgroundFor-RO59lCw (Lorg/jetbrains/jewel/styling/ButtonColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun borderFor-RO59lCw (Lorg/jetbrains/jewel/styling/ButtonColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun contentFor-RO59lCw (Lorg/jetbrains/jewel/styling/ButtonColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/ButtonMetrics {
+	public abstract fun getBorderWidth-D9Ej5fM ()F
+	public abstract fun getCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public abstract fun getMinSize-MYxV2XQ ()J
+	public abstract fun getPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/ButtonStyle {
+	public abstract fun getColors ()Lorg/jetbrains/jewel/styling/ButtonColors;
+	public abstract fun getMetrics ()Lorg/jetbrains/jewel/styling/ButtonMetrics;
+}
+
+public final class org/jetbrains/jewel/styling/ButtonStylingKt {
+	public static final fun getLocalDefaultButtonStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+	public static final fun getLocalOutlinedButtonStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/CheckboxColors {
+	public abstract fun backgroundFor-An7rHrs (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun contentFor-An7rHrs (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun getCheckboxBackground-0d7_KjU ()J
+	public abstract fun getCheckboxBackgroundDisabled-0d7_KjU ()J
+	public abstract fun getCheckboxBackgroundSelected-0d7_KjU ()J
+	public abstract fun getContent-0d7_KjU ()J
+	public abstract fun getContentDisabled-0d7_KjU ()J
+	public abstract fun getContentSelected-0d7_KjU ()J
+}
+
+public final class org/jetbrains/jewel/styling/CheckboxColors$DefaultImpls {
+	public static fun backgroundFor-An7rHrs (Lorg/jetbrains/jewel/styling/CheckboxColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun contentFor-An7rHrs (Lorg/jetbrains/jewel/styling/CheckboxColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/CheckboxIcons {
+	public abstract fun getCheckbox ()Lorg/jetbrains/jewel/painter/PainterProvider;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/CheckboxMetrics {
+	public abstract fun getCheckboxCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public abstract fun getCheckboxSize-MYxV2XQ ()J
+	public abstract fun getIconContentGap-D9Ej5fM ()F
+	public abstract fun getOutlineOffset-RKDOV3M ()J
+	public abstract fun getOutlineSize-MYxV2XQ ()J
+}
+
+public abstract interface class org/jetbrains/jewel/styling/CheckboxStyle {
+	public abstract fun getColors ()Lorg/jetbrains/jewel/styling/CheckboxColors;
+	public abstract fun getIcons ()Lorg/jetbrains/jewel/styling/CheckboxIcons;
+	public abstract fun getMetrics ()Lorg/jetbrains/jewel/styling/CheckboxMetrics;
+}
+
+public final class org/jetbrains/jewel/styling/CheckboxStylingKt {
+	public static final fun getLocalCheckboxStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/ChipColors {
+	public abstract fun backgroundFor-z6rh5VY (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun borderFor-z6rh5VY (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun contentFor-z6rh5VY (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun getBackground ()Landroidx/compose/ui/graphics/Brush;
+	public abstract fun getBackgroundDisabled ()Landroidx/compose/ui/graphics/Brush;
+	public abstract fun getBackgroundFocused ()Landroidx/compose/ui/graphics/Brush;
+	public abstract fun getBackgroundHovered ()Landroidx/compose/ui/graphics/Brush;
+	public abstract fun getBackgroundPressed ()Landroidx/compose/ui/graphics/Brush;
+	public abstract fun getBackgroundSelected ()Landroidx/compose/ui/graphics/Brush;
+	public abstract fun getBackgroundSelectedDisabled ()Landroidx/compose/ui/graphics/Brush;
+	public abstract fun getBackgroundSelectedFocused ()Landroidx/compose/ui/graphics/Brush;
+	public abstract fun getBackgroundSelectedHovered ()Landroidx/compose/ui/graphics/Brush;
+	public abstract fun getBackgroundSelectedPressed ()Landroidx/compose/ui/graphics/Brush;
+	public abstract fun getBorder-0d7_KjU ()J
+	public abstract fun getBorderDisabled-0d7_KjU ()J
+	public abstract fun getBorderFocused-0d7_KjU ()J
+	public abstract fun getBorderHovered-0d7_KjU ()J
+	public abstract fun getBorderPressed-0d7_KjU ()J
+	public abstract fun getBorderSelected-0d7_KjU ()J
+	public abstract fun getBorderSelectedDisabled-0d7_KjU ()J
+	public abstract fun getBorderSelectedFocused-0d7_KjU ()J
+	public abstract fun getBorderSelectedHovered-0d7_KjU ()J
+	public abstract fun getBorderSelectedPressed-0d7_KjU ()J
+	public abstract fun getContent-0d7_KjU ()J
+	public abstract fun getContentDisabled-0d7_KjU ()J
+	public abstract fun getContentFocused-0d7_KjU ()J
+	public abstract fun getContentHovered-0d7_KjU ()J
+	public abstract fun getContentPressed-0d7_KjU ()J
+	public abstract fun getContentSelected-0d7_KjU ()J
+	public abstract fun getContentSelectedDisabled-0d7_KjU ()J
+	public abstract fun getContentSelectedFocused-0d7_KjU ()J
+	public abstract fun getContentSelectedHovered-0d7_KjU ()J
+	public abstract fun getContentSelectedPressed-0d7_KjU ()J
+}
+
+public final class org/jetbrains/jewel/styling/ChipColors$DefaultImpls {
+	public static fun backgroundFor-z6rh5VY (Lorg/jetbrains/jewel/styling/ChipColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun borderFor-z6rh5VY (Lorg/jetbrains/jewel/styling/ChipColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun contentFor-z6rh5VY (Lorg/jetbrains/jewel/styling/ChipColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/ChipMetrics {
+	public abstract fun getBorderWidth-D9Ej5fM ()F
+	public abstract fun getBorderWidthSelected-D9Ej5fM ()F
+	public abstract fun getCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public abstract fun getPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/ChipStyle {
+	public abstract fun getColors ()Lorg/jetbrains/jewel/styling/ChipColors;
+	public abstract fun getMetrics ()Lorg/jetbrains/jewel/styling/ChipMetrics;
+}
+
+public final class org/jetbrains/jewel/styling/ChipStylingKt {
+	public static final fun getLocalChipStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/CircularProgressStyle {
+	public abstract fun getColor-0d7_KjU ()J
+	public abstract fun getFrameTime-UwyO8pc ()J
+}
+
+public final class org/jetbrains/jewel/styling/CircularProgressStyleKt {
+	public static final fun getLocalCircularProgressStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/DividerMetrics {
+	public abstract fun getStartIndent-D9Ej5fM ()F
+	public abstract fun getThickness-D9Ej5fM ()F
+}
+
+public abstract interface class org/jetbrains/jewel/styling/DividerStyle {
+	public abstract fun getColor-0d7_KjU ()J
+	public abstract fun getMetrics ()Lorg/jetbrains/jewel/styling/DividerMetrics;
+}
+
+public final class org/jetbrains/jewel/styling/DividerStylingKt {
+	public static final fun getLocalDividerStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/DropdownColors {
+	public abstract fun backgroundFor-7I1Rs2w (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun borderFor-7I1Rs2w (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun contentFor-7I1Rs2w (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun getBackground-0d7_KjU ()J
+	public abstract fun getBackgroundDisabled-0d7_KjU ()J
+	public abstract fun getBackgroundFocused-0d7_KjU ()J
+	public abstract fun getBackgroundHovered-0d7_KjU ()J
+	public abstract fun getBackgroundPressed-0d7_KjU ()J
+	public abstract fun getBorder-0d7_KjU ()J
+	public abstract fun getBorderDisabled-0d7_KjU ()J
+	public abstract fun getBorderFocused-0d7_KjU ()J
+	public abstract fun getBorderHovered-0d7_KjU ()J
+	public abstract fun getBorderPressed-0d7_KjU ()J
+	public abstract fun getContent-0d7_KjU ()J
+	public abstract fun getContentDisabled-0d7_KjU ()J
+	public abstract fun getContentFocused-0d7_KjU ()J
+	public abstract fun getContentHovered-0d7_KjU ()J
+	public abstract fun getContentPressed-0d7_KjU ()J
+	public abstract fun getIconTint-0d7_KjU ()J
+	public abstract fun getIconTintDisabled-0d7_KjU ()J
+	public abstract fun getIconTintFocused-0d7_KjU ()J
+	public abstract fun getIconTintHovered-0d7_KjU ()J
+	public abstract fun getIconTintPressed-0d7_KjU ()J
+	public abstract fun iconTintFor-7I1Rs2w (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public final class org/jetbrains/jewel/styling/DropdownColors$DefaultImpls {
+	public static fun backgroundFor-7I1Rs2w (Lorg/jetbrains/jewel/styling/DropdownColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun borderFor-7I1Rs2w (Lorg/jetbrains/jewel/styling/DropdownColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun contentFor-7I1Rs2w (Lorg/jetbrains/jewel/styling/DropdownColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun iconTintFor-7I1Rs2w (Lorg/jetbrains/jewel/styling/DropdownColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/DropdownIcons {
+	public abstract fun getChevronDown ()Lorg/jetbrains/jewel/painter/PainterProvider;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/DropdownMetrics {
+	public abstract fun getArrowMinSize-MYxV2XQ ()J
+	public abstract fun getBorderWidth-D9Ej5fM ()F
+	public abstract fun getContentPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public abstract fun getCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public abstract fun getMinSize-MYxV2XQ ()J
+}
+
+public abstract interface class org/jetbrains/jewel/styling/DropdownStyle {
+	public abstract fun getColors ()Lorg/jetbrains/jewel/styling/DropdownColors;
+	public abstract fun getIcons ()Lorg/jetbrains/jewel/styling/DropdownIcons;
+	public abstract fun getMenuStyle ()Lorg/jetbrains/jewel/styling/MenuStyle;
+	public abstract fun getMetrics ()Lorg/jetbrains/jewel/styling/DropdownMetrics;
+	public abstract fun getTextStyle ()Landroidx/compose/ui/text/TextStyle;
+}
+
+public final class org/jetbrains/jewel/styling/DropdownStylingKt {
+	public static final fun getLocalDropdownStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/GroupHeaderColors {
+	public abstract fun getDivider-0d7_KjU ()J
+}
+
+public abstract interface class org/jetbrains/jewel/styling/GroupHeaderMetrics {
+	public abstract fun getDividerThickness-D9Ej5fM ()F
+	public abstract fun getIndent-D9Ej5fM ()F
+}
+
+public abstract interface class org/jetbrains/jewel/styling/GroupHeaderStyle {
+	public abstract fun getColors ()Lorg/jetbrains/jewel/styling/GroupHeaderColors;
+	public abstract fun getMetrics ()Lorg/jetbrains/jewel/styling/GroupHeaderMetrics;
+}
+
+public final class org/jetbrains/jewel/styling/GroupHeaderStylingKt {
+	public static final fun getLocalGroupHeaderStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/HorizontalProgressBarColors {
+	public abstract fun getIndeterminateBase-0d7_KjU ()J
+	public abstract fun getIndeterminateHighlight-0d7_KjU ()J
+	public abstract fun getProgress-0d7_KjU ()J
+	public abstract fun getTrack-0d7_KjU ()J
+}
+
+public abstract interface class org/jetbrains/jewel/styling/HorizontalProgressBarMetrics {
+	public abstract fun getCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public abstract fun getIndeterminateHighlightWidth-D9Ej5fM ()F
+	public abstract fun getMinHeight-D9Ej5fM ()F
+}
+
+public abstract interface class org/jetbrains/jewel/styling/HorizontalProgressBarStyle {
+	public abstract fun getColors ()Lorg/jetbrains/jewel/styling/HorizontalProgressBarColors;
+	public abstract fun getIndeterminateCycleDuration-UwyO8pc ()J
+	public abstract fun getMetrics ()Lorg/jetbrains/jewel/styling/HorizontalProgressBarMetrics;
+}
+
+public final class org/jetbrains/jewel/styling/HorizontalProgressBarStylingKt {
+	public static final fun getLocalHorizontalProgressBarStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/IconButtonColors {
+	public abstract fun backgroundFor-RO59lCw (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun borderFor-RO59lCw (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun getBackground-0d7_KjU ()J
+	public abstract fun getBackgroundDisabled-0d7_KjU ()J
+	public abstract fun getBackgroundFocused-0d7_KjU ()J
+	public abstract fun getBackgroundHovered-0d7_KjU ()J
+	public abstract fun getBackgroundPressed-0d7_KjU ()J
+	public abstract fun getBorder-0d7_KjU ()J
+	public abstract fun getBorderDisabled-0d7_KjU ()J
+	public abstract fun getBorderFocused-0d7_KjU ()J
+	public abstract fun getBorderHovered-0d7_KjU ()J
+	public abstract fun getBorderPressed-0d7_KjU ()J
+}
+
+public final class org/jetbrains/jewel/styling/IconButtonColors$DefaultImpls {
+	public static fun backgroundFor-RO59lCw (Lorg/jetbrains/jewel/styling/IconButtonColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun borderFor-RO59lCw (Lorg/jetbrains/jewel/styling/IconButtonColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/IconButtonMetrics {
+	public abstract fun getBorderWidth-D9Ej5fM ()F
+	public abstract fun getCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public abstract fun getMinSize-MYxV2XQ ()J
+	public abstract fun getPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+}
+
+public final class org/jetbrains/jewel/styling/IconButtonMetricsKt {
+	public static final fun getLocalIconButtonStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/IconButtonStyle {
+	public abstract fun getColors ()Lorg/jetbrains/jewel/styling/IconButtonColors;
+	public abstract fun getMetrics ()Lorg/jetbrains/jewel/styling/IconButtonMetrics;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/InputFieldColors {
+	public abstract fun backgroundFor-37MyHpk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun borderFor-37MyHpk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun caretFor-37MyHpk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun contentFor-37MyHpk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun getBackground-0d7_KjU ()J
+	public abstract fun getBackgroundDisabled-0d7_KjU ()J
+	public abstract fun getBackgroundFocused-0d7_KjU ()J
+	public abstract fun getBackgroundHovered-0d7_KjU ()J
+	public abstract fun getBackgroundPressed-0d7_KjU ()J
+	public abstract fun getBorder-0d7_KjU ()J
+	public abstract fun getBorderDisabled-0d7_KjU ()J
+	public abstract fun getBorderFocused-0d7_KjU ()J
+	public abstract fun getBorderHovered-0d7_KjU ()J
+	public abstract fun getBorderPressed-0d7_KjU ()J
+	public abstract fun getCaret-0d7_KjU ()J
+	public abstract fun getCaretDisabled-0d7_KjU ()J
+	public abstract fun getCaretFocused-0d7_KjU ()J
+	public abstract fun getCaretHovered-0d7_KjU ()J
+	public abstract fun getCaretPressed-0d7_KjU ()J
+	public abstract fun getContent-0d7_KjU ()J
+	public abstract fun getContentDisabled-0d7_KjU ()J
+	public abstract fun getContentFocused-0d7_KjU ()J
+	public abstract fun getContentHovered-0d7_KjU ()J
+	public abstract fun getContentPressed-0d7_KjU ()J
+}
+
+public final class org/jetbrains/jewel/styling/InputFieldColors$DefaultImpls {
+	public static fun backgroundFor-37MyHpk (Lorg/jetbrains/jewel/styling/InputFieldColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun borderFor-37MyHpk (Lorg/jetbrains/jewel/styling/InputFieldColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun caretFor-37MyHpk (Lorg/jetbrains/jewel/styling/InputFieldColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun contentFor-37MyHpk (Lorg/jetbrains/jewel/styling/InputFieldColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/InputFieldMetrics {
+	public abstract fun getBorderWidth-D9Ej5fM ()F
+	public abstract fun getContentPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public abstract fun getCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public abstract fun getMinSize-MYxV2XQ ()J
+}
+
+public abstract interface class org/jetbrains/jewel/styling/InputFieldStyle {
+	public abstract fun getColors ()Lorg/jetbrains/jewel/styling/InputFieldColors;
+	public abstract fun getMetrics ()Lorg/jetbrains/jewel/styling/InputFieldMetrics;
+	public abstract fun getTextStyle ()Landroidx/compose/ui/text/TextStyle;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/LabelledTextFieldColors : org/jetbrains/jewel/styling/TextFieldColors {
+	public abstract fun getHint-0d7_KjU ()J
+	public abstract fun getLabel-0d7_KjU ()J
+}
+
+public final class org/jetbrains/jewel/styling/LabelledTextFieldColors$DefaultImpls {
+	public static fun backgroundFor-37MyHpk (Lorg/jetbrains/jewel/styling/LabelledTextFieldColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun borderFor-37MyHpk (Lorg/jetbrains/jewel/styling/LabelledTextFieldColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun caretFor-37MyHpk (Lorg/jetbrains/jewel/styling/LabelledTextFieldColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun contentFor-37MyHpk (Lorg/jetbrains/jewel/styling/LabelledTextFieldColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/LabelledTextFieldMetrics : org/jetbrains/jewel/styling/InputFieldMetrics {
+	public abstract fun getHintSpacing-D9Ej5fM ()F
+	public abstract fun getLabelSpacing-D9Ej5fM ()F
+}
+
+public abstract interface class org/jetbrains/jewel/styling/LabelledTextFieldStyle : org/jetbrains/jewel/styling/TextFieldStyle {
+	public abstract fun getColors ()Lorg/jetbrains/jewel/styling/LabelledTextFieldColors;
+	public abstract fun getMetrics ()Lorg/jetbrains/jewel/styling/LabelledTextFieldMetrics;
+	public abstract fun getTextStyles ()Lorg/jetbrains/jewel/styling/LabelledTextFieldTextStyles;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/LabelledTextFieldTextStyles {
+	public abstract fun getHint ()Landroidx/compose/ui/text/TextStyle;
+	public abstract fun getLabel ()Landroidx/compose/ui/text/TextStyle;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/LazyTreeColors {
+	public abstract fun contentFor-iZdlh1w (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun getContent-0d7_KjU ()J
+	public abstract fun getContentFocused-0d7_KjU ()J
+	public abstract fun getContentSelected-0d7_KjU ()J
+	public abstract fun getContentSelectedFocused-0d7_KjU ()J
+	public abstract fun getElementBackgroundFocused-0d7_KjU ()J
+	public abstract fun getElementBackgroundSelected-0d7_KjU ()J
+	public abstract fun getElementBackgroundSelectedFocused-0d7_KjU ()J
+}
+
+public final class org/jetbrains/jewel/styling/LazyTreeColors$DefaultImpls {
+	public static fun contentFor-iZdlh1w (Lorg/jetbrains/jewel/styling/LazyTreeColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/LazyTreeIcons {
+	public abstract fun chevron (ZZLandroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/painter/PainterProvider;
+	public abstract fun getChevronCollapsed ()Lorg/jetbrains/jewel/painter/PainterProvider;
+	public abstract fun getChevronExpanded ()Lorg/jetbrains/jewel/painter/PainterProvider;
+	public abstract fun getChevronSelectedCollapsed ()Lorg/jetbrains/jewel/painter/PainterProvider;
+	public abstract fun getChevronSelectedExpanded ()Lorg/jetbrains/jewel/painter/PainterProvider;
+}
+
+public final class org/jetbrains/jewel/styling/LazyTreeIcons$DefaultImpls {
+	public static fun chevron (Lorg/jetbrains/jewel/styling/LazyTreeIcons;ZZLandroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/painter/PainterProvider;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/LazyTreeMetrics {
+	public abstract fun getChevronContentGap-D9Ej5fM ()F
+	public abstract fun getElementBackgroundCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public abstract fun getElementContentPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public abstract fun getElementMinHeight-D9Ej5fM ()F
+	public abstract fun getElementPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public abstract fun getIndentSize-D9Ej5fM ()F
+}
+
+public abstract interface class org/jetbrains/jewel/styling/LazyTreeStyle {
+	public abstract fun getColors ()Lorg/jetbrains/jewel/styling/LazyTreeColors;
+	public abstract fun getIcons ()Lorg/jetbrains/jewel/styling/LazyTreeIcons;
+	public abstract fun getMetrics ()Lorg/jetbrains/jewel/styling/LazyTreeMetrics;
+}
+
+public final class org/jetbrains/jewel/styling/LazyTreeStylingKt {
+	public static final fun getLocalLazyTreeStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/LinkColors {
+	public abstract fun contentFor-4qImzQQ (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun getContent-0d7_KjU ()J
+	public abstract fun getContentDisabled-0d7_KjU ()J
+	public abstract fun getContentFocused-0d7_KjU ()J
+	public abstract fun getContentHovered-0d7_KjU ()J
+	public abstract fun getContentPressed-0d7_KjU ()J
+	public abstract fun getContentVisited-0d7_KjU ()J
+}
+
+public final class org/jetbrains/jewel/styling/LinkColors$DefaultImpls {
+	public static fun contentFor-4qImzQQ (Lorg/jetbrains/jewel/styling/LinkColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/LinkIcons {
+	public abstract fun getDropdownChevron ()Lorg/jetbrains/jewel/painter/PainterProvider;
+	public abstract fun getExternalLink ()Lorg/jetbrains/jewel/painter/PainterProvider;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/LinkMetrics {
+	public abstract fun getFocusHaloCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public abstract fun getIconSize-MYxV2XQ ()J
+	public abstract fun getTextIconGap-D9Ej5fM ()F
+}
+
+public abstract interface class org/jetbrains/jewel/styling/LinkStyle {
+	public abstract fun getColors ()Lorg/jetbrains/jewel/styling/LinkColors;
+	public abstract fun getIcons ()Lorg/jetbrains/jewel/styling/LinkIcons;
+	public abstract fun getMetrics ()Lorg/jetbrains/jewel/styling/LinkMetrics;
+	public abstract fun getTextStyles ()Lorg/jetbrains/jewel/styling/LinkTextStyles;
+}
+
+public final class org/jetbrains/jewel/styling/LinkStylingKt {
+	public static final fun getLocalLinkStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/LinkTextStyles {
+	public abstract fun getDisabled ()Landroidx/compose/ui/text/TextStyle;
+	public abstract fun getFocused ()Landroidx/compose/ui/text/TextStyle;
+	public abstract fun getHovered ()Landroidx/compose/ui/text/TextStyle;
+	public abstract fun getNormal ()Landroidx/compose/ui/text/TextStyle;
+	public abstract fun getPressed ()Landroidx/compose/ui/text/TextStyle;
+	public abstract fun getVisited ()Landroidx/compose/ui/text/TextStyle;
+	public abstract fun styleFor-4qImzQQ (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public final class org/jetbrains/jewel/styling/LinkTextStyles$DefaultImpls {
+	public static fun styleFor-4qImzQQ (Lorg/jetbrains/jewel/styling/LinkTextStyles;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/MenuColors {
+	public abstract fun getBackground-0d7_KjU ()J
+	public abstract fun getBorder-0d7_KjU ()J
+	public abstract fun getItemColors ()Lorg/jetbrains/jewel/styling/MenuItemColors;
+	public abstract fun getShadow-0d7_KjU ()J
+}
+
+public abstract interface class org/jetbrains/jewel/styling/MenuIcons {
+	public abstract fun getSubmenuChevron ()Lorg/jetbrains/jewel/painter/PainterProvider;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/MenuItemColors {
+	public abstract fun backgroundFor-BYhRtsk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun contentFor-BYhRtsk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun getBackground-0d7_KjU ()J
+	public abstract fun getBackgroundDisabled-0d7_KjU ()J
+	public abstract fun getBackgroundFocused-0d7_KjU ()J
+	public abstract fun getBackgroundHovered-0d7_KjU ()J
+	public abstract fun getBackgroundPressed-0d7_KjU ()J
+	public abstract fun getContent-0d7_KjU ()J
+	public abstract fun getContentDisabled-0d7_KjU ()J
+	public abstract fun getContentFocused-0d7_KjU ()J
+	public abstract fun getContentHovered-0d7_KjU ()J
+	public abstract fun getContentPressed-0d7_KjU ()J
+	public abstract fun getIconTint-0d7_KjU ()J
+	public abstract fun getIconTintDisabled-0d7_KjU ()J
+	public abstract fun getIconTintFocused-0d7_KjU ()J
+	public abstract fun getIconTintHovered-0d7_KjU ()J
+	public abstract fun getIconTintPressed-0d7_KjU ()J
+	public abstract fun getSeparator-0d7_KjU ()J
+	public abstract fun iconTintFor-BYhRtsk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public final class org/jetbrains/jewel/styling/MenuItemColors$DefaultImpls {
+	public static fun backgroundFor-BYhRtsk (Lorg/jetbrains/jewel/styling/MenuItemColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun contentFor-BYhRtsk (Lorg/jetbrains/jewel/styling/MenuItemColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun iconTintFor-BYhRtsk (Lorg/jetbrains/jewel/styling/MenuItemColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/MenuItemMetrics {
+	public abstract fun getContentPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public abstract fun getOuterPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public abstract fun getSelectionCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public abstract fun getSeparatorPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public abstract fun getSeparatorThickness-D9Ej5fM ()F
+}
+
+public abstract interface class org/jetbrains/jewel/styling/MenuMetrics {
+	public abstract fun getBorderWidth-D9Ej5fM ()F
+	public abstract fun getContentPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public abstract fun getCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public abstract fun getItemMetrics ()Lorg/jetbrains/jewel/styling/MenuItemMetrics;
+	public abstract fun getMenuMargin ()Landroidx/compose/foundation/layout/PaddingValues;
+	public abstract fun getOffset-RKDOV3M ()J
+	public abstract fun getShadowSize-D9Ej5fM ()F
+	public abstract fun getSubmenuMetrics ()Lorg/jetbrains/jewel/styling/SubmenuMetrics;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/MenuStyle {
+	public abstract fun getColors ()Lorg/jetbrains/jewel/styling/MenuColors;
+	public abstract fun getIcons ()Lorg/jetbrains/jewel/styling/MenuIcons;
+	public abstract fun getMetrics ()Lorg/jetbrains/jewel/styling/MenuMetrics;
+}
+
+public final class org/jetbrains/jewel/styling/MenuStylingKt {
+	public static final fun getLocalMenuStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/RadioButtonColors {
+	public abstract fun contentFor-dQFH0ko (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun getContent-0d7_KjU ()J
+	public abstract fun getContentDisabled-0d7_KjU ()J
+	public abstract fun getContentHovered-0d7_KjU ()J
+	public abstract fun getContentSelected-0d7_KjU ()J
+	public abstract fun getContentSelectedDisabled-0d7_KjU ()J
+	public abstract fun getContentSelectedHovered-0d7_KjU ()J
+}
+
+public final class org/jetbrains/jewel/styling/RadioButtonColors$DefaultImpls {
+	public static fun contentFor-dQFH0ko (Lorg/jetbrains/jewel/styling/RadioButtonColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/RadioButtonIcons {
+	public abstract fun getRadioButton ()Lorg/jetbrains/jewel/painter/PainterProvider;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/RadioButtonMetrics {
+	public abstract fun getIconContentGap-D9Ej5fM ()F
+	public abstract fun getRadioButtonSize-MYxV2XQ ()J
+}
+
+public abstract interface class org/jetbrains/jewel/styling/RadioButtonStyle {
+	public abstract fun getColors ()Lorg/jetbrains/jewel/styling/RadioButtonColors;
+	public abstract fun getIcons ()Lorg/jetbrains/jewel/styling/RadioButtonIcons;
+	public abstract fun getMetrics ()Lorg/jetbrains/jewel/styling/RadioButtonMetrics;
+}
+
+public final class org/jetbrains/jewel/styling/RadioButtonStylingKt {
+	public static final fun getLocalRadioButtonStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/ScrollbarColors {
+	public abstract fun getThumbBackground-0d7_KjU ()J
+	public abstract fun getThumbBackgroundHovered-0d7_KjU ()J
+}
+
+public abstract interface class org/jetbrains/jewel/styling/ScrollbarMetrics {
+	public abstract fun getMinThumbLength-D9Ej5fM ()F
+	public abstract fun getThumbCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public abstract fun getThumbThickness-D9Ej5fM ()F
+	public abstract fun getTrackPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/ScrollbarStyle {
+	public abstract fun getColors ()Lorg/jetbrains/jewel/styling/ScrollbarColors;
+	public abstract fun getHoverDuration-UwyO8pc ()J
+	public abstract fun getMetrics ()Lorg/jetbrains/jewel/styling/ScrollbarMetrics;
+}
+
+public final class org/jetbrains/jewel/styling/ScrollbarStylingKt {
+	public static final fun getLocalScrollbarStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/SubmenuMetrics {
+	public abstract fun getOffset-RKDOV3M ()J
+}
+
+public abstract interface class org/jetbrains/jewel/styling/TabColors {
+	public abstract fun backgroundFor-WCiaD9s (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun contentFor-WCiaD9s (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun getBackground-0d7_KjU ()J
+	public abstract fun getBackgroundDisabled-0d7_KjU ()J
+	public abstract fun getBackgroundFocused-0d7_KjU ()J
+	public abstract fun getBackgroundHovered-0d7_KjU ()J
+	public abstract fun getBackgroundPressed-0d7_KjU ()J
+	public abstract fun getBackgroundSelected-0d7_KjU ()J
+	public abstract fun getContent-0d7_KjU ()J
+	public abstract fun getContentDisabled-0d7_KjU ()J
+	public abstract fun getContentFocused-0d7_KjU ()J
+	public abstract fun getContentHovered-0d7_KjU ()J
+	public abstract fun getContentPressed-0d7_KjU ()J
+	public abstract fun getContentSelected-0d7_KjU ()J
+	public abstract fun getUnderline-0d7_KjU ()J
+	public abstract fun getUnderlineDisabled-0d7_KjU ()J
+	public abstract fun getUnderlineFocused-0d7_KjU ()J
+	public abstract fun getUnderlineHovered-0d7_KjU ()J
+	public abstract fun getUnderlinePressed-0d7_KjU ()J
+	public abstract fun getUnderlineSelected-0d7_KjU ()J
+	public abstract fun underlineFor-WCiaD9s (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public final class org/jetbrains/jewel/styling/TabColors$DefaultImpls {
+	public static fun backgroundFor-WCiaD9s (Lorg/jetbrains/jewel/styling/TabColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun contentFor-WCiaD9s (Lorg/jetbrains/jewel/styling/TabColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun underlineFor-WCiaD9s (Lorg/jetbrains/jewel/styling/TabColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/TabContentAlpha {
+	public abstract fun getIconDisabled ()F
+	public abstract fun getIconFocused ()F
+	public abstract fun getIconHovered ()F
+	public abstract fun getIconNormal ()F
+	public abstract fun getIconPressed ()F
+	public abstract fun getIconSelected ()F
+	public abstract fun getLabelDisabled ()F
+	public abstract fun getLabelFocused ()F
+	public abstract fun getLabelHovered ()F
+	public abstract fun getLabelNormal ()F
+	public abstract fun getLabelPressed ()F
+	public abstract fun getLabelSelected ()F
+	public abstract fun iconFor-WCiaD9s (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun labelFor-WCiaD9s (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public final class org/jetbrains/jewel/styling/TabContentAlpha$DefaultImpls {
+	public static fun iconFor-WCiaD9s (Lorg/jetbrains/jewel/styling/TabContentAlpha;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun labelFor-WCiaD9s (Lorg/jetbrains/jewel/styling/TabContentAlpha;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/TabIcons {
+	public abstract fun getClose ()Lorg/jetbrains/jewel/painter/PainterProvider;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/TabMetrics {
+	public abstract fun getCloseContentGap-D9Ej5fM ()F
+	public abstract fun getTabHeight-D9Ej5fM ()F
+	public abstract fun getTabPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public abstract fun getUnderlineThickness-D9Ej5fM ()F
+}
+
+public abstract interface class org/jetbrains/jewel/styling/TabStyle {
+	public abstract fun getColors ()Lorg/jetbrains/jewel/styling/TabColors;
+	public abstract fun getContentAlpha ()Lorg/jetbrains/jewel/styling/TabContentAlpha;
+	public abstract fun getIcons ()Lorg/jetbrains/jewel/styling/TabIcons;
+	public abstract fun getMetrics ()Lorg/jetbrains/jewel/styling/TabMetrics;
+}
+
+public final class org/jetbrains/jewel/styling/TabStylingKt {
+	public static final fun getLocalDefaultTabStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+	public static final fun getLocalEditorTabStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/TextAreaColors : org/jetbrains/jewel/styling/InputFieldColors {
+	public abstract fun getPlaceholder-0d7_KjU ()J
+}
+
+public final class org/jetbrains/jewel/styling/TextAreaColors$DefaultImpls {
+	public static fun backgroundFor-37MyHpk (Lorg/jetbrains/jewel/styling/TextAreaColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun borderFor-37MyHpk (Lorg/jetbrains/jewel/styling/TextAreaColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun caretFor-37MyHpk (Lorg/jetbrains/jewel/styling/TextAreaColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun contentFor-37MyHpk (Lorg/jetbrains/jewel/styling/TextAreaColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/TextAreaStyle : org/jetbrains/jewel/styling/InputFieldStyle {
+	public abstract fun getColors ()Lorg/jetbrains/jewel/styling/TextAreaColors;
+	public abstract fun getMetrics ()Lorg/jetbrains/jewel/styling/InputFieldMetrics;
+}
+
+public final class org/jetbrains/jewel/styling/TextAreaStylingKt {
+	public static final fun getLocalTextAreaStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/TextFieldColors : org/jetbrains/jewel/styling/InputFieldColors {
+	public abstract fun getPlaceholder-0d7_KjU ()J
+}
+
+public final class org/jetbrains/jewel/styling/TextFieldColors$DefaultImpls {
+	public static fun backgroundFor-37MyHpk (Lorg/jetbrains/jewel/styling/TextFieldColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun borderFor-37MyHpk (Lorg/jetbrains/jewel/styling/TextFieldColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun caretFor-37MyHpk (Lorg/jetbrains/jewel/styling/TextFieldColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public static fun contentFor-37MyHpk (Lorg/jetbrains/jewel/styling/TextFieldColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/TextFieldStyle : org/jetbrains/jewel/styling/InputFieldStyle {
+	public abstract fun getColors ()Lorg/jetbrains/jewel/styling/TextFieldColors;
+}
+
+public final class org/jetbrains/jewel/styling/TextFieldStylingKt {
+	public static final fun getLocalLabelledTextFieldStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+	public static final fun getLocalTextFieldStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class org/jetbrains/jewel/styling/TooltipColors {
+	public abstract fun getBackground-0d7_KjU ()J
+	public abstract fun getBorder-0d7_KjU ()J
+	public abstract fun getContent-0d7_KjU ()J
+	public abstract fun getShadow-0d7_KjU ()J
+}
+
+public abstract interface class org/jetbrains/jewel/styling/TooltipMetrics {
+	public abstract fun getBorderWidth-D9Ej5fM ()F
+	public abstract fun getContentPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public abstract fun getCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public abstract fun getShadowSize-D9Ej5fM ()F
+	public abstract fun getShowDelay-UwyO8pc ()J
+	public abstract fun getTooltipAlignment ()Landroidx/compose/ui/Alignment$Horizontal;
+	public abstract fun getTooltipOffset-RKDOV3M ()J
+}
+
+public abstract interface class org/jetbrains/jewel/styling/TooltipStyle {
+	public abstract fun getColors ()Lorg/jetbrains/jewel/styling/TooltipColors;
+	public abstract fun getMetrics ()Lorg/jetbrains/jewel/styling/TooltipMetrics;
+}
+
+public final class org/jetbrains/jewel/styling/TooltipStylingKt {
+	public static final fun getLocalTooltipStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public final class org/jetbrains/jewel/util/ColorExtensionsKt {
+	public static final fun fromRGBAHexString (Landroidx/compose/ui/graphics/Color$Companion;Ljava/lang/String;)Landroidx/compose/ui/graphics/Color;
+	public static final fun isDark-8_81llA (J)Z
+	public static final fun toRgbaHexString-8_81llA (J)Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/util/DebugKt {
+}
+
+public final class org/jetbrains/jewel/util/ModifierExtensionsKt {
+	public static final fun appendIf (Landroidx/compose/ui/Modifier;ZLkotlin/jvm/functions/Function1;)Landroidx/compose/ui/Modifier;
+}
+
+public final class org/jetbrains/jewel/util/SpinnerProgressIconGenerator {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/util/SpinnerProgressIconGenerator;
+}
+
+public final class org/jetbrains/jewel/util/SpinnerProgressIconGenerator$Big {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/util/SpinnerProgressIconGenerator$Big;
+	public final fun generateRawSvg (Ljava/lang/String;)Ljava/util/List;
+}
+
+public final class org/jetbrains/jewel/util/SpinnerProgressIconGenerator$Small {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/util/SpinnerProgressIconGenerator$Small;
+	public final fun generateRawSvg (Ljava/lang/String;)Ljava/util/List;
+}
+

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -233,6 +233,9 @@ public final class org/jetbrains/jewel/FocusableComponentState$DefaultImpls {
 	public static fun chooseValue (Lorg/jetbrains/jewel/FocusableComponentState;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;Landroidx/compose/runtime/Composer;I)Ljava/lang/Object;
 }
 
+public abstract interface annotation class org/jetbrains/jewel/GenerateDataFunctions : java/lang/annotation/Annotation {
+}
+
 public abstract interface class org/jetbrains/jewel/GlobalColors {
 	public abstract fun getBorders ()Lorg/jetbrains/jewel/BorderColors;
 	public abstract fun getInfoContent-0d7_KjU ()J

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1470,17 +1470,31 @@ public final class org/jetbrains/jewel/foundation/utils/ModifierExtensionsKt {
 	public static final fun thenIf (Landroidx/compose/ui/Modifier;ZLkotlin/jvm/functions/Function1;)Landroidx/compose/ui/Modifier;
 }
 
-public final class org/jetbrains/jewel/painter/DarkPainterHintsProvider : org/jetbrains/jewel/painter/PainterHintsProvider {
+public abstract interface class org/jetbrains/jewel/painter/BitmapPainterHint : org/jetbrains/jewel/painter/PainterHint {
+	public abstract fun canApplyTo (Ljava/lang/String;)Z
+}
+
+public final class org/jetbrains/jewel/painter/BitmapPainterHint$DefaultImpls {
+	public static fun canApplyTo (Lorg/jetbrains/jewel/painter/BitmapPainterHint;Ljava/lang/String;)Z
+}
+
+public final class org/jetbrains/jewel/painter/CommonPainterHintsProvider : org/jetbrains/jewel/painter/PainterHintsProvider {
 	public static final field $stable I
-	public static final field INSTANCE Lorg/jetbrains/jewel/painter/DarkPainterHintsProvider;
+	public static final field INSTANCE Lorg/jetbrains/jewel/painter/CommonPainterHintsProvider;
 	public fun hints (Ljava/lang/String;Landroidx/compose/runtime/Composer;I)Ljava/util/List;
 }
 
 public abstract interface class org/jetbrains/jewel/painter/PainterHint {
 	public static final field None Lorg/jetbrains/jewel/painter/PainterHint$None;
+	public abstract fun canApplyTo (Ljava/lang/String;)Z
+}
+
+public final class org/jetbrains/jewel/painter/PainterHint$DefaultImpls {
+	public static fun canApplyTo (Lorg/jetbrains/jewel/painter/PainterHint;Ljava/lang/String;)Z
 }
 
 public final class org/jetbrains/jewel/painter/PainterHint$None : org/jetbrains/jewel/painter/PainterHint {
+	public fun canApplyTo (Ljava/lang/String;)Z
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -1496,9 +1510,14 @@ public abstract interface class org/jetbrains/jewel/painter/PainterPathHint : or
 	public abstract fun patch (Ljava/lang/String;)Ljava/lang/String;
 }
 
+public final class org/jetbrains/jewel/painter/PainterPathHint$DefaultImpls {
+	public static fun canApplyTo (Lorg/jetbrains/jewel/painter/PainterPathHint;Ljava/lang/String;)Z
+}
+
 public abstract class org/jetbrains/jewel/painter/PainterPrefixHint : org/jetbrains/jewel/painter/PainterPathHint {
 	public static final field $stable I
 	public fun <init> ()V
+	public fun canApplyTo (Ljava/lang/String;)Z
 	public fun patch (Ljava/lang/String;)Ljava/lang/String;
 	public abstract fun prefix ()Ljava/lang/String;
 }
@@ -1511,15 +1530,24 @@ public abstract interface class org/jetbrains/jewel/painter/PainterResourcePathH
 	public abstract fun patch (Ljava/lang/String;Ljava/util/List;)Ljava/lang/String;
 }
 
+public final class org/jetbrains/jewel/painter/PainterResourcePathHint$DefaultImpls {
+	public static fun canApplyTo (Lorg/jetbrains/jewel/painter/PainterResourcePathHint;Ljava/lang/String;)Z
+}
+
 public abstract class org/jetbrains/jewel/painter/PainterSuffixHint : org/jetbrains/jewel/painter/PainterPathHint {
 	public static final field $stable I
 	public fun <init> ()V
+	public fun canApplyTo (Ljava/lang/String;)Z
 	public fun patch (Ljava/lang/String;)Ljava/lang/String;
 	public abstract fun suffix ()Ljava/lang/String;
 }
 
-public abstract interface class org/jetbrains/jewel/painter/PainterSvgPatchHint : org/jetbrains/jewel/painter/PainterHint {
+public abstract interface class org/jetbrains/jewel/painter/PainterSvgPatchHint : org/jetbrains/jewel/painter/SvgPainterHint {
 	public abstract fun patch (Lorg/w3c/dom/Element;)V
+}
+
+public final class org/jetbrains/jewel/painter/PainterSvgPatchHint$DefaultImpls {
+	public static fun canApplyTo (Lorg/jetbrains/jewel/painter/PainterSvgPatchHint;Ljava/lang/String;)Z
 }
 
 public final class org/jetbrains/jewel/painter/ResourcePainterProvider : org/jetbrains/jewel/painter/PainterProvider {
@@ -1532,9 +1560,30 @@ public final class org/jetbrains/jewel/painter/ResourcePainterProviderKt {
 	public static final fun rememberResourcePainterProvider (Ljava/lang/String;Ljava/lang/Class;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/painter/PainterProvider;
 }
 
+public abstract interface class org/jetbrains/jewel/painter/SvgPainterHint : org/jetbrains/jewel/painter/PainterHint {
+	public abstract fun canApplyTo (Ljava/lang/String;)Z
+}
+
+public final class org/jetbrains/jewel/painter/SvgPainterHint$DefaultImpls {
+	public static fun canApplyTo (Lorg/jetbrains/jewel/painter/SvgPainterHint;Ljava/lang/String;)Z
+}
+
+public abstract interface class org/jetbrains/jewel/painter/XmlPainterHint : org/jetbrains/jewel/painter/PainterHint {
+	public abstract fun canApplyTo (Ljava/lang/String;)Z
+}
+
+public final class org/jetbrains/jewel/painter/XmlPainterHint$DefaultImpls {
+	public static fun canApplyTo (Lorg/jetbrains/jewel/painter/XmlPainterHint;Ljava/lang/String;)Z
+}
+
 public final class org/jetbrains/jewel/painter/hints/DarkKt {
 	public static final fun Dark (Z)Lorg/jetbrains/jewel/painter/PainterHint;
 	public static synthetic fun Dark$default (ZILjava/lang/Object;)Lorg/jetbrains/jewel/painter/PainterHint;
+}
+
+public final class org/jetbrains/jewel/painter/hints/HiDpiKt {
+	public static final fun HiDpi (Landroidx/compose/ui/unit/Density;)Lorg/jetbrains/jewel/painter/PainterHint;
+	public static final fun HiDpi (Z)Lorg/jetbrains/jewel/painter/PainterHint;
 }
 
 public final class org/jetbrains/jewel/painter/hints/OverrideKt {
@@ -1554,6 +1603,7 @@ public final class org/jetbrains/jewel/painter/hints/SelectedKt {
 public final class org/jetbrains/jewel/painter/hints/SizeKt {
 	public static final fun Size (II)Lorg/jetbrains/jewel/painter/PainterHint;
 	public static final fun Size (Ljava/lang/String;)Lorg/jetbrains/jewel/painter/PainterHint;
+	public static synthetic fun Size$default (IIILjava/lang/Object;)Lorg/jetbrains/jewel/painter/PainterHint;
 }
 
 public final class org/jetbrains/jewel/painter/hints/StatefulKt {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -3,8 +3,9 @@ import org.jetbrains.compose.ComposeBuildConfig
 plugins {
     jewel
     `jewel-publish`
+    `jewel-check-public-api`
     alias(libs.plugins.composeDesktop)
-    alias(libs.plugins.kotlinSerialization)
+    alias(libs.plugins.kotlinx.serialization)
 }
 
 private val composeVersion get() = ComposeBuildConfig.composeVersion

--- a/core/src/main/kotlin/org/jetbrains/jewel/GenerateDataFunctions.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/GenerateDataFunctions.kt
@@ -1,0 +1,10 @@
+package org.jetbrains.jewel
+
+/**
+ * Instructs the Poko compiler plugin to generate equals, hashcode,
+ * and toString functions for the class it's attached to.
+ *
+ * See https://github.com/JetBrains/jewel/issues/83
+ */
+@Target(AnnotationTarget.CLASS)
+annotation class GenerateDataFunctions

--- a/core/src/main/kotlin/org/jetbrains/jewel/foundation/Stroke.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/foundation/Stroke.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.isUnspecified
 import androidx.compose.ui.unit.Dp
+import dev.drewhamilton.poko.Poko
 
 sealed class Stroke {
     @Immutable
@@ -15,7 +16,8 @@ sealed class Stroke {
     }
 
     @Immutable
-    data class Solid internal constructor(
+    @Poko
+    class Solid internal constructor(
         val width: Dp,
         val color: Color,
         val alignment: Alignment,
@@ -23,7 +25,8 @@ sealed class Stroke {
     ) : Stroke()
 
     @Immutable
-    data class Brush internal constructor(
+    @Poko
+    class Brush internal constructor(
         val width: Dp,
         val brush: androidx.compose.ui.graphics.Brush,
         val alignment: Alignment,

--- a/core/src/main/kotlin/org/jetbrains/jewel/foundation/Stroke.kt
+++ b/core/src/main/kotlin/org/jetbrains/jewel/foundation/Stroke.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.graphics.isUnspecified
 import androidx.compose.ui.unit.Dp
-import dev.drewhamilton.poko.Poko
+import org.jetbrains.jewel.GenerateDataFunctions
 
 sealed class Stroke {
     @Immutable
@@ -16,7 +16,7 @@ sealed class Stroke {
     }
 
     @Immutable
-    @Poko
+    @GenerateDataFunctions
     class Solid internal constructor(
         val width: Dp,
         val color: Color,
@@ -25,7 +25,7 @@ sealed class Stroke {
     ) : Stroke()
 
     @Immutable
-    @Poko
+    @GenerateDataFunctions
     class Brush internal constructor(
         val width: Dp,
         val brush: androidx.compose.ui.graphics.Brush,

--- a/decorated-window/api/decorated-window.api
+++ b/decorated-window/api/decorated-window.api
@@ -1,0 +1,197 @@
+public abstract interface class com/jetbrains/DesktopActions {
+	public abstract fun setHandler (Lcom/jetbrains/DesktopActions$Handler;)V
+}
+
+public abstract interface class com/jetbrains/DesktopActions$Handler {
+	public fun browse (Ljava/net/URI;)V
+	public fun edit (Ljava/io/File;)V
+	public fun mail (Ljava/net/URI;)V
+	public fun open (Ljava/io/File;)V
+	public fun print (Ljava/io/File;)V
+}
+
+public class com/jetbrains/JBR {
+	public static fun getApiVersion ()Ljava/lang/String;
+	public static fun getDesktopActions ()Lcom/jetbrains/DesktopActions;
+	public static fun getRoundedCornersManager ()Lcom/jetbrains/RoundedCornersManager;
+	public static fun getWindowDecorations ()Lcom/jetbrains/WindowDecorations;
+	public static fun getWindowMove ()Lcom/jetbrains/WindowMove;
+	public static fun isAvailable ()Z
+	public static fun isDesktopActionsSupported ()Z
+	public static fun isRoundedCornersManagerSupported ()Z
+	public static fun isWindowDecorationsSupported ()Z
+	public static fun isWindowMoveSupported ()Z
+}
+
+public abstract interface class com/jetbrains/RoundedCornersManager {
+	public abstract fun setRoundedCorners (Ljava/awt/Window;Ljava/lang/Object;)V
+}
+
+public abstract interface class com/jetbrains/WindowDecorations {
+	public abstract fun createCustomTitleBar ()Lcom/jetbrains/WindowDecorations$CustomTitleBar;
+	public abstract fun setCustomTitleBar (Ljava/awt/Dialog;Lcom/jetbrains/WindowDecorations$CustomTitleBar;)V
+	public abstract fun setCustomTitleBar (Ljava/awt/Frame;Lcom/jetbrains/WindowDecorations$CustomTitleBar;)V
+}
+
+public abstract interface class com/jetbrains/WindowDecorations$CustomTitleBar {
+	public abstract fun forceHitTest (Z)V
+	public abstract fun getContainingWindow ()Ljava/awt/Window;
+	public abstract fun getHeight ()F
+	public abstract fun getLeftInset ()F
+	public abstract fun getProperties ()Ljava/util/Map;
+	public abstract fun getRightInset ()F
+	public abstract fun putProperties (Ljava/util/Map;)V
+	public abstract fun putProperty (Ljava/lang/String;Ljava/lang/Object;)V
+	public abstract fun setHeight (F)V
+}
+
+public abstract interface class com/jetbrains/WindowMove {
+	public abstract fun startMovingTogetherWithMouse (Ljava/awt/Window;I)V
+}
+
+public final class org/jetbrains/jewel/window/DecoratedWindowKt {
+	public static final fun DecoratedWindow (Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/window/WindowState;ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZZZZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/jewel/window/styling/DecoratedWindowStyle;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
+}
+
+public abstract interface class org/jetbrains/jewel/window/DecoratedWindowScope : androidx/compose/ui/window/FrameWindowScope {
+	public abstract fun getState-VA8cQZQ ()J
+	public abstract fun getWindow ()Landroidx/compose/ui/awt/ComposeWindow;
+}
+
+public final class org/jetbrains/jewel/window/DecoratedWindowState {
+	public static final field Companion Lorg/jetbrains/jewel/window/DecoratedWindowState$Companion;
+	public static final synthetic fun box-impl (J)Lorg/jetbrains/jewel/window/DecoratedWindowState;
+	public static fun constructor-impl (J)J
+	public static final fun copy-zAQEbgo (JZZZZ)J
+	public static synthetic fun copy-zAQEbgo$default (JZZZZILjava/lang/Object;)J
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (JLjava/lang/Object;)Z
+	public static final fun equals-impl0 (JJ)Z
+	public final fun getState-s-VKNKU ()J
+	public fun hashCode ()I
+	public static fun hashCode-impl (J)I
+	public static final fun isActive-impl (J)Z
+	public static final fun isFullscreen-impl (J)Z
+	public static final fun isMaximized-impl (J)Z
+	public static final fun isMinimized-impl (J)Z
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (J)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()J
+}
+
+public final class org/jetbrains/jewel/window/DecoratedWindowState$Companion {
+	public final fun getActive-s-VKNKU ()J
+	public final fun getFullscreen-s-VKNKU ()J
+	public final fun getMaximize-s-VKNKU ()J
+	public final fun getMinimize-s-VKNKU ()J
+	public final fun of-LPCgXDc (Landroidx/compose/ui/awt/ComposeWindow;)J
+	public final fun of-zAQEbgo (ZZZZ)J
+	public static synthetic fun of-zAQEbgo$default (Lorg/jetbrains/jewel/window/DecoratedWindowState$Companion;ZZZZILjava/lang/Object;)J
+}
+
+public final class org/jetbrains/jewel/window/ThemeKt {
+	public static final fun getDefaultDecoratedWindowStyle (Lorg/jetbrains/jewel/IntelliJTheme$Companion;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/window/styling/DecoratedWindowStyle;
+	public static final fun getDefaultTitleBarStyle (Lorg/jetbrains/jewel/IntelliJTheme$Companion;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/window/styling/TitleBarStyle;
+}
+
+public final class org/jetbrains/jewel/window/TitleBarKt {
+	public static final fun TitleBar-T042LqI (Lorg/jetbrains/jewel/window/DecoratedWindowScope;Landroidx/compose/ui/Modifier;JLorg/jetbrains/jewel/window/styling/TitleBarStyle;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
+}
+
+public abstract interface class org/jetbrains/jewel/window/TitleBarScope {
+	public abstract fun align (Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment$Horizontal;)Landroidx/compose/ui/Modifier;
+	public abstract fun getIcon ()Landroidx/compose/ui/graphics/painter/Painter;
+	public abstract fun getTitle ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/window/TitleBar_MacOSKt {
+	public static final fun newFullscreenControls (Landroidx/compose/ui/Modifier;Z)Landroidx/compose/ui/Modifier;
+	public static synthetic fun newFullscreenControls$default (Landroidx/compose/ui/Modifier;ZILjava/lang/Object;)Landroidx/compose/ui/Modifier;
+}
+
+public abstract interface class org/jetbrains/jewel/window/styling/DecoratedWindowColors {
+	public abstract fun borderFor-3hEOMOc (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun getBorder-0d7_KjU ()J
+	public abstract fun getBorderInactive-0d7_KjU ()J
+}
+
+public final class org/jetbrains/jewel/window/styling/DecoratedWindowColors$DefaultImpls {
+	public static fun borderFor-3hEOMOc (Lorg/jetbrains/jewel/window/styling/DecoratedWindowColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public abstract interface class org/jetbrains/jewel/window/styling/DecoratedWindowMetrics {
+	public abstract fun getBorderWidth-D9Ej5fM ()F
+}
+
+public abstract interface class org/jetbrains/jewel/window/styling/DecoratedWindowStyle {
+	public abstract fun getColors ()Lorg/jetbrains/jewel/window/styling/DecoratedWindowColors;
+	public abstract fun getMetrics ()Lorg/jetbrains/jewel/window/styling/DecoratedWindowMetrics;
+}
+
+public final class org/jetbrains/jewel/window/styling/DecoratedWindowStylingKt {
+	public static final fun getLocalDecoratedWindowStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public abstract interface class org/jetbrains/jewel/window/styling/TitleBarColors {
+	public abstract fun backgroundFor-3hEOMOc (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public abstract fun getBackground-0d7_KjU ()J
+	public abstract fun getBorder-0d7_KjU ()J
+	public abstract fun getContent-0d7_KjU ()J
+	public abstract fun getDropdownHoverBackground-0d7_KjU ()J
+	public abstract fun getDropdownPressBackground-0d7_KjU ()J
+	public abstract fun getFullscreenControlButtonsBackground-0d7_KjU ()J
+	public abstract fun getIconButtonHoverBackground-0d7_KjU ()J
+	public abstract fun getIconButtonPressBackground-0d7_KjU ()J
+	public abstract fun getInactiveBackground-0d7_KjU ()J
+	public abstract fun getTitlePaneButtonHoverBackground-0d7_KjU ()J
+	public abstract fun getTitlePaneButtonPressBackground-0d7_KjU ()J
+	public abstract fun getTitlePaneCloseButtonHoverBackground-0d7_KjU ()J
+	public abstract fun getTitlePaneCloseButtonPressBackground-0d7_KjU ()J
+}
+
+public final class org/jetbrains/jewel/window/styling/TitleBarColors$DefaultImpls {
+	public static fun backgroundFor-3hEOMOc (Lorg/jetbrains/jewel/window/styling/TitleBarColors;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public abstract interface class org/jetbrains/jewel/window/styling/TitleBarIcons {
+	public abstract fun getCloseButton ()Lorg/jetbrains/jewel/painter/PainterProvider;
+	public abstract fun getMaximizeButton ()Lorg/jetbrains/jewel/painter/PainterProvider;
+	public abstract fun getMinimizeButton ()Lorg/jetbrains/jewel/painter/PainterProvider;
+	public abstract fun getRestoreButton ()Lorg/jetbrains/jewel/painter/PainterProvider;
+}
+
+public abstract interface class org/jetbrains/jewel/window/styling/TitleBarMetrics {
+	public abstract fun getGradientEndX-D9Ej5fM ()F
+	public abstract fun getGradientStartX-D9Ej5fM ()F
+	public abstract fun getHeight-D9Ej5fM ()F
+	public abstract fun getTitlePaneButtonSize-MYxV2XQ ()J
+}
+
+public abstract interface class org/jetbrains/jewel/window/styling/TitleBarStyle {
+	public abstract fun getColors ()Lorg/jetbrains/jewel/window/styling/TitleBarColors;
+	public abstract fun getDropdownStyle ()Lorg/jetbrains/jewel/styling/DropdownStyle;
+	public abstract fun getIconButtonStyle ()Lorg/jetbrains/jewel/styling/IconButtonStyle;
+	public abstract fun getIcons ()Lorg/jetbrains/jewel/window/styling/TitleBarIcons;
+	public abstract fun getMetrics ()Lorg/jetbrains/jewel/window/styling/TitleBarMetrics;
+	public abstract fun getPaneButtonStyle ()Lorg/jetbrains/jewel/styling/IconButtonStyle;
+	public abstract fun getPaneCloseButtonStyle ()Lorg/jetbrains/jewel/styling/IconButtonStyle;
+}
+
+public final class org/jetbrains/jewel/window/styling/TitleBarStylingKt {
+	public static final fun getLocalTitleBarStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public final class org/jetbrains/jewel/window/utils/DesktopPlatform : java/lang/Enum {
+	public static final field Companion Lorg/jetbrains/jewel/window/utils/DesktopPlatform$Companion;
+	public static final field Linux Lorg/jetbrains/jewel/window/utils/DesktopPlatform;
+	public static final field MacOS Lorg/jetbrains/jewel/window/utils/DesktopPlatform;
+	public static final field Unknown Lorg/jetbrains/jewel/window/utils/DesktopPlatform;
+	public static final field Windows Lorg/jetbrains/jewel/window/utils/DesktopPlatform;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/jewel/window/utils/DesktopPlatform;
+	public static fun values ()[Lorg/jetbrains/jewel/window/utils/DesktopPlatform;
+}
+
+public final class org/jetbrains/jewel/window/utils/DesktopPlatform$Companion {
+	public final fun getCurrent ()Lorg/jetbrains/jewel/window/utils/DesktopPlatform;
+}
+

--- a/decorated-window/build.gradle.kts
+++ b/decorated-window/build.gradle.kts
@@ -3,8 +3,8 @@ import org.jetbrains.compose.ComposeBuildConfig
 plugins {
     jewel
     `jewel-publish`
+    `jewel-check-public-api`
     alias(libs.plugins.composeDesktop)
-    alias(libs.plugins.kotlinSerialization)
 }
 
 private val composeVersion get() = ComposeBuildConfig.composeVersion

--- a/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/TitleBar.Linux.kt
+++ b/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/TitleBar.Linux.kt
@@ -50,9 +50,7 @@ import java.awt.event.WindowEvent
         },
         gradientStartColor,
         style,
-        { size, state ->
-            PaddingValues(0.dp)
-        },
+        { _, _ -> PaddingValues(0.dp) },
     ) { state ->
         CloseButton({
             window.dispatchEvent(WindowEvent(window, WindowEvent.WINDOW_CLOSING))

--- a/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/TitleBar.Windows.kt
+++ b/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/TitleBar.Windows.kt
@@ -29,7 +29,7 @@ import org.jetbrains.jewel.window.styling.TitleBarStyle
         modifier.customTitleBarMouseEventHandler(titleBar),
         gradientStartColor,
         style,
-        { height, state ->
+        { height, _ ->
             titleBar.height = height.value
             titleBar.putProperty("controls.dark", style.colors.background.isDark())
             JBR.getWindowDecorations().setCustomTitleBar(window, titleBar)

--- a/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/TitleBar.kt
+++ b/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/TitleBar.kt
@@ -185,13 +185,13 @@ internal class TitleBarMeasurePolicy(
             var headUsedSpace = leftInset
             var trailerUsedSpace = rightInset
 
-            placeableGroups[Alignment.Start]?.forEach { (measurable, placeable) ->
+            placeableGroups[Alignment.Start]?.forEach { (_, placeable) ->
                 val x = headUsedSpace
                 val y = Alignment.CenterVertically.align(placeable.height, boxHeight)
                 placeable.placeRelative(x, y)
                 headUsedSpace += placeable.width
             }
-            placeableGroups[Alignment.End]?.forEach { (measurable, placeable) ->
+            placeableGroups[Alignment.End]?.forEach { (_, placeable) ->
                 val x = boxWidth - placeable.width - trailerUsedSpace
                 val y = Alignment.CenterVertically.align(placeable.height, boxHeight)
                 placeable.placeRelative(x, y)
@@ -213,7 +213,7 @@ internal class TitleBarMeasurePolicy(
                     centerX = minX
                 }
 
-                centerPlaceable.forEach { (measurable, placeable) ->
+                centerPlaceable.forEach { (_, placeable) ->
                     val x = centerX
                     val y = Alignment.CenterVertically.align(placeable.height, boxHeight)
                     placeable.placeRelative(x, y)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,19 +2,21 @@
 composeDesktop = "1.5.2"
 coroutines = "1.7.3"
 detekt = "1.23.1"
+dokka = "1.8.20"
 idea232 = "232.8660.185"
 idea233 = "233.9802.14-EAP-SNAPSHOT"
 ideaGradlePlugin = "1.15.0"
 javaSarif = "2.0"
-kotlinSarif = "0.4.0"
+jna = "5.13.0"
 kotlin = "1.8.21"
-dokka = "1.8.20"
+kotlinSarif = "0.4.0"
+kotlinpoet = "1.14.2"
 kotlinterGradlePlugin = "3.16.0"
 kotlinxSerialization = "1.5.1"
-kotlinpoet = "1.14.2"
+kotlinxBinaryCompat = "0.13.2"
+poko = "0.13.1"
 semVer = "1.2.0"
 simpleXml = "2.7.1"
-jna = "5.13.0"
 
 [libraries]
 javaSarif = { module = "com.contrastsecurity:java-sarif", version.ref = "javaSarif" }
@@ -36,10 +38,12 @@ jna-core = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 
 # Plugin libraries for build-logic's convention plugins to use to resolve the types/tasks coming from these plugins
 detekt-gradlePlugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
-kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
-kotlinter-gradlePlugin = { module = "org.jmailen.gradle:kotlinter-gradle", version.ref = "kotlinterGradlePlugin" }
 dokka-gradlePlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
+kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
+kotlinter-gradlePlugin = { module = "org.jmailen.gradle:kotlinter-gradle", version.ref = "kotlinterGradlePlugin" }
+kotlinx-binaryCompatValidator-gradlePlugin = { module = "org.jetbrains.kotlinx:binary-compatibility-validator", version.ref = "kotlinxBinaryCompat" }
+poko-gradlePlugin = { module = "dev.drewhamilton.poko:poko-gradle-plugin", version.ref = "poko" }
 
 [bundles]
 idea232 = ["ij-platform-ide-core-232", "ij-platform-ide-impl-232", "ij-platform-core-ui-232"]
@@ -48,9 +52,10 @@ idea233 = ["ij-platform-ide-core-233", "ij-platform-ide-impl-233", "ij-platform-
 [plugins]
 composeDesktop = { id = "org.jetbrains.compose", version.ref = "composeDesktop" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
-ideaGradlePlugin = { id = "org.jetbrains.intellij", version.ref = "ideaGradlePlugin" }
-kotlinter = { id = "org.jmailen.kotlinter", version.ref = "kotlinterGradlePlugin" }
-kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
-kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+ideaGradlePlugin = { id = "org.jetbrains.intellij", version.ref = "ideaGradlePlugin" }
+kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlinx-binaryCompatValidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinxBinaryCompat" }
+kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlinter = { id = "org.jmailen.kotlinter", version.ref = "kotlinterGradlePlugin" }
+poko = { id = "dev.drewhamilton.poko", version.ref = "poko" }

--- a/ide-laf-bridge/api/ide-laf-bridge.api
+++ b/ide-laf-bridge/api/ide-laf-bridge.api
@@ -1,0 +1,91 @@
+public final class org/jetbrains/jewel/bridge/BridgeResourceResolverKt {
+	public static final fun bridgePainterProvider (Ljava/lang/String;)Lorg/jetbrains/jewel/painter/ResourcePainterProvider;
+}
+
+public final class org/jetbrains/jewel/bridge/BridgeThemeColorPalette : org/jetbrains/jewel/intui/core/IntUiThemeColorPalette {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/bridge/BridgeThemeColorPalette$Companion;
+	public synthetic fun <init> (Ljava/util/Map;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun blue ()Ljava/util/List;
+	public fun blue-vNxB06k (I)J
+	public fun getRawMap ()Ljava/util/Map;
+	public fun green ()Ljava/util/List;
+	public fun green-vNxB06k (I)J
+	public fun grey ()Ljava/util/List;
+	public fun grey-vNxB06k (I)J
+	public fun lookup-ijrfgN4 (Ljava/lang/String;)Landroidx/compose/ui/graphics/Color;
+	public fun orange ()Ljava/util/List;
+	public fun orange-vNxB06k (I)J
+	public fun purple ()Ljava/util/List;
+	public fun purple-vNxB06k (I)J
+	public fun red ()Ljava/util/List;
+	public fun red-vNxB06k (I)J
+	public fun teal ()Ljava/util/List;
+	public fun teal-vNxB06k (I)J
+	public fun yellow ()Ljava/util/List;
+	public fun yellow-vNxB06k (I)J
+}
+
+public final class org/jetbrains/jewel/bridge/BridgeThemeColorPalette$Companion {
+	public final fun readFromLaF ()Lorg/jetbrains/jewel/bridge/BridgeThemeColorPalette;
+}
+
+public final class org/jetbrains/jewel/bridge/BridgeUtilsKt {
+	public static final fun createVerticalBrush-8A-3gB4 (Ljava/util/List;FFI)Landroidx/compose/ui/graphics/Brush;
+	public static synthetic fun createVerticalBrush-8A-3gB4$default (Ljava/util/List;FFIILjava/lang/Object;)Landroidx/compose/ui/graphics/Brush;
+	public static final fun getDp (Lcom/intellij/util/ui/JBValue;)F
+	public static final fun retrieveArcAsCornerSize (Ljava/lang/String;)Landroidx/compose/foundation/shape/CornerSize;
+	public static final fun retrieveArcAsCornerSizeWithFallbacks ([Ljava/lang/String;)Landroidx/compose/foundation/shape/CornerSize;
+	public static final fun retrieveColorOrNull (Ljava/lang/String;)Landroidx/compose/ui/graphics/Color;
+	public static final fun retrieveColorOrUnspecified (Ljava/lang/String;)J
+	public static final fun retrieveColorsOrUnspecified ([Ljava/lang/String;)Ljava/util/List;
+	public static final fun retrieveInsetsAsPaddingValues (Ljava/lang/String;)Landroidx/compose/foundation/layout/PaddingValues;
+	public static final fun retrieveIntAsDp (Ljava/lang/String;)F
+	public static final fun retrieveIntAsDpOrUnspecified (Ljava/lang/String;)F
+	public static final fun retrieveTextStyle (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun retrieveTextStyle$default (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun retrieveTextStyle-_Wfy91w (Ljava/lang/String;JJZIJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun retrieveTextStyle-_Wfy91w$default (Ljava/lang/String;JJZIJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun toComposeColor (Ljava/awt/Color;)J
+	public static final fun toComposeColorOrUnspecified (Ljava/awt/Color;)J
+	public static final fun toDpSize (Lcom/intellij/util/ui/JBDimension;)J
+	public static final fun toDpSize (Ljava/awt/Dimension;)J
+	public static final fun toFontFamily (Ljava/awt/Font;)Landroidx/compose/ui/text/font/FontFamily;
+	public static final fun toPaddingValues (Lcom/intellij/util/ui/JBInsets;)Landroidx/compose/foundation/layout/PaddingValues;
+	public static final fun toPaddingValues (Ljava/awt/Insets;)Landroidx/compose/foundation/layout/PaddingValues;
+}
+
+public abstract class org/jetbrains/jewel/bridge/JewelBridgeException : java/lang/RuntimeException {
+	public static final field $stable I
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun getMessage ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/bridge/JewelBridgeException$KeyNotFoundException : org/jetbrains/jewel/bridge/JewelBridgeException {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+}
+
+public final class org/jetbrains/jewel/bridge/JewelBridgeException$KeysNotFoundException : org/jetbrains/jewel/bridge/JewelBridgeException {
+	public static final field $stable I
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+}
+
+public final class org/jetbrains/jewel/bridge/SwingBridgeThemeKt {
+	public static final fun SwingBridgeTheme (Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+}
+
+public abstract interface annotation class org/jetbrains/jewel/bridge/SwingLafKey : java/lang/annotation/Annotation {
+	public abstract fun key ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/bridge/ToolWindowExtensionsKt {
+	public static final fun addComposeTab (Lcom/intellij/openapi/wm/ToolWindow;Ljava/lang/String;ZZLkotlin/jvm/functions/Function2;)V
+	public static synthetic fun addComposeTab$default (Lcom/intellij/openapi/wm/ToolWindow;Ljava/lang/String;ZZLkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+}
+
+public final class org/jetbrains/jewel/bridge/actionSystem/ProvideDataKt {
+	public static final fun ComponentDataProviderBridge (Ljavax/swing/JComponent;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun provideData (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;)Landroidx/compose/ui/Modifier;
+}
+

--- a/ide-laf-bridge/build.gradle.kts
+++ b/ide-laf-bridge/build.gradle.kts
@@ -3,6 +3,7 @@ import SupportedIJVersion.*
 plugins {
     jewel
     `jewel-ij-publish`
+    `jewel-check-public-api`
     alias(libs.plugins.composeDesktop)
 }
 

--- a/ide-laf-bridge/ide-laf-bridge-232/api/ide-laf-bridge-232.api
+++ b/ide-laf-bridge/ide-laf-bridge-232/api/ide-laf-bridge-232.api
@@ -1,0 +1,11 @@
+public final class org/jetbrains/jewel/bridge/BridgeIconData$Companion {
+	public final fun readFromLaF ()Lorg/jetbrains/jewel/bridge/BridgeIconData;
+}
+
+public final class org/jetbrains/jewel/bridge/BridgePainterHintsProvider$Companion {
+	public final fun invoke (Z)Lorg/jetbrains/jewel/intui/core/IntUiPainterHintsProvider;
+}
+
+public final class org/jetbrains/jewel/bridge/UiThemeExtensionsKt {
+}
+

--- a/ide-laf-bridge/ide-laf-bridge-232/src/main/kotlin/org/jetbrains/jewel/bridge/BridgePainterHintsProvider.kt
+++ b/ide-laf-bridge/ide-laf-bridge-232/src/main/kotlin/org/jetbrains/jewel/bridge/BridgePainterHintsProvider.kt
@@ -44,7 +44,7 @@ class BridgePainterHintsProvider private constructor(
 
             val iconColorPalette = uiTheme.iconColorPalette
             val keyPalette = UITheme.getColorPalette()
-            val themeColors = uiTheme.colors.orEmpty().mapValues { (k, v) ->
+            val themeColors = uiTheme.colors.orEmpty().mapValues { (_, v) ->
                 when (v) {
                     is Int -> Color(v)
                     is String -> Color.fromRGBAHexString(v)

--- a/ide-laf-bridge/ide-laf-bridge-233/api/ide-laf-bridge-233.api
+++ b/ide-laf-bridge/ide-laf-bridge-233/api/ide-laf-bridge-233.api
@@ -1,0 +1,8 @@
+public final class org/jetbrains/jewel/bridge/BridgeIconData$Companion {
+	public final fun readFromLaF ()Lorg/jetbrains/jewel/bridge/BridgeIconData;
+}
+
+public final class org/jetbrains/jewel/bridge/BridgePainterHintsProvider$Companion {
+	public final fun invoke (Z)Lorg/jetbrains/jewel/intui/core/IntUiPainterHintsProvider;
+}
+

--- a/ide-laf-bridge/ide-laf-bridge-233/src/main/kotlin/org/jetbrains/jewel/bridge/BridgePainterHintsProvider.kt
+++ b/ide-laf-bridge/ide-laf-bridge-233/src/main/kotlin/org/jetbrains/jewel/bridge/BridgePainterHintsProvider.kt
@@ -49,9 +49,8 @@ class BridgePainterHintsProvider private constructor(
                 }
             }
             val keyPalette = UITheme.getColorPalette()
-            val themeColors = bean.colors.mapValues { (k, v) ->
-                Color(v)
-            }
+            val themeColors = bean.colors
+                .mapValues { (_, v) -> Color(v) }
 
             return BridgePainterHintsProvider(isDark, keyPalette, iconColorPalette, themeColors)
         }

--- a/int-ui/int-ui-core/api/int-ui-core.api
+++ b/int-ui/int-ui-core/api/int-ui-core.api
@@ -1,0 +1,373 @@
+public abstract interface class org/jetbrains/jewel/intui/core/BaseIntUiTheme : org/jetbrains/jewel/IntelliJTheme {
+	public abstract fun getCheckboxStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/CheckboxStyle;
+	public abstract fun getChipStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/ChipStyle;
+	public abstract fun getCircularProgressStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/CircularProgressStyle;
+	public abstract fun getColorPalette (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/intui/core/IntUiThemeColorPalette;
+	public abstract fun getContentColor (Landroidx/compose/runtime/Composer;I)J
+	public abstract fun getDefaultButtonStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/ButtonStyle;
+	public abstract fun getDefaultTabStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/TabStyle;
+	public abstract fun getDividerStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/DividerStyle;
+	public abstract fun getDropdownStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/DropdownStyle;
+	public abstract fun getEditorTabStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/TabStyle;
+	public abstract fun getGlobalColors (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/GlobalColors;
+	public abstract fun getGlobalMetrics (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/GlobalMetrics;
+	public abstract fun getGroupHeaderStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/GroupHeaderStyle;
+	public abstract fun getHorizontalProgressBarStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/HorizontalProgressBarStyle;
+	public abstract fun getIconData (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/IntelliJThemeIconData;
+	public abstract fun getLabelledTextFieldStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/LabelledTextFieldStyle;
+	public abstract fun getLinkStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/LinkStyle;
+	public abstract fun getMenuStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/MenuStyle;
+	public abstract fun getOutlinedButtonStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/ButtonStyle;
+	public abstract fun getRadioButtonStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/RadioButtonStyle;
+	public abstract fun getScrollbarStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/ScrollbarStyle;
+	public abstract fun getTextAreaStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/TextAreaStyle;
+	public abstract fun getTextFieldStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/TextFieldStyle;
+	public abstract fun getTextStyle (Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/text/TextStyle;
+	public abstract fun getTreeStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/LazyTreeStyle;
+	public abstract fun isDark (Landroidx/compose/runtime/Composer;I)Z
+	public abstract fun isSwingCompatMode (Landroidx/compose/runtime/Composer;I)Z
+}
+
+public final class org/jetbrains/jewel/intui/core/BaseIntUiTheme$DefaultImpls {
+	public static fun getCheckboxStyle (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/CheckboxStyle;
+	public static fun getChipStyle (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/ChipStyle;
+	public static fun getCircularProgressStyle (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/CircularProgressStyle;
+	public static fun getColorPalette (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/intui/core/IntUiThemeColorPalette;
+	public static fun getContentColor (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)J
+	public static fun getDefaultButtonStyle (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/ButtonStyle;
+	public static fun getDefaultTabStyle (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/TabStyle;
+	public static fun getDividerStyle (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/DividerStyle;
+	public static fun getDropdownStyle (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/DropdownStyle;
+	public static fun getEditorTabStyle (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/TabStyle;
+	public static fun getGlobalColors (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/GlobalColors;
+	public static fun getGlobalMetrics (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/GlobalMetrics;
+	public static fun getGroupHeaderStyle (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/GroupHeaderStyle;
+	public static fun getHorizontalProgressBarStyle (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/HorizontalProgressBarStyle;
+	public static fun getIconData (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/IntelliJThemeIconData;
+	public static fun getLabelledTextFieldStyle (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/LabelledTextFieldStyle;
+	public static fun getLinkStyle (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/LinkStyle;
+	public static fun getMenuStyle (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/MenuStyle;
+	public static fun getOutlinedButtonStyle (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/ButtonStyle;
+	public static fun getRadioButtonStyle (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/RadioButtonStyle;
+	public static fun getScrollbarStyle (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/ScrollbarStyle;
+	public static fun getTextAreaStyle (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/TextAreaStyle;
+	public static fun getTextFieldStyle (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/TextFieldStyle;
+	public static fun getTextStyle (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/text/TextStyle;
+	public static fun getTreeStyle (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/LazyTreeStyle;
+	public static fun isDark (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Z
+	public static fun isSwingCompatMode (Lorg/jetbrains/jewel/intui/core/BaseIntUiTheme;Landroidx/compose/runtime/Composer;I)Z
+}
+
+public final class org/jetbrains/jewel/intui/core/BaseIntUiThemeKt {
+	public static final fun BaseIntUiTheme (Lorg/jetbrains/jewel/intui/core/IntUiThemeDefinition;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+	public static final fun BaseIntUiTheme (Lorg/jetbrains/jewel/intui/core/IntUiThemeDefinition;Lkotlin/jvm/functions/Function2;ZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+}
+
+public abstract class org/jetbrains/jewel/intui/core/IntUiPainterHintsProvider : org/jetbrains/jewel/painter/PainterHintsProvider {
+	public static final field $stable I
+	public fun <init> (ZLjava/util/Map;Ljava/util/Map;Ljava/util/Map;)V
+	protected final fun getPaletteHint (Ljava/lang/String;)Lorg/jetbrains/jewel/painter/PainterHint;
+}
+
+public abstract interface class org/jetbrains/jewel/intui/core/IntUiThemeColorPalette : org/jetbrains/jewel/IntelliJThemeColorPalette {
+	public abstract fun blue ()Ljava/util/List;
+	public abstract fun blue-vNxB06k (I)J
+	public abstract fun green ()Ljava/util/List;
+	public abstract fun green-vNxB06k (I)J
+	public abstract fun grey ()Ljava/util/List;
+	public abstract fun grey-vNxB06k (I)J
+	public abstract fun lookup-ijrfgN4 (Ljava/lang/String;)Landroidx/compose/ui/graphics/Color;
+	public abstract fun orange ()Ljava/util/List;
+	public abstract fun orange-vNxB06k (I)J
+	public abstract fun purple ()Ljava/util/List;
+	public abstract fun purple-vNxB06k (I)J
+	public abstract fun red ()Ljava/util/List;
+	public abstract fun red-vNxB06k (I)J
+	public abstract fun teal ()Ljava/util/List;
+	public abstract fun teal-vNxB06k (I)J
+	public abstract fun yellow ()Ljava/util/List;
+	public abstract fun yellow-vNxB06k (I)J
+}
+
+public final class org/jetbrains/jewel/intui/core/IntUiThemeColorPalette$DefaultImpls {
+	public static fun lookup-ijrfgN4 (Lorg/jetbrains/jewel/intui/core/IntUiThemeColorPalette;Ljava/lang/String;)Landroidx/compose/ui/graphics/Color;
+}
+
+public final class org/jetbrains/jewel/intui/core/IntUiThemeDefinition : org/jetbrains/jewel/IntelliJThemeDefinition {
+	public static final field $stable I
+	public synthetic fun <init> (ZLorg/jetbrains/jewel/GlobalColors;Lorg/jetbrains/jewel/intui/core/IntUiThemeColorPalette;Lorg/jetbrains/jewel/IntelliJThemeIconData;Lorg/jetbrains/jewel/GlobalMetrics;Landroidx/compose/ui/text/TextStyle;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public synthetic fun getColorPalette ()Lorg/jetbrains/jewel/IntelliJThemeColorPalette;
+	public fun getColorPalette ()Lorg/jetbrains/jewel/intui/core/IntUiThemeColorPalette;
+	public fun getContentColor-0d7_KjU ()J
+	public fun getDefaultTextStyle ()Landroidx/compose/ui/text/TextStyle;
+	public fun getGlobalColors ()Lorg/jetbrains/jewel/GlobalColors;
+	public fun getGlobalMetrics ()Lorg/jetbrains/jewel/GlobalMetrics;
+	public fun getIconData ()Lorg/jetbrains/jewel/IntelliJThemeIconData;
+	public fun hashCode ()I
+	public fun isDark ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/core/theme/IntUiDarkTheme : org/jetbrains/jewel/IntelliJThemeDescriptor {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/intui/core/theme/IntUiDarkTheme;
+	public synthetic fun getColors ()Lorg/jetbrains/jewel/IntelliJThemeColorPalette;
+	public fun getColors ()Lorg/jetbrains/jewel/intui/core/IntUiThemeColorPalette;
+	public fun getIcons ()Lorg/jetbrains/jewel/IntelliJThemeIconData;
+	public fun getName ()Ljava/lang/String;
+	public fun isDark ()Z
+}
+
+public final class org/jetbrains/jewel/intui/core/theme/IntUiDarkTheme$Colors : org/jetbrains/jewel/intui/core/IntUiThemeColorPalette {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/intui/core/theme/IntUiDarkTheme$Colors;
+	public fun blue ()Ljava/util/List;
+	public fun blue-vNxB06k (I)J
+	public final fun getBlue1-0d7_KjU ()J
+	public final fun getBlue10-0d7_KjU ()J
+	public final fun getBlue11-0d7_KjU ()J
+	public final fun getBlue2-0d7_KjU ()J
+	public final fun getBlue3-0d7_KjU ()J
+	public final fun getBlue4-0d7_KjU ()J
+	public final fun getBlue5-0d7_KjU ()J
+	public final fun getBlue6-0d7_KjU ()J
+	public final fun getBlue7-0d7_KjU ()J
+	public final fun getBlue8-0d7_KjU ()J
+	public final fun getBlue9-0d7_KjU ()J
+	public final fun getGreen1-0d7_KjU ()J
+	public final fun getGreen10-0d7_KjU ()J
+	public final fun getGreen11-0d7_KjU ()J
+	public final fun getGreen2-0d7_KjU ()J
+	public final fun getGreen3-0d7_KjU ()J
+	public final fun getGreen4-0d7_KjU ()J
+	public final fun getGreen5-0d7_KjU ()J
+	public final fun getGreen6-0d7_KjU ()J
+	public final fun getGreen7-0d7_KjU ()J
+	public final fun getGreen8-0d7_KjU ()J
+	public final fun getGreen9-0d7_KjU ()J
+	public final fun getGrey1-0d7_KjU ()J
+	public final fun getGrey10-0d7_KjU ()J
+	public final fun getGrey11-0d7_KjU ()J
+	public final fun getGrey12-0d7_KjU ()J
+	public final fun getGrey13-0d7_KjU ()J
+	public final fun getGrey14-0d7_KjU ()J
+	public final fun getGrey2-0d7_KjU ()J
+	public final fun getGrey3-0d7_KjU ()J
+	public final fun getGrey4-0d7_KjU ()J
+	public final fun getGrey5-0d7_KjU ()J
+	public final fun getGrey6-0d7_KjU ()J
+	public final fun getGrey7-0d7_KjU ()J
+	public final fun getGrey8-0d7_KjU ()J
+	public final fun getGrey9-0d7_KjU ()J
+	public final fun getOrange1-0d7_KjU ()J
+	public final fun getOrange10-0d7_KjU ()J
+	public final fun getOrange11-0d7_KjU ()J
+	public final fun getOrange2-0d7_KjU ()J
+	public final fun getOrange3-0d7_KjU ()J
+	public final fun getOrange4-0d7_KjU ()J
+	public final fun getOrange5-0d7_KjU ()J
+	public final fun getOrange6-0d7_KjU ()J
+	public final fun getOrange7-0d7_KjU ()J
+	public final fun getOrange8-0d7_KjU ()J
+	public final fun getOrange9-0d7_KjU ()J
+	public final fun getPurple1-0d7_KjU ()J
+	public final fun getPurple10-0d7_KjU ()J
+	public final fun getPurple11-0d7_KjU ()J
+	public final fun getPurple2-0d7_KjU ()J
+	public final fun getPurple3-0d7_KjU ()J
+	public final fun getPurple4-0d7_KjU ()J
+	public final fun getPurple5-0d7_KjU ()J
+	public final fun getPurple6-0d7_KjU ()J
+	public final fun getPurple7-0d7_KjU ()J
+	public final fun getPurple8-0d7_KjU ()J
+	public final fun getPurple9-0d7_KjU ()J
+	public fun getRawMap ()Ljava/util/Map;
+	public final fun getRed1-0d7_KjU ()J
+	public final fun getRed10-0d7_KjU ()J
+	public final fun getRed11-0d7_KjU ()J
+	public final fun getRed2-0d7_KjU ()J
+	public final fun getRed3-0d7_KjU ()J
+	public final fun getRed4-0d7_KjU ()J
+	public final fun getRed5-0d7_KjU ()J
+	public final fun getRed6-0d7_KjU ()J
+	public final fun getRed7-0d7_KjU ()J
+	public final fun getRed8-0d7_KjU ()J
+	public final fun getRed9-0d7_KjU ()J
+	public final fun getTeal1-0d7_KjU ()J
+	public final fun getTeal10-0d7_KjU ()J
+	public final fun getTeal11-0d7_KjU ()J
+	public final fun getTeal2-0d7_KjU ()J
+	public final fun getTeal3-0d7_KjU ()J
+	public final fun getTeal4-0d7_KjU ()J
+	public final fun getTeal5-0d7_KjU ()J
+	public final fun getTeal6-0d7_KjU ()J
+	public final fun getTeal7-0d7_KjU ()J
+	public final fun getTeal8-0d7_KjU ()J
+	public final fun getTeal9-0d7_KjU ()J
+	public final fun getYellow1-0d7_KjU ()J
+	public final fun getYellow10-0d7_KjU ()J
+	public final fun getYellow11-0d7_KjU ()J
+	public final fun getYellow2-0d7_KjU ()J
+	public final fun getYellow3-0d7_KjU ()J
+	public final fun getYellow4-0d7_KjU ()J
+	public final fun getYellow5-0d7_KjU ()J
+	public final fun getYellow6-0d7_KjU ()J
+	public final fun getYellow7-0d7_KjU ()J
+	public final fun getYellow8-0d7_KjU ()J
+	public final fun getYellow9-0d7_KjU ()J
+	public fun green ()Ljava/util/List;
+	public fun green-vNxB06k (I)J
+	public fun grey ()Ljava/util/List;
+	public fun grey-vNxB06k (I)J
+	public fun lookup-ijrfgN4 (Ljava/lang/String;)Landroidx/compose/ui/graphics/Color;
+	public fun orange ()Ljava/util/List;
+	public fun orange-vNxB06k (I)J
+	public fun purple ()Ljava/util/List;
+	public fun purple-vNxB06k (I)J
+	public fun red ()Ljava/util/List;
+	public fun red-vNxB06k (I)J
+	public fun teal ()Ljava/util/List;
+	public fun teal-vNxB06k (I)J
+	public fun yellow ()Ljava/util/List;
+	public fun yellow-vNxB06k (I)J
+}
+
+public final class org/jetbrains/jewel/intui/core/theme/IntUiDarkTheme$Icons : org/jetbrains/jewel/IntelliJThemeIconData {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/intui/core/theme/IntUiDarkTheme$Icons;
+	public fun getColorPalette ()Ljava/util/Map;
+	public fun getIconOverrides ()Ljava/util/Map;
+	public fun getSelectionColorPalette ()Ljava/util/Map;
+	public fun selectionColorMapping ()Ljava/util/Map;
+}
+
+public final class org/jetbrains/jewel/intui/core/theme/IntUiLightTheme : org/jetbrains/jewel/IntelliJThemeDescriptor {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/intui/core/theme/IntUiLightTheme;
+	public synthetic fun getColors ()Lorg/jetbrains/jewel/IntelliJThemeColorPalette;
+	public fun getColors ()Lorg/jetbrains/jewel/intui/core/IntUiThemeColorPalette;
+	public fun getIcons ()Lorg/jetbrains/jewel/IntelliJThemeIconData;
+	public fun getName ()Ljava/lang/String;
+	public fun isDark ()Z
+}
+
+public final class org/jetbrains/jewel/intui/core/theme/IntUiLightTheme$Colors : org/jetbrains/jewel/intui/core/IntUiThemeColorPalette {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/intui/core/theme/IntUiLightTheme$Colors;
+	public fun blue ()Ljava/util/List;
+	public fun blue-vNxB06k (I)J
+	public final fun getBlue1-0d7_KjU ()J
+	public final fun getBlue10-0d7_KjU ()J
+	public final fun getBlue11-0d7_KjU ()J
+	public final fun getBlue12-0d7_KjU ()J
+	public final fun getBlue13-0d7_KjU ()J
+	public final fun getBlue2-0d7_KjU ()J
+	public final fun getBlue3-0d7_KjU ()J
+	public final fun getBlue4-0d7_KjU ()J
+	public final fun getBlue5-0d7_KjU ()J
+	public final fun getBlue6-0d7_KjU ()J
+	public final fun getBlue7-0d7_KjU ()J
+	public final fun getBlue8-0d7_KjU ()J
+	public final fun getBlue9-0d7_KjU ()J
+	public final fun getGreen1-0d7_KjU ()J
+	public final fun getGreen10-0d7_KjU ()J
+	public final fun getGreen11-0d7_KjU ()J
+	public final fun getGreen2-0d7_KjU ()J
+	public final fun getGreen3-0d7_KjU ()J
+	public final fun getGreen4-0d7_KjU ()J
+	public final fun getGreen5-0d7_KjU ()J
+	public final fun getGreen6-0d7_KjU ()J
+	public final fun getGreen7-0d7_KjU ()J
+	public final fun getGreen8-0d7_KjU ()J
+	public final fun getGreen9-0d7_KjU ()J
+	public final fun getGrey1-0d7_KjU ()J
+	public final fun getGrey10-0d7_KjU ()J
+	public final fun getGrey11-0d7_KjU ()J
+	public final fun getGrey12-0d7_KjU ()J
+	public final fun getGrey13-0d7_KjU ()J
+	public final fun getGrey14-0d7_KjU ()J
+	public final fun getGrey2-0d7_KjU ()J
+	public final fun getGrey3-0d7_KjU ()J
+	public final fun getGrey4-0d7_KjU ()J
+	public final fun getGrey5-0d7_KjU ()J
+	public final fun getGrey6-0d7_KjU ()J
+	public final fun getGrey7-0d7_KjU ()J
+	public final fun getGrey8-0d7_KjU ()J
+	public final fun getGrey9-0d7_KjU ()J
+	public final fun getOrange1-0d7_KjU ()J
+	public final fun getOrange2-0d7_KjU ()J
+	public final fun getOrange3-0d7_KjU ()J
+	public final fun getOrange4-0d7_KjU ()J
+	public final fun getOrange5-0d7_KjU ()J
+	public final fun getOrange6-0d7_KjU ()J
+	public final fun getOrange7-0d7_KjU ()J
+	public final fun getOrange8-0d7_KjU ()J
+	public final fun getOrange9-0d7_KjU ()J
+	public final fun getPurple1-0d7_KjU ()J
+	public final fun getPurple2-0d7_KjU ()J
+	public final fun getPurple3-0d7_KjU ()J
+	public final fun getPurple4-0d7_KjU ()J
+	public final fun getPurple5-0d7_KjU ()J
+	public final fun getPurple6-0d7_KjU ()J
+	public final fun getPurple7-0d7_KjU ()J
+	public final fun getPurple8-0d7_KjU ()J
+	public final fun getPurple9-0d7_KjU ()J
+	public fun getRawMap ()Ljava/util/Map;
+	public final fun getRed1-0d7_KjU ()J
+	public final fun getRed10-0d7_KjU ()J
+	public final fun getRed11-0d7_KjU ()J
+	public final fun getRed2-0d7_KjU ()J
+	public final fun getRed3-0d7_KjU ()J
+	public final fun getRed4-0d7_KjU ()J
+	public final fun getRed5-0d7_KjU ()J
+	public final fun getRed6-0d7_KjU ()J
+	public final fun getRed7-0d7_KjU ()J
+	public final fun getRed8-0d7_KjU ()J
+	public final fun getRed9-0d7_KjU ()J
+	public final fun getTeal1-0d7_KjU ()J
+	public final fun getTeal2-0d7_KjU ()J
+	public final fun getTeal3-0d7_KjU ()J
+	public final fun getTeal4-0d7_KjU ()J
+	public final fun getTeal5-0d7_KjU ()J
+	public final fun getTeal6-0d7_KjU ()J
+	public final fun getTeal7-0d7_KjU ()J
+	public final fun getTeal8-0d7_KjU ()J
+	public final fun getTeal9-0d7_KjU ()J
+	public final fun getWindowsPopupBorder-0d7_KjU ()J
+	public final fun getYellow1-0d7_KjU ()J
+	public final fun getYellow10-0d7_KjU ()J
+	public final fun getYellow2-0d7_KjU ()J
+	public final fun getYellow3-0d7_KjU ()J
+	public final fun getYellow4-0d7_KjU ()J
+	public final fun getYellow5-0d7_KjU ()J
+	public final fun getYellow6-0d7_KjU ()J
+	public final fun getYellow7-0d7_KjU ()J
+	public final fun getYellow8-0d7_KjU ()J
+	public final fun getYellow9-0d7_KjU ()J
+	public fun green ()Ljava/util/List;
+	public fun green-vNxB06k (I)J
+	public fun grey ()Ljava/util/List;
+	public fun grey-vNxB06k (I)J
+	public fun lookup-ijrfgN4 (Ljava/lang/String;)Landroidx/compose/ui/graphics/Color;
+	public fun orange ()Ljava/util/List;
+	public fun orange-vNxB06k (I)J
+	public fun purple ()Ljava/util/List;
+	public fun purple-vNxB06k (I)J
+	public fun red ()Ljava/util/List;
+	public fun red-vNxB06k (I)J
+	public fun teal ()Ljava/util/List;
+	public fun teal-vNxB06k (I)J
+	public fun yellow ()Ljava/util/List;
+	public fun yellow-vNxB06k (I)J
+}
+
+public final class org/jetbrains/jewel/intui/core/theme/IntUiLightTheme$Icons : org/jetbrains/jewel/IntelliJThemeIconData {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/intui/core/theme/IntUiLightTheme$Icons;
+	public fun getColorPalette ()Ljava/util/Map;
+	public fun getIconOverrides ()Ljava/util/Map;
+	public fun getSelectionColorPalette ()Ljava/util/Map;
+	public fun selectionColorMapping ()Ljava/util/Map;
+}
+

--- a/int-ui/int-ui-core/build.gradle.kts
+++ b/int-ui/int-ui-core/build.gradle.kts
@@ -3,6 +3,7 @@
 plugins {
     jewel
     `jewel-publish`
+    `jewel-check-public-api`
     alias(libs.plugins.composeDesktop)
     `intellij-theme-generator`
 }

--- a/int-ui/int-ui-core/src/main/kotlin/org/jetbrains/jewel/intui/core/IntUiThemeDefinition.kt
+++ b/int-ui/int-ui-core/src/main/kotlin/org/jetbrains/jewel/intui/core/IntUiThemeDefinition.kt
@@ -3,6 +3,7 @@ package org.jetbrains.jewel.intui.core
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
+import org.jetbrains.jewel.GenerateDataFunctions
 import org.jetbrains.jewel.GlobalColors
 import org.jetbrains.jewel.GlobalMetrics
 import org.jetbrains.jewel.IntelliJThemeDefinition

--- a/int-ui/int-ui-core/src/main/kotlin/org/jetbrains/jewel/intui/core/IntUiThemeDefinition.kt
+++ b/int-ui/int-ui-core/src/main/kotlin/org/jetbrains/jewel/intui/core/IntUiThemeDefinition.kt
@@ -3,14 +3,13 @@ package org.jetbrains.jewel.intui.core
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
-import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.GlobalColors
 import org.jetbrains.jewel.GlobalMetrics
 import org.jetbrains.jewel.IntelliJThemeDefinition
 import org.jetbrains.jewel.IntelliJThemeIconData
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiThemeDefinition(
     override val isDark: Boolean,
     override val globalColors: GlobalColors,

--- a/int-ui/int-ui-core/src/main/kotlin/org/jetbrains/jewel/intui/core/IntUiThemeDefinition.kt
+++ b/int-ui/int-ui-core/src/main/kotlin/org/jetbrains/jewel/intui/core/IntUiThemeDefinition.kt
@@ -3,12 +3,14 @@ package org.jetbrains.jewel.intui.core
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
+import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.GlobalColors
 import org.jetbrains.jewel.GlobalMetrics
 import org.jetbrains.jewel.IntelliJThemeDefinition
 import org.jetbrains.jewel.IntelliJThemeIconData
 
 @Immutable
+@Poko
 class IntUiThemeDefinition(
     override val isDark: Boolean,
     override val globalColors: GlobalColors,
@@ -17,51 +19,4 @@ class IntUiThemeDefinition(
     override val globalMetrics: GlobalMetrics,
     override val defaultTextStyle: TextStyle,
     override val contentColor: Color,
-) : IntelliJThemeDefinition {
-
-    fun copy(
-        isDark: Boolean = this.isDark,
-        globalColors: GlobalColors = this.globalColors,
-        colorPalette: IntUiThemeColorPalette = this.colorPalette,
-        iconData: IntelliJThemeIconData = this.iconData,
-        globalMetrics: GlobalMetrics = this.globalMetrics,
-        defaultTextStyle: TextStyle = this.defaultTextStyle,
-        contentColor: Color = this.contentColor,
-    ): IntUiThemeDefinition = IntUiThemeDefinition(
-        isDark = isDark,
-        globalColors = globalColors,
-        colorPalette = colorPalette,
-        iconData = iconData,
-        globalMetrics = globalMetrics,
-        defaultTextStyle = defaultTextStyle,
-        contentColor = contentColor,
-    )
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as IntUiThemeDefinition
-
-        if (isDark != other.isDark) return false
-        if (globalColors != other.globalColors) return false
-        if (colorPalette != other.colorPalette) return false
-        if (iconData != other.iconData) return false
-        if (globalMetrics != other.globalMetrics) return false
-        if (defaultTextStyle != other.defaultTextStyle) return false
-        if (contentColor != other.contentColor) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = isDark.hashCode()
-        result = 31 * result + globalColors.hashCode()
-        result = 31 * result + colorPalette.hashCode()
-        result = 31 * result + iconData.hashCode()
-        result = 31 * result + globalMetrics.hashCode()
-        result = 31 * result + defaultTextStyle.hashCode()
-        result = 31 * result + contentColor.hashCode()
-        return result
-    }
-}
+) : IntelliJThemeDefinition

--- a/int-ui/int-ui-decorated-window/api/int-ui-decorated-window.api
+++ b/int-ui/int-ui-decorated-window/api/int-ui-decorated-window.api
@@ -1,0 +1,143 @@
+public final class org/jetbrains/jewel/intui/window/IntUiDecoratedWindowResourceResolverKt {
+	public static final fun decoratedWindowPainterProvider (Ljava/lang/String;)Lorg/jetbrains/jewel/painter/ResourcePainterProvider;
+}
+
+public final class org/jetbrains/jewel/intui/window/IntUiThemeKt {
+	public static final fun decoratedWindowComponentStyling (Lorg/jetbrains/jewel/intui/core/IntUiThemeDefinition;Lorg/jetbrains/jewel/intui/window/styling/IntUiDecoratedWindowStyle;Lorg/jetbrains/jewel/window/styling/TitleBarStyle;Landroidx/compose/runtime/Composer;II)[Landroidx/compose/runtime/ProvidedValue;
+}
+
+public final class org/jetbrains/jewel/intui/window/styling/IntUiDecoratedWindowColors : org/jetbrains/jewel/window/styling/DecoratedWindowColors {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/window/styling/IntUiDecoratedWindowColors$Companion;
+	public synthetic fun <init> (JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun borderFor-3hEOMOc (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBorder-0d7_KjU ()J
+	public fun getBorderInactive-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/window/styling/IntUiDecoratedWindowColors$Companion {
+	public final fun dark-dgg9oW8 (JJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/window/styling/IntUiDecoratedWindowColors;
+	public final fun light-dgg9oW8 (JJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/window/styling/IntUiDecoratedWindowColors;
+}
+
+public final class org/jetbrains/jewel/intui/window/styling/IntUiDecoratedWindowMetrics : org/jetbrains/jewel/window/styling/DecoratedWindowMetrics {
+	public static final field $stable I
+	public synthetic fun <init> (FILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (FLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBorderWidth-D9Ej5fM ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/window/styling/IntUiDecoratedWindowStyle : org/jetbrains/jewel/window/styling/DecoratedWindowStyle {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/window/styling/IntUiDecoratedWindowStyle$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/intui/window/styling/IntUiDecoratedWindowColors;Lorg/jetbrains/jewel/intui/window/styling/IntUiDecoratedWindowMetrics;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getColors ()Lorg/jetbrains/jewel/intui/window/styling/IntUiDecoratedWindowColors;
+	public synthetic fun getColors ()Lorg/jetbrains/jewel/window/styling/DecoratedWindowColors;
+	public fun getMetrics ()Lorg/jetbrains/jewel/intui/window/styling/IntUiDecoratedWindowMetrics;
+	public synthetic fun getMetrics ()Lorg/jetbrains/jewel/window/styling/DecoratedWindowMetrics;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/window/styling/IntUiDecoratedWindowStyle$Companion {
+	public final fun dark (Lorg/jetbrains/jewel/intui/window/styling/IntUiDecoratedWindowColors;Lorg/jetbrains/jewel/intui/window/styling/IntUiDecoratedWindowMetrics;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/window/styling/IntUiDecoratedWindowStyle;
+	public final fun light (Lorg/jetbrains/jewel/intui/window/styling/IntUiDecoratedWindowColors;Lorg/jetbrains/jewel/intui/window/styling/IntUiDecoratedWindowMetrics;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/window/styling/IntUiDecoratedWindowStyle;
+}
+
+public final class org/jetbrains/jewel/intui/window/styling/IntUiTitleBarColors : org/jetbrains/jewel/window/styling/TitleBarColors {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/window/styling/IntUiTitleBarColors$Companion;
+	public synthetic fun <init> (JJJJJJJJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun backgroundFor-3hEOMOc (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBackground-0d7_KjU ()J
+	public fun getBorder-0d7_KjU ()J
+	public fun getContent-0d7_KjU ()J
+	public fun getDropdownHoverBackground-0d7_KjU ()J
+	public fun getDropdownPressBackground-0d7_KjU ()J
+	public fun getFullscreenControlButtonsBackground-0d7_KjU ()J
+	public fun getIconButtonHoverBackground-0d7_KjU ()J
+	public fun getIconButtonPressBackground-0d7_KjU ()J
+	public fun getInactiveBackground-0d7_KjU ()J
+	public fun getTitlePaneButtonHoverBackground-0d7_KjU ()J
+	public fun getTitlePaneButtonPressBackground-0d7_KjU ()J
+	public fun getTitlePaneCloseButtonHoverBackground-0d7_KjU ()J
+	public fun getTitlePaneCloseButtonPressBackground-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/window/styling/IntUiTitleBarColors$Companion {
+	public final fun dark-kwJvTHA (JJJJJJJJJJJJJLandroidx/compose/runtime/Composer;III)Lorg/jetbrains/jewel/intui/window/styling/IntUiTitleBarColors;
+	public final fun light-kwJvTHA (JJJJJJJJJJJJJLandroidx/compose/runtime/Composer;III)Lorg/jetbrains/jewel/intui/window/styling/IntUiTitleBarColors;
+	public final fun lightWithLightHeader-kwJvTHA (JJJJJJJJJJJJJLandroidx/compose/runtime/Composer;III)Lorg/jetbrains/jewel/intui/window/styling/IntUiTitleBarColors;
+}
+
+public final class org/jetbrains/jewel/intui/window/styling/IntUiTitleBarIcons : org/jetbrains/jewel/window/styling/TitleBarIcons {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/window/styling/IntUiTitleBarIcons$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/painter/PainterProvider;Lorg/jetbrains/jewel/painter/PainterProvider;Lorg/jetbrains/jewel/painter/PainterProvider;Lorg/jetbrains/jewel/painter/PainterProvider;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getCloseButton ()Lorg/jetbrains/jewel/painter/PainterProvider;
+	public fun getMaximizeButton ()Lorg/jetbrains/jewel/painter/PainterProvider;
+	public fun getMinimizeButton ()Lorg/jetbrains/jewel/painter/PainterProvider;
+	public fun getRestoreButton ()Lorg/jetbrains/jewel/painter/PainterProvider;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/window/styling/IntUiTitleBarIcons$Companion {
+	public final fun close (Ljava/lang/String;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/painter/PainterProvider;
+	public final fun maximize (Ljava/lang/String;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/painter/PainterProvider;
+	public final fun minimize (Ljava/lang/String;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/painter/PainterProvider;
+	public final fun restore (Ljava/lang/String;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/painter/PainterProvider;
+}
+
+public final class org/jetbrains/jewel/intui/window/styling/IntUiTitleBarMetrics : org/jetbrains/jewel/window/styling/TitleBarMetrics {
+	public static final field $stable I
+	public synthetic fun <init> (FFFJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (FFFJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getGradientEndX-D9Ej5fM ()F
+	public fun getGradientStartX-D9Ej5fM ()F
+	public fun getHeight-D9Ej5fM ()F
+	public fun getTitlePaneButtonSize-MYxV2XQ ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/window/styling/IntUiTitleBarStyle : org/jetbrains/jewel/window/styling/TitleBarStyle {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/window/styling/IntUiTitleBarStyle$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/intui/window/styling/IntUiTitleBarColors;Lorg/jetbrains/jewel/intui/window/styling/IntUiTitleBarMetrics;Lorg/jetbrains/jewel/window/styling/TitleBarIcons;Lorg/jetbrains/jewel/styling/DropdownStyle;Lorg/jetbrains/jewel/styling/IconButtonStyle;Lorg/jetbrains/jewel/styling/IconButtonStyle;Lorg/jetbrains/jewel/styling/IconButtonStyle;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getColors ()Lorg/jetbrains/jewel/intui/window/styling/IntUiTitleBarColors;
+	public synthetic fun getColors ()Lorg/jetbrains/jewel/window/styling/TitleBarColors;
+	public fun getDropdownStyle ()Lorg/jetbrains/jewel/styling/DropdownStyle;
+	public fun getIconButtonStyle ()Lorg/jetbrains/jewel/styling/IconButtonStyle;
+	public fun getIcons ()Lorg/jetbrains/jewel/window/styling/TitleBarIcons;
+	public fun getMetrics ()Lorg/jetbrains/jewel/intui/window/styling/IntUiTitleBarMetrics;
+	public synthetic fun getMetrics ()Lorg/jetbrains/jewel/window/styling/TitleBarMetrics;
+	public fun getPaneButtonStyle ()Lorg/jetbrains/jewel/styling/IconButtonStyle;
+	public fun getPaneCloseButtonStyle ()Lorg/jetbrains/jewel/styling/IconButtonStyle;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/window/styling/IntUiTitleBarStyle$Companion {
+	public final fun dark (Lorg/jetbrains/jewel/intui/window/styling/IntUiTitleBarColors;Lorg/jetbrains/jewel/intui/window/styling/IntUiTitleBarMetrics;Lorg/jetbrains/jewel/intui/window/styling/IntUiTitleBarIcons;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/window/styling/IntUiTitleBarStyle;
+	public final fun light (Lorg/jetbrains/jewel/intui/window/styling/IntUiTitleBarColors;Lorg/jetbrains/jewel/intui/window/styling/IntUiTitleBarMetrics;Lorg/jetbrains/jewel/intui/window/styling/IntUiTitleBarIcons;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/window/styling/IntUiTitleBarStyle;
+	public final fun lightWithLightHeader (Lorg/jetbrains/jewel/intui/window/styling/IntUiTitleBarColors;Lorg/jetbrains/jewel/intui/window/styling/IntUiTitleBarMetrics;Lorg/jetbrains/jewel/intui/window/styling/IntUiTitleBarIcons;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/window/styling/IntUiTitleBarStyle;
+}
+
+public final class org/jetbrains/jewel/intui/window/styling/IntUiTitleBarStylingKt {
+	public static final fun intUiTitleBarIcons (Lorg/jetbrains/jewel/painter/PainterProvider;Lorg/jetbrains/jewel/painter/PainterProvider;Lorg/jetbrains/jewel/painter/PainterProvider;Lorg/jetbrains/jewel/painter/PainterProvider;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/window/styling/IntUiTitleBarIcons;
+}
+

--- a/int-ui/int-ui-decorated-window/build.gradle.kts
+++ b/int-ui/int-ui-decorated-window/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     jewel
     `jewel-publish`
+    `jewel-check-public-api`
     alias(libs.plugins.composeDesktop)
 }
 

--- a/int-ui/int-ui-standalone/api/int-ui-standalone.api
+++ b/int-ui/int-ui-standalone/api/int-ui-standalone.api
@@ -1,0 +1,1505 @@
+public final class org/jetbrains/jewel/intui/standalone/IntUiBorderColors : org/jetbrains/jewel/BorderColors {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/IntUiBorderColors$Companion;
+	public synthetic fun <init> (JJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDisabled-0d7_KjU ()J
+	public fun getFocused-0d7_KjU ()J
+	public fun getNormal-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/IntUiBorderColors$Companion {
+	public final fun dark-RGew2ao (JJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/IntUiBorderColors;
+	public final fun light-RGew2ao (JJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/IntUiBorderColors;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/IntUiGlobalColors : org/jetbrains/jewel/GlobalColors {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/IntUiGlobalColors$Companion;
+	public synthetic fun <init> (Lorg/jetbrains/jewel/BorderColors;Lorg/jetbrains/jewel/OutlineColors;JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBorders ()Lorg/jetbrains/jewel/BorderColors;
+	public fun getInfoContent-0d7_KjU ()J
+	public fun getOutlines ()Lorg/jetbrains/jewel/OutlineColors;
+	public fun getPaneBackground-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/IntUiGlobalColors$Companion {
+	public final fun dark-eaDK9VM (Lorg/jetbrains/jewel/BorderColors;Lorg/jetbrains/jewel/OutlineColors;JJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/IntUiGlobalColors;
+	public final fun light-eaDK9VM (Lorg/jetbrains/jewel/BorderColors;Lorg/jetbrains/jewel/OutlineColors;JJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/IntUiGlobalColors;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/IntUiGlobalMetrics : org/jetbrains/jewel/GlobalMetrics {
+	public static final field $stable I
+	public synthetic fun <init> (FFILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (FFLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getOutlineWidth-D9Ej5fM ()F
+	public fun getRowHeight-D9Ej5fM ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/IntUiOutlineColors : org/jetbrains/jewel/OutlineColors {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/IntUiOutlineColors$Companion;
+	public synthetic fun <init> (JJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getError-0d7_KjU ()J
+	public fun getFocused-0d7_KjU ()J
+	public fun getFocusedError-0d7_KjU ()J
+	public fun getFocusedWarning-0d7_KjU ()J
+	public fun getWarning-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/IntUiOutlineColors$Companion {
+	public final fun dark-zjMxDiM (JJJJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/IntUiOutlineColors;
+	public final fun light-zjMxDiM (JJJJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/IntUiOutlineColors;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/IntUiTheme : org/jetbrains/jewel/intui/core/BaseIntUiTheme {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/intui/standalone/IntUiTheme;
+	public final fun darkComponentStyling (Lorg/jetbrains/jewel/styling/ButtonStyle;Lorg/jetbrains/jewel/styling/ButtonStyle;Lorg/jetbrains/jewel/styling/CheckboxStyle;Lorg/jetbrains/jewel/styling/ChipStyle;Lorg/jetbrains/jewel/styling/DividerStyle;Lorg/jetbrains/jewel/styling/DropdownStyle;Lorg/jetbrains/jewel/styling/GroupHeaderStyle;Lorg/jetbrains/jewel/styling/LabelledTextFieldStyle;Lorg/jetbrains/jewel/styling/LinkStyle;Lorg/jetbrains/jewel/styling/MenuStyle;Lorg/jetbrains/jewel/styling/HorizontalProgressBarStyle;Lorg/jetbrains/jewel/styling/RadioButtonStyle;Lorg/jetbrains/jewel/styling/ScrollbarStyle;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaStyle;Lorg/jetbrains/jewel/styling/TextFieldStyle;Lorg/jetbrains/jewel/styling/LazyTreeStyle;Lorg/jetbrains/jewel/styling/TabStyle;Lorg/jetbrains/jewel/styling/TabStyle;Lorg/jetbrains/jewel/styling/CircularProgressStyle;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTooltipStyle;Lorg/jetbrains/jewel/styling/IconButtonStyle;Landroidx/compose/runtime/Composer;IIII)Lorg/jetbrains/jewel/IntelliJComponentStyling;
+	public final fun darkThemeDefinition-V-9fs2A (Lorg/jetbrains/jewel/GlobalColors;Lorg/jetbrains/jewel/GlobalMetrics;Lorg/jetbrains/jewel/intui/core/IntUiThemeColorPalette;Lorg/jetbrains/jewel/IntelliJThemeIconData;Landroidx/compose/ui/text/TextStyle;JLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/core/IntUiThemeDefinition;
+	public final fun defaultComponentStyling (Lorg/jetbrains/jewel/intui/core/IntUiThemeDefinition;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/IntelliJComponentStyling;
+	public fun getCheckboxStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/CheckboxStyle;
+	public fun getChipStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/ChipStyle;
+	public fun getCircularProgressStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/CircularProgressStyle;
+	public fun getColorPalette (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/intui/core/IntUiThemeColorPalette;
+	public fun getContentColor (Landroidx/compose/runtime/Composer;I)J
+	public fun getDefaultButtonStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/ButtonStyle;
+	public fun getDefaultTabStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/TabStyle;
+	public final fun getDefaultTextStyle ()Landroidx/compose/ui/text/TextStyle;
+	public fun getDividerStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/DividerStyle;
+	public fun getDropdownStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/DropdownStyle;
+	public fun getEditorTabStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/TabStyle;
+	public fun getGlobalColors (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/GlobalColors;
+	public fun getGlobalMetrics (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/GlobalMetrics;
+	public fun getGroupHeaderStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/GroupHeaderStyle;
+	public fun getHorizontalProgressBarStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/HorizontalProgressBarStyle;
+	public fun getIconData (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/IntelliJThemeIconData;
+	public fun getLabelledTextFieldStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/LabelledTextFieldStyle;
+	public fun getLinkStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/LinkStyle;
+	public fun getMenuStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/MenuStyle;
+	public fun getOutlinedButtonStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/ButtonStyle;
+	public fun getRadioButtonStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/RadioButtonStyle;
+	public fun getScrollbarStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/ScrollbarStyle;
+	public fun getTextAreaStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/TextAreaStyle;
+	public fun getTextFieldStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/TextFieldStyle;
+	public fun getTextStyle (Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/text/TextStyle;
+	public fun getTreeStyle (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/styling/LazyTreeStyle;
+	public fun isDark (Landroidx/compose/runtime/Composer;I)Z
+	public fun isSwingCompatMode (Landroidx/compose/runtime/Composer;I)Z
+	public final fun lightComponentStyling (Lorg/jetbrains/jewel/styling/ButtonStyle;Lorg/jetbrains/jewel/styling/ButtonStyle;Lorg/jetbrains/jewel/styling/CheckboxStyle;Lorg/jetbrains/jewel/styling/ChipStyle;Lorg/jetbrains/jewel/styling/DividerStyle;Lorg/jetbrains/jewel/styling/DropdownStyle;Lorg/jetbrains/jewel/styling/GroupHeaderStyle;Lorg/jetbrains/jewel/styling/LabelledTextFieldStyle;Lorg/jetbrains/jewel/styling/LinkStyle;Lorg/jetbrains/jewel/styling/MenuStyle;Lorg/jetbrains/jewel/styling/HorizontalProgressBarStyle;Lorg/jetbrains/jewel/styling/RadioButtonStyle;Lorg/jetbrains/jewel/styling/ScrollbarStyle;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaStyle;Lorg/jetbrains/jewel/styling/TextFieldStyle;Lorg/jetbrains/jewel/styling/LazyTreeStyle;Lorg/jetbrains/jewel/styling/TabStyle;Lorg/jetbrains/jewel/styling/TabStyle;Lorg/jetbrains/jewel/styling/CircularProgressStyle;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTooltipStyle;Lorg/jetbrains/jewel/styling/IconButtonStyle;Landroidx/compose/runtime/Composer;IIII)Lorg/jetbrains/jewel/IntelliJComponentStyling;
+	public final fun lightThemeDefinition-V-9fs2A (Lorg/jetbrains/jewel/GlobalColors;Lorg/jetbrains/jewel/GlobalMetrics;Lorg/jetbrains/jewel/intui/core/IntUiThemeColorPalette;Lorg/jetbrains/jewel/IntelliJThemeIconData;Landroidx/compose/ui/text/TextStyle;JLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/core/IntUiThemeDefinition;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/IntUiThemeKt {
+	public static final fun IntUiTheme (Lorg/jetbrains/jewel/intui/core/IntUiThemeDefinition;Lkotlin/jvm/functions/Function2;ZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+}
+
+public final class org/jetbrains/jewel/intui/standalone/InterFontKt {
+	public static final fun getInter (Landroidx/compose/ui/text/font/FontFamily$Companion;)Landroidx/compose/ui/text/font/FontFamily;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/PainterProviderKt {
+	public static final fun standalonePainterProvider (Ljava/lang/String;)Lorg/jetbrains/jewel/painter/ResourcePainterProvider;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/StandalonePainterHintsProvider : org/jetbrains/jewel/intui/core/IntUiPainterHintsProvider {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/StandalonePainterHintsProvider$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/intui/core/IntUiThemeDefinition;)V
+	public fun hints (Ljava/lang/String;Landroidx/compose/runtime/Composer;I)Ljava/util/List;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/StandalonePainterHintsProvider$Companion {
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiButtonColors : org/jetbrains/jewel/styling/ButtonColors {
+	public static final field $stable I
+	public synthetic fun <init> (Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;JJJJJLandroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun backgroundFor-RO59lCw (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun borderFor-RO59lCw (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun contentFor-RO59lCw (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBackground ()Landroidx/compose/ui/graphics/Brush;
+	public fun getBackgroundDisabled ()Landroidx/compose/ui/graphics/Brush;
+	public fun getBackgroundFocused ()Landroidx/compose/ui/graphics/Brush;
+	public fun getBackgroundHovered ()Landroidx/compose/ui/graphics/Brush;
+	public fun getBackgroundPressed ()Landroidx/compose/ui/graphics/Brush;
+	public fun getBorder ()Landroidx/compose/ui/graphics/Brush;
+	public fun getBorderDisabled ()Landroidx/compose/ui/graphics/Brush;
+	public fun getBorderFocused ()Landroidx/compose/ui/graphics/Brush;
+	public fun getBorderHovered ()Landroidx/compose/ui/graphics/Brush;
+	public fun getBorderPressed ()Landroidx/compose/ui/graphics/Brush;
+	public fun getContent-0d7_KjU ()J
+	public fun getContentDisabled-0d7_KjU ()J
+	public fun getContentFocused-0d7_KjU ()J
+	public fun getContentHovered-0d7_KjU ()J
+	public fun getContentPressed-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiButtonColors$Default {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonColors$Default;
+	public final fun dark-AckW74Y (Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;JJJJJLandroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/runtime/Composer;III)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonColors;
+	public final fun light-AckW74Y (Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;JJJJJLandroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/runtime/Composer;III)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonColors;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiButtonColors$Outlined {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonColors$Outlined;
+	public final fun dark-AckW74Y (Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;JJJJJLandroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/runtime/Composer;III)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonColors;
+	public final fun light-AckW74Y (Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;JJJJJLandroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/runtime/Composer;III)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonColors;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiButtonMetrics : org/jetbrains/jewel/styling/ButtonMetrics {
+	public static final field $stable I
+	public synthetic fun <init> (Landroidx/compose/foundation/shape/CornerSize;Landroidx/compose/foundation/layout/PaddingValues;JFLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBorderWidth-D9Ej5fM ()F
+	public fun getCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public fun getMinSize-MYxV2XQ ()J
+	public fun getPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiButtonMetrics$Default {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonMetrics$Default;
+	public final fun create-wlUqFBo (Landroidx/compose/foundation/shape/CornerSize;Landroidx/compose/foundation/layout/PaddingValues;JF)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonMetrics;
+	public static synthetic fun create-wlUqFBo$default (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonMetrics$Default;Landroidx/compose/foundation/shape/CornerSize;Landroidx/compose/foundation/layout/PaddingValues;JFILjava/lang/Object;)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonMetrics;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiButtonMetrics$Outlined {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonMetrics$Outlined;
+	public final fun create-wlUqFBo (Landroidx/compose/foundation/shape/CornerSize;Landroidx/compose/foundation/layout/PaddingValues;JF)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonMetrics;
+	public static synthetic fun create-wlUqFBo$default (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonMetrics$Outlined;Landroidx/compose/foundation/shape/CornerSize;Landroidx/compose/foundation/layout/PaddingValues;JFILjava/lang/Object;)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonMetrics;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiButtonStyle : org/jetbrains/jewel/styling/ButtonStyle {
+	public static final field $stable I
+	public fun <init> (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonMetrics;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getColors ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonColors;
+	public synthetic fun getColors ()Lorg/jetbrains/jewel/styling/ButtonColors;
+	public fun getMetrics ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonMetrics;
+	public synthetic fun getMetrics ()Lorg/jetbrains/jewel/styling/ButtonMetrics;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiButtonStyle$Default {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonStyle$Default;
+	public final fun dark (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonMetrics;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/styling/ButtonStyle;
+	public final fun light (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonMetrics;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/styling/ButtonStyle;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiButtonStyle$Outlined {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonStyle$Outlined;
+	public final fun dark (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonMetrics;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/styling/ButtonStyle;
+	public final fun light (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiButtonMetrics;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/styling/ButtonStyle;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxColors : org/jetbrains/jewel/styling/CheckboxColors {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxColors$Companion;
+	public synthetic fun <init> (JJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun backgroundFor-An7rHrs (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun contentFor-An7rHrs (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getCheckboxBackground-0d7_KjU ()J
+	public fun getCheckboxBackgroundDisabled-0d7_KjU ()J
+	public fun getCheckboxBackgroundSelected-0d7_KjU ()J
+	public fun getContent-0d7_KjU ()J
+	public fun getContentDisabled-0d7_KjU ()J
+	public fun getContentSelected-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxColors$Companion {
+	public final fun dark-5tl4gsc (JJJJJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxColors;
+	public final fun light-5tl4gsc (JJJJJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxColors;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxIcons : org/jetbrains/jewel/styling/CheckboxIcons {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxIcons$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/painter/PainterProvider;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getCheckbox ()Lorg/jetbrains/jewel/painter/PainterProvider;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxIcons$Companion {
+	public final fun checkbox (Ljava/lang/String;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/painter/PainterProvider;
+	public final fun dark (Lorg/jetbrains/jewel/painter/PainterProvider;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxIcons;
+	public final fun light (Lorg/jetbrains/jewel/painter/PainterProvider;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxIcons;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxMetrics : org/jetbrains/jewel/styling/CheckboxMetrics {
+	public static final field $stable I
+	public synthetic fun <init> (JLandroidx/compose/foundation/shape/CornerSize;JJFILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLandroidx/compose/foundation/shape/CornerSize;JJFLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getCheckboxCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public fun getCheckboxSize-MYxV2XQ ()J
+	public fun getIconContentGap-D9Ej5fM ()F
+	public fun getOutlineOffset-RKDOV3M ()J
+	public fun getOutlineSize-MYxV2XQ ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxStyle : org/jetbrains/jewel/styling/CheckboxStyle {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxStyle$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxMetrics;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxIcons;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getColors ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxColors;
+	public synthetic fun getColors ()Lorg/jetbrains/jewel/styling/CheckboxColors;
+	public fun getIcons ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxIcons;
+	public synthetic fun getIcons ()Lorg/jetbrains/jewel/styling/CheckboxIcons;
+	public fun getMetrics ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxMetrics;
+	public synthetic fun getMetrics ()Lorg/jetbrains/jewel/styling/CheckboxMetrics;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxStyle$Companion {
+	public final fun dark (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxMetrics;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxIcons;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxStyle;
+	public final fun light (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxMetrics;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxIcons;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxStyle;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiChipColors : org/jetbrains/jewel/styling/ChipColors {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiChipColors$Companion;
+	public synthetic fun <init> (Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;JJJJJJJJJJJJJJJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun backgroundFor-z6rh5VY (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun borderFor-z6rh5VY (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun contentFor-z6rh5VY (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBackground ()Landroidx/compose/ui/graphics/Brush;
+	public fun getBackgroundDisabled ()Landroidx/compose/ui/graphics/Brush;
+	public fun getBackgroundFocused ()Landroidx/compose/ui/graphics/Brush;
+	public fun getBackgroundHovered ()Landroidx/compose/ui/graphics/Brush;
+	public fun getBackgroundPressed ()Landroidx/compose/ui/graphics/Brush;
+	public fun getBackgroundSelected ()Landroidx/compose/ui/graphics/Brush;
+	public fun getBackgroundSelectedDisabled ()Landroidx/compose/ui/graphics/Brush;
+	public fun getBackgroundSelectedFocused ()Landroidx/compose/ui/graphics/Brush;
+	public fun getBackgroundSelectedHovered ()Landroidx/compose/ui/graphics/Brush;
+	public fun getBackgroundSelectedPressed ()Landroidx/compose/ui/graphics/Brush;
+	public fun getBorder-0d7_KjU ()J
+	public fun getBorderDisabled-0d7_KjU ()J
+	public fun getBorderFocused-0d7_KjU ()J
+	public fun getBorderHovered-0d7_KjU ()J
+	public fun getBorderPressed-0d7_KjU ()J
+	public fun getBorderSelected-0d7_KjU ()J
+	public fun getBorderSelectedDisabled-0d7_KjU ()J
+	public fun getBorderSelectedFocused-0d7_KjU ()J
+	public fun getBorderSelectedHovered-0d7_KjU ()J
+	public fun getBorderSelectedPressed-0d7_KjU ()J
+	public fun getContent-0d7_KjU ()J
+	public fun getContentDisabled-0d7_KjU ()J
+	public fun getContentFocused-0d7_KjU ()J
+	public fun getContentHovered-0d7_KjU ()J
+	public fun getContentPressed-0d7_KjU ()J
+	public fun getContentSelected-0d7_KjU ()J
+	public fun getContentSelectedDisabled-0d7_KjU ()J
+	public fun getContentSelectedFocused-0d7_KjU ()J
+	public fun getContentSelectedHovered-0d7_KjU ()J
+	public fun getContentSelectedPressed-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiChipColors$Companion {
+	public final fun dark-JwitS0g (Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;JJJJJJJJJJJJJJJJJJJJLandroidx/compose/runtime/Composer;IIIII)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiChipColors;
+	public final fun light-JwitS0g (Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;Landroidx/compose/ui/graphics/Brush;JJJJJJJJJJJJJJJJJJJJLandroidx/compose/runtime/Composer;IIIII)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiChipColors;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiChipMetrics : org/jetbrains/jewel/styling/ChipMetrics {
+	public static final field $stable I
+	public synthetic fun <init> (Landroidx/compose/foundation/shape/CornerSize;Landroidx/compose/foundation/layout/PaddingValues;FFILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Landroidx/compose/foundation/shape/CornerSize;Landroidx/compose/foundation/layout/PaddingValues;FFLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBorderWidth-D9Ej5fM ()F
+	public fun getBorderWidthSelected-D9Ej5fM ()F
+	public fun getCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public fun getPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiChipStyle : org/jetbrains/jewel/styling/ChipStyle {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiChipStyle$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiChipColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiChipMetrics;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getColors ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiChipColors;
+	public synthetic fun getColors ()Lorg/jetbrains/jewel/styling/ChipColors;
+	public fun getMetrics ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiChipMetrics;
+	public synthetic fun getMetrics ()Lorg/jetbrains/jewel/styling/ChipMetrics;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiChipStyle$Companion {
+	public final fun dark (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiChipColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiChipMetrics;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiChipStyle;
+	public final fun light (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiChipColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiChipMetrics;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiChipStyle;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiCircularProgressStyle : org/jetbrains/jewel/styling/CircularProgressStyle {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCircularProgressStyle$Companion;
+	public synthetic fun <init> (JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getColor-0d7_KjU ()J
+	public fun getFrameTime-UwyO8pc ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiCircularProgressStyle$Companion {
+	public final fun dark-1Vw8gao (JJ)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCircularProgressStyle;
+	public static synthetic fun dark-1Vw8gao$default (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCircularProgressStyle$Companion;JJILjava/lang/Object;)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCircularProgressStyle;
+	public final fun light-1Vw8gao (JJ)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCircularProgressStyle;
+	public static synthetic fun light-1Vw8gao$default (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCircularProgressStyle$Companion;JJILjava/lang/Object;)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiCircularProgressStyle;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiDividerMetrics : org/jetbrains/jewel/styling/DividerMetrics {
+	public static final field $stable I
+	public synthetic fun <init> (FFILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (FFLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getStartIndent-D9Ej5fM ()F
+	public fun getThickness-D9Ej5fM ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiDividerStyle : org/jetbrains/jewel/styling/DividerStyle {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDividerStyle$Companion;
+	public synthetic fun <init> (JLorg/jetbrains/jewel/styling/DividerMetrics;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getColor-0d7_KjU ()J
+	public fun getMetrics ()Lorg/jetbrains/jewel/styling/DividerMetrics;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiDividerStyle$Companion {
+	public final fun dark-3J-VO9M (JLorg/jetbrains/jewel/intui/standalone/styling/IntUiDividerMetrics;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDividerStyle;
+	public final fun light-3J-VO9M (JLorg/jetbrains/jewel/intui/standalone/styling/IntUiDividerMetrics;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDividerStyle;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiDropdownColors : org/jetbrains/jewel/styling/DropdownColors {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownColors$Companion;
+	public synthetic fun <init> (JJJJJJJJJJJJJJJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun backgroundFor-7I1Rs2w (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun borderFor-7I1Rs2w (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun contentFor-7I1Rs2w (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBackground-0d7_KjU ()J
+	public fun getBackgroundDisabled-0d7_KjU ()J
+	public fun getBackgroundFocused-0d7_KjU ()J
+	public fun getBackgroundHovered-0d7_KjU ()J
+	public fun getBackgroundPressed-0d7_KjU ()J
+	public fun getBorder-0d7_KjU ()J
+	public fun getBorderDisabled-0d7_KjU ()J
+	public fun getBorderFocused-0d7_KjU ()J
+	public fun getBorderHovered-0d7_KjU ()J
+	public fun getBorderPressed-0d7_KjU ()J
+	public fun getContent-0d7_KjU ()J
+	public fun getContentDisabled-0d7_KjU ()J
+	public fun getContentFocused-0d7_KjU ()J
+	public fun getContentHovered-0d7_KjU ()J
+	public fun getContentPressed-0d7_KjU ()J
+	public fun getIconTint-0d7_KjU ()J
+	public fun getIconTintDisabled-0d7_KjU ()J
+	public fun getIconTintFocused-0d7_KjU ()J
+	public fun getIconTintHovered-0d7_KjU ()J
+	public fun getIconTintPressed-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun iconTintFor-7I1Rs2w (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiDropdownColors$Companion {
+	public final fun dark-Xf8s2Ik (JJJJJJJJJJJJJJJJJJJJLandroidx/compose/runtime/Composer;IIII)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownColors;
+	public final fun light-Xf8s2Ik (JJJJJJJJJJJJJJJJJJJJLandroidx/compose/runtime/Composer;IIII)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownColors;
+	public final fun undecorated-5tl4gsc (JJJJJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownColors;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiDropdownIcons : org/jetbrains/jewel/styling/DropdownIcons {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownIcons$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/painter/PainterProvider;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getChevronDown ()Lorg/jetbrains/jewel/painter/PainterProvider;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiDropdownIcons$Companion {
+	public final fun chevronDown (Ljava/lang/String;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/painter/PainterProvider;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiDropdownMetrics : org/jetbrains/jewel/styling/DropdownMetrics {
+	public static final field $stable I
+	public synthetic fun <init> (JJLandroidx/compose/foundation/shape/CornerSize;Landroidx/compose/foundation/layout/PaddingValues;FILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJLandroidx/compose/foundation/shape/CornerSize;Landroidx/compose/foundation/layout/PaddingValues;FLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getArrowMinSize-MYxV2XQ ()J
+	public fun getBorderWidth-D9Ej5fM ()F
+	public fun getContentPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public fun getCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public fun getMinSize-MYxV2XQ ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiDropdownStyle : org/jetbrains/jewel/styling/DropdownStyle {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownStyle$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownMetrics;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownIcons;Landroidx/compose/ui/text/TextStyle;Lorg/jetbrains/jewel/styling/MenuStyle;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getColors ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownColors;
+	public synthetic fun getColors ()Lorg/jetbrains/jewel/styling/DropdownColors;
+	public fun getIcons ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownIcons;
+	public synthetic fun getIcons ()Lorg/jetbrains/jewel/styling/DropdownIcons;
+	public fun getMenuStyle ()Lorg/jetbrains/jewel/styling/MenuStyle;
+	public fun getMetrics ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownMetrics;
+	public synthetic fun getMetrics ()Lorg/jetbrains/jewel/styling/DropdownMetrics;
+	public fun getTextStyle ()Landroidx/compose/ui/text/TextStyle;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiDropdownStyle$Companion {
+	public final fun dark (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownMetrics;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownIcons;Landroidx/compose/ui/text/TextStyle;Lorg/jetbrains/jewel/styling/MenuStyle;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownStyle;
+	public final fun light (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownMetrics;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownIcons;Landroidx/compose/ui/text/TextStyle;Lorg/jetbrains/jewel/styling/MenuStyle;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownStyle;
+	public final fun undecorated (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownMetrics;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownIcons;Landroidx/compose/ui/text/TextStyle;Lorg/jetbrains/jewel/styling/MenuStyle;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownStyle;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiDropdownStylingKt {
+	public static final fun intUiDropdownIcons (Lorg/jetbrains/jewel/painter/PainterProvider;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDropdownIcons;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderColors : org/jetbrains/jewel/styling/GroupHeaderColors {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderColors$Companion;
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDivider-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderColors$Companion {
+	public final fun dark-Iv8Zu3U (JLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderColors;
+	public final fun light-Iv8Zu3U (JLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderColors;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderMetrics : org/jetbrains/jewel/styling/GroupHeaderMetrics {
+	public static final field $stable I
+	public synthetic fun <init> (FFILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (FFLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDividerThickness-D9Ej5fM ()F
+	public fun getIndent-D9Ej5fM ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderStyle : org/jetbrains/jewel/styling/GroupHeaderStyle {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderStyle$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderMetrics;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getColors ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderColors;
+	public synthetic fun getColors ()Lorg/jetbrains/jewel/styling/GroupHeaderColors;
+	public fun getMetrics ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderMetrics;
+	public synthetic fun getMetrics ()Lorg/jetbrains/jewel/styling/GroupHeaderMetrics;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderStyle$Companion {
+	public final fun dark (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderMetrics;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderStyle;
+	public final fun light (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderMetrics;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderStyle;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarColors : org/jetbrains/jewel/styling/HorizontalProgressBarColors {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarColors$Companion;
+	public synthetic fun <init> (JJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getIndeterminateBase-0d7_KjU ()J
+	public fun getIndeterminateHighlight-0d7_KjU ()J
+	public fun getProgress-0d7_KjU ()J
+	public fun getTrack-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarColors$Companion {
+	public final fun dark-ro_MJ88 (JJJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarColors;
+	public final fun light-ro_MJ88 (JJJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarColors;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarMetrics : org/jetbrains/jewel/styling/HorizontalProgressBarMetrics {
+	public static final field $stable I
+	public synthetic fun <init> (Landroidx/compose/foundation/shape/CornerSize;FFILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Landroidx/compose/foundation/shape/CornerSize;FFLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public fun getIndeterminateHighlightWidth-D9Ej5fM ()F
+	public fun getMinHeight-D9Ej5fM ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarStyle : org/jetbrains/jewel/styling/HorizontalProgressBarStyle {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarStyle$Companion;
+	public synthetic fun <init> (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarMetrics;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getColors ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarColors;
+	public synthetic fun getColors ()Lorg/jetbrains/jewel/styling/HorizontalProgressBarColors;
+	public fun getIndeterminateCycleDuration-UwyO8pc ()J
+	public fun getMetrics ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarMetrics;
+	public synthetic fun getMetrics ()Lorg/jetbrains/jewel/styling/HorizontalProgressBarMetrics;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarStyle$Companion {
+	public final fun dark-WPi__2c (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarMetrics;JLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarStyle;
+	public final fun light-WPi__2c (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarMetrics;JLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarStyle;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiIconButtonColors : org/jetbrains/jewel/styling/IconButtonColors {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiIconButtonColors$Companion;
+	public synthetic fun <init> (JJJJJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun backgroundFor-RO59lCw (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun borderFor-RO59lCw (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBackground-0d7_KjU ()J
+	public fun getBackgroundDisabled-0d7_KjU ()J
+	public fun getBackgroundFocused-0d7_KjU ()J
+	public fun getBackgroundHovered-0d7_KjU ()J
+	public fun getBackgroundPressed-0d7_KjU ()J
+	public fun getBorder-0d7_KjU ()J
+	public fun getBorderDisabled-0d7_KjU ()J
+	public fun getBorderFocused-0d7_KjU ()J
+	public fun getBorderHovered-0d7_KjU ()J
+	public fun getBorderPressed-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiIconButtonColors$Companion {
+	public final fun dark-q0g_0yA (JJJJJJJJJJLandroidx/compose/runtime/Composer;III)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiIconButtonColors;
+	public final fun light-q0g_0yA (JJJJJJJJJJLandroidx/compose/runtime/Composer;III)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiIconButtonColors;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiIconButtonMetrics : org/jetbrains/jewel/styling/IconButtonMetrics {
+	public static final field $stable I
+	public synthetic fun <init> (Landroidx/compose/foundation/shape/CornerSize;FLandroidx/compose/foundation/layout/PaddingValues;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Landroidx/compose/foundation/shape/CornerSize;FLandroidx/compose/foundation/layout/PaddingValues;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBorderWidth-D9Ej5fM ()F
+	public fun getCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public fun getMinSize-MYxV2XQ ()J
+	public fun getPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiIconButtonStyle : org/jetbrains/jewel/styling/IconButtonStyle {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiIconButtonStyle$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiIconButtonColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiIconButtonMetrics;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getColors ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiIconButtonColors;
+	public synthetic fun getColors ()Lorg/jetbrains/jewel/styling/IconButtonColors;
+	public fun getMetrics ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiIconButtonMetrics;
+	public synthetic fun getMetrics ()Lorg/jetbrains/jewel/styling/IconButtonMetrics;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiIconButtonStyle$Companion {
+	public final fun dark (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiIconButtonStyle;
+	public final fun light (Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiIconButtonStyle;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldColors : org/jetbrains/jewel/styling/LabelledTextFieldColors {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldColors$Companion;
+	public synthetic fun <init> (JJJJJJJJJJJJJJJJJJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun backgroundFor-37MyHpk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun borderFor-37MyHpk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun caretFor-37MyHpk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun contentFor-37MyHpk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBackground-0d7_KjU ()J
+	public fun getBackgroundDisabled-0d7_KjU ()J
+	public fun getBackgroundFocused-0d7_KjU ()J
+	public fun getBackgroundHovered-0d7_KjU ()J
+	public fun getBackgroundPressed-0d7_KjU ()J
+	public fun getBorder-0d7_KjU ()J
+	public fun getBorderDisabled-0d7_KjU ()J
+	public fun getBorderFocused-0d7_KjU ()J
+	public fun getBorderHovered-0d7_KjU ()J
+	public fun getBorderPressed-0d7_KjU ()J
+	public fun getCaret-0d7_KjU ()J
+	public fun getCaretDisabled-0d7_KjU ()J
+	public fun getCaretFocused-0d7_KjU ()J
+	public fun getCaretHovered-0d7_KjU ()J
+	public fun getCaretPressed-0d7_KjU ()J
+	public fun getContent-0d7_KjU ()J
+	public fun getContentDisabled-0d7_KjU ()J
+	public fun getContentFocused-0d7_KjU ()J
+	public fun getContentHovered-0d7_KjU ()J
+	public fun getContentPressed-0d7_KjU ()J
+	public fun getHint-0d7_KjU ()J
+	public fun getLabel-0d7_KjU ()J
+	public fun getPlaceholder-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldColors$Companion {
+	public final fun dark-4JUtha0 (JJJJJJJJJJJJJJJJJJJJJJJLandroidx/compose/runtime/Composer;IIII)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldColors;
+	public final fun light-4JUtha0 (JJJJJJJJJJJJJJJJJJJJJJJLandroidx/compose/runtime/Composer;IIII)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldColors;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldMetrics : org/jetbrains/jewel/styling/LabelledTextFieldMetrics {
+	public static final field $stable I
+	public synthetic fun <init> (Landroidx/compose/foundation/shape/CornerSize;Landroidx/compose/foundation/layout/PaddingValues;JFFFILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Landroidx/compose/foundation/shape/CornerSize;Landroidx/compose/foundation/layout/PaddingValues;JFFFLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBorderWidth-D9Ej5fM ()F
+	public fun getContentPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public fun getCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public fun getHintSpacing-D9Ej5fM ()F
+	public fun getLabelSpacing-D9Ej5fM ()F
+	public fun getMinSize-MYxV2XQ ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldStyle : org/jetbrains/jewel/styling/LabelledTextFieldStyle {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldStyle$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldMetrics;Landroidx/compose/ui/text/TextStyle;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldTextStyles;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getColors ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldColors;
+	public synthetic fun getColors ()Lorg/jetbrains/jewel/styling/InputFieldColors;
+	public synthetic fun getColors ()Lorg/jetbrains/jewel/styling/LabelledTextFieldColors;
+	public synthetic fun getColors ()Lorg/jetbrains/jewel/styling/TextFieldColors;
+	public fun getMetrics ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldMetrics;
+	public synthetic fun getMetrics ()Lorg/jetbrains/jewel/styling/InputFieldMetrics;
+	public synthetic fun getMetrics ()Lorg/jetbrains/jewel/styling/LabelledTextFieldMetrics;
+	public fun getTextStyle ()Landroidx/compose/ui/text/TextStyle;
+	public fun getTextStyles ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldTextStyles;
+	public synthetic fun getTextStyles ()Lorg/jetbrains/jewel/styling/LabelledTextFieldTextStyles;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldStyle$Companion {
+	public final fun dark (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldMetrics;Landroidx/compose/ui/text/TextStyle;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldTextStyles;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldStyle;
+	public final fun light (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldMetrics;Landroidx/compose/ui/text/TextStyle;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldTextStyles;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldStyle;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldTextStyles : org/jetbrains/jewel/styling/LabelledTextFieldTextStyles {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldTextStyles$Companion;
+	public fun <init> (Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getHint ()Landroidx/compose/ui/text/TextStyle;
+	public fun getLabel ()Landroidx/compose/ui/text/TextStyle;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldTextStyles$Companion {
+	public final fun dark (Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldTextStyles;
+	public final fun light (Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldTextStyles;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeColors : org/jetbrains/jewel/styling/LazyTreeColors {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeColors$Companion;
+	public synthetic fun <init> (JJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun contentFor-iZdlh1w (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getContent-0d7_KjU ()J
+	public fun getContentFocused-0d7_KjU ()J
+	public fun getContentSelected-0d7_KjU ()J
+	public fun getContentSelectedFocused-0d7_KjU ()J
+	public fun getElementBackgroundFocused-0d7_KjU ()J
+	public fun getElementBackgroundSelected-0d7_KjU ()J
+	public fun getElementBackgroundSelectedFocused-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeColors$Companion {
+	public final fun dark-69fazGs (JJJJJJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeColors;
+	public final fun light-69fazGs (JJJJJJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeColors;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeIcons : org/jetbrains/jewel/styling/LazyTreeIcons {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeIcons$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/painter/PainterProvider;Lorg/jetbrains/jewel/painter/PainterProvider;Lorg/jetbrains/jewel/painter/PainterProvider;Lorg/jetbrains/jewel/painter/PainterProvider;)V
+	public fun chevron (ZZLandroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/painter/PainterProvider;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getChevronCollapsed ()Lorg/jetbrains/jewel/painter/PainterProvider;
+	public fun getChevronExpanded ()Lorg/jetbrains/jewel/painter/PainterProvider;
+	public fun getChevronSelectedCollapsed ()Lorg/jetbrains/jewel/painter/PainterProvider;
+	public fun getChevronSelectedExpanded ()Lorg/jetbrains/jewel/painter/PainterProvider;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeIcons$Companion {
+	public final fun chevronCollapsed (Ljava/lang/String;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/painter/PainterProvider;
+	public final fun chevronExpanded (Ljava/lang/String;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/painter/PainterProvider;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeMetrics : org/jetbrains/jewel/styling/LazyTreeMetrics {
+	public static final field $stable I
+	public synthetic fun <init> (FLandroidx/compose/foundation/shape/CornerSize;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/foundation/layout/PaddingValues;FFILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (FLandroidx/compose/foundation/shape/CornerSize;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/foundation/layout/PaddingValues;FFLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getChevronContentGap-D9Ej5fM ()F
+	public fun getElementBackgroundCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public fun getElementContentPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public fun getElementMinHeight-D9Ej5fM ()F
+	public fun getElementPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public fun getIndentSize-D9Ej5fM ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeStyle : org/jetbrains/jewel/styling/LazyTreeStyle {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeStyle$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeMetrics;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeIcons;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getColors ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeColors;
+	public synthetic fun getColors ()Lorg/jetbrains/jewel/styling/LazyTreeColors;
+	public fun getIcons ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeIcons;
+	public synthetic fun getIcons ()Lorg/jetbrains/jewel/styling/LazyTreeIcons;
+	public fun getMetrics ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeMetrics;
+	public synthetic fun getMetrics ()Lorg/jetbrains/jewel/styling/LazyTreeMetrics;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeStyle$Companion {
+	public final fun dark (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeMetrics;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeIcons;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeStyle;
+	public final fun light (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeMetrics;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeIcons;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeStyle;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeStylingKt {
+	public static final fun intUiLazyTreeIcons (Lorg/jetbrains/jewel/painter/PainterProvider;Lorg/jetbrains/jewel/painter/PainterProvider;Lorg/jetbrains/jewel/painter/PainterProvider;Lorg/jetbrains/jewel/painter/PainterProvider;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeIcons;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLinkColors : org/jetbrains/jewel/styling/LinkColors {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkColors$Companion;
+	public synthetic fun <init> (JJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun contentFor-4qImzQQ (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getContent-0d7_KjU ()J
+	public fun getContentDisabled-0d7_KjU ()J
+	public fun getContentFocused-0d7_KjU ()J
+	public fun getContentHovered-0d7_KjU ()J
+	public fun getContentPressed-0d7_KjU ()J
+	public fun getContentVisited-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLinkColors$Companion {
+	public final fun dark-5tl4gsc (JJJJJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkColors;
+	public final fun light-5tl4gsc (JJJJJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkColors;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLinkIcons : org/jetbrains/jewel/styling/LinkIcons {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkIcons$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/painter/PainterProvider;Lorg/jetbrains/jewel/painter/PainterProvider;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDropdownChevron ()Lorg/jetbrains/jewel/painter/PainterProvider;
+	public fun getExternalLink ()Lorg/jetbrains/jewel/painter/PainterProvider;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLinkIcons$Companion {
+	public final fun dropdownChevron (Ljava/lang/String;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/painter/PainterProvider;
+	public final fun externalLink (Ljava/lang/String;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/painter/PainterProvider;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLinkMetrics : org/jetbrains/jewel/styling/LinkMetrics {
+	public static final field $stable I
+	public synthetic fun <init> (Landroidx/compose/foundation/shape/CornerSize;FJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Landroidx/compose/foundation/shape/CornerSize;FJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getFocusHaloCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public fun getIconSize-MYxV2XQ ()J
+	public fun getTextIconGap-D9Ej5fM ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLinkStyle : org/jetbrains/jewel/styling/LinkStyle {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkStyle$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkMetrics;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkIcons;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkTextStyles;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getColors ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkColors;
+	public synthetic fun getColors ()Lorg/jetbrains/jewel/styling/LinkColors;
+	public fun getIcons ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkIcons;
+	public synthetic fun getIcons ()Lorg/jetbrains/jewel/styling/LinkIcons;
+	public fun getMetrics ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkMetrics;
+	public synthetic fun getMetrics ()Lorg/jetbrains/jewel/styling/LinkMetrics;
+	public fun getTextStyles ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkTextStyles;
+	public synthetic fun getTextStyles ()Lorg/jetbrains/jewel/styling/LinkTextStyles;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLinkStyle$Companion {
+	public final fun dark (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkMetrics;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkIcons;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkTextStyles;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkStyle;
+	public final fun light (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkMetrics;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkIcons;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkTextStyles;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkStyle;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLinkStylingKt {
+	public static final fun intUiLinkIcons (Lorg/jetbrains/jewel/painter/PainterProvider;Lorg/jetbrains/jewel/painter/PainterProvider;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkIcons;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLinkTextStyles : org/jetbrains/jewel/styling/LinkTextStyles {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkTextStyles$Companion;
+	public fun <init> (Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getDisabled ()Landroidx/compose/ui/text/TextStyle;
+	public fun getFocused ()Landroidx/compose/ui/text/TextStyle;
+	public fun getHovered ()Landroidx/compose/ui/text/TextStyle;
+	public fun getNormal ()Landroidx/compose/ui/text/TextStyle;
+	public fun getPressed ()Landroidx/compose/ui/text/TextStyle;
+	public fun getVisited ()Landroidx/compose/ui/text/TextStyle;
+	public fun hashCode ()I
+	public fun styleFor-4qImzQQ (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLinkTextStyles$Companion {
+	public final fun dark (Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkTextStyles;
+	public final fun light (Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiLinkTextStyles;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiMenuColors : org/jetbrains/jewel/styling/MenuColors {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuColors$Companion;
+	public synthetic fun <init> (JJJLorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuItemColors;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBackground-0d7_KjU ()J
+	public fun getBorder-0d7_KjU ()J
+	public fun getItemColors ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuItemColors;
+	public synthetic fun getItemColors ()Lorg/jetbrains/jewel/styling/MenuItemColors;
+	public fun getShadow-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiMenuColors$Companion {
+	public final fun dark-g9RBwZg (JJJLorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuItemColors;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuColors;
+	public final fun light-g9RBwZg (JJJLorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuItemColors;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuColors;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiMenuIcons : org/jetbrains/jewel/styling/MenuIcons {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuIcons$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/painter/PainterProvider;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getSubmenuChevron ()Lorg/jetbrains/jewel/painter/PainterProvider;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiMenuIcons$Companion {
+	public final fun submenuChevron (Ljava/lang/String;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/painter/PainterProvider;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiMenuItemColors : org/jetbrains/jewel/styling/MenuItemColors {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuItemColors$Companion;
+	public synthetic fun <init> (JJJJJJJJJJJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun backgroundFor-BYhRtsk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun contentFor-BYhRtsk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBackground-0d7_KjU ()J
+	public fun getBackgroundDisabled-0d7_KjU ()J
+	public fun getBackgroundFocused-0d7_KjU ()J
+	public fun getBackgroundHovered-0d7_KjU ()J
+	public fun getBackgroundPressed-0d7_KjU ()J
+	public fun getContent-0d7_KjU ()J
+	public fun getContentDisabled-0d7_KjU ()J
+	public fun getContentFocused-0d7_KjU ()J
+	public fun getContentHovered-0d7_KjU ()J
+	public fun getContentPressed-0d7_KjU ()J
+	public fun getIconTint-0d7_KjU ()J
+	public fun getIconTintDisabled-0d7_KjU ()J
+	public fun getIconTintFocused-0d7_KjU ()J
+	public fun getIconTintHovered-0d7_KjU ()J
+	public fun getIconTintPressed-0d7_KjU ()J
+	public fun getSeparator-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun iconTintFor-BYhRtsk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiMenuItemColors$Companion {
+	public final fun dark-V1nXRL4 (JJJJJJJJJJJJJJJJLandroidx/compose/runtime/Composer;III)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuItemColors;
+	public final fun light-V1nXRL4 (JJJJJJJJJJJJJJJJLandroidx/compose/runtime/Composer;III)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuItemColors;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiMenuItemMetrics : org/jetbrains/jewel/styling/MenuItemMetrics {
+	public static final field $stable I
+	public synthetic fun <init> (Landroidx/compose/foundation/shape/CornerSize;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/foundation/layout/PaddingValues;FILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Landroidx/compose/foundation/shape/CornerSize;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/foundation/layout/PaddingValues;FLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getContentPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public fun getOuterPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public fun getSelectionCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public fun getSeparatorPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public fun getSeparatorThickness-D9Ej5fM ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiMenuMetrics : org/jetbrains/jewel/styling/MenuMetrics {
+	public static final field $stable I
+	public synthetic fun <init> (Landroidx/compose/foundation/shape/CornerSize;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/foundation/layout/PaddingValues;JFFLorg/jetbrains/jewel/styling/MenuItemMetrics;Lorg/jetbrains/jewel/styling/SubmenuMetrics;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Landroidx/compose/foundation/shape/CornerSize;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/foundation/layout/PaddingValues;JFFLorg/jetbrains/jewel/styling/MenuItemMetrics;Lorg/jetbrains/jewel/styling/SubmenuMetrics;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBorderWidth-D9Ej5fM ()F
+	public fun getContentPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public fun getCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public fun getItemMetrics ()Lorg/jetbrains/jewel/styling/MenuItemMetrics;
+	public fun getMenuMargin ()Landroidx/compose/foundation/layout/PaddingValues;
+	public fun getOffset-RKDOV3M ()J
+	public fun getShadowSize-D9Ej5fM ()F
+	public fun getSubmenuMetrics ()Lorg/jetbrains/jewel/styling/SubmenuMetrics;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiMenuStyle : org/jetbrains/jewel/styling/MenuStyle {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuStyle$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuMetrics;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuIcons;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getColors ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuColors;
+	public synthetic fun getColors ()Lorg/jetbrains/jewel/styling/MenuColors;
+	public fun getIcons ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuIcons;
+	public synthetic fun getIcons ()Lorg/jetbrains/jewel/styling/MenuIcons;
+	public fun getMetrics ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuMetrics;
+	public synthetic fun getMetrics ()Lorg/jetbrains/jewel/styling/MenuMetrics;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiMenuStyle$Companion {
+	public final fun dark (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuMetrics;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuIcons;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuStyle;
+	public final fun light (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuMetrics;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuIcons;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuStyle;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiMenuStylingKt {
+	public static final fun intUiMenuIcons (Lorg/jetbrains/jewel/painter/PainterProvider;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiMenuIcons;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonColors : org/jetbrains/jewel/styling/RadioButtonColors {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonColors$Companion;
+	public synthetic fun <init> (JJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun contentFor-dQFH0ko (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getContent-0d7_KjU ()J
+	public fun getContentDisabled-0d7_KjU ()J
+	public fun getContentHovered-0d7_KjU ()J
+	public fun getContentSelected-0d7_KjU ()J
+	public fun getContentSelectedDisabled-0d7_KjU ()J
+	public fun getContentSelectedHovered-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonColors$Companion {
+	public final fun dark-5tl4gsc (JJJJJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonColors;
+	public final fun light-5tl4gsc (JJJJJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonColors;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonIcons : org/jetbrains/jewel/styling/RadioButtonIcons {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonIcons$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/painter/PainterProvider;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getRadioButton ()Lorg/jetbrains/jewel/painter/PainterProvider;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonIcons$Companion {
+	public final fun dark (Lorg/jetbrains/jewel/painter/PainterProvider;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonIcons;
+	public final fun light (Lorg/jetbrains/jewel/painter/PainterProvider;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonIcons;
+	public final fun radioButton (Ljava/lang/String;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/painter/PainterProvider;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonMetrics : org/jetbrains/jewel/styling/RadioButtonMetrics {
+	public static final field $stable I
+	public synthetic fun <init> (JFILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JFLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getIconContentGap-D9Ej5fM ()F
+	public fun getRadioButtonSize-MYxV2XQ ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonStyle : org/jetbrains/jewel/styling/RadioButtonStyle {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonStyle$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonMetrics;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonIcons;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getColors ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonColors;
+	public synthetic fun getColors ()Lorg/jetbrains/jewel/styling/RadioButtonColors;
+	public fun getIcons ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonIcons;
+	public synthetic fun getIcons ()Lorg/jetbrains/jewel/styling/RadioButtonIcons;
+	public fun getMetrics ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonMetrics;
+	public synthetic fun getMetrics ()Lorg/jetbrains/jewel/styling/RadioButtonMetrics;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonStyle$Companion {
+	public final fun dark (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonMetrics;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonIcons;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonStyle;
+	public final fun light (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonMetrics;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonIcons;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonStyle;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarColors : org/jetbrains/jewel/styling/ScrollbarColors {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarColors$Companion;
+	public synthetic fun <init> (JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getThumbBackground-0d7_KjU ()J
+	public fun getThumbBackgroundHovered-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarColors$Companion {
+	public final fun dark-dgg9oW8 (JJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarColors;
+	public final fun light-dgg9oW8 (JJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarColors;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarMetrics : org/jetbrains/jewel/styling/ScrollbarMetrics {
+	public static final field $stable I
+	public synthetic fun <init> (Landroidx/compose/foundation/shape/CornerSize;FFLandroidx/compose/foundation/layout/PaddingValues;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Landroidx/compose/foundation/shape/CornerSize;FFLandroidx/compose/foundation/layout/PaddingValues;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMinThumbLength-D9Ej5fM ()F
+	public fun getThumbCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public fun getThumbThickness-D9Ej5fM ()F
+	public fun getTrackPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarStyle : org/jetbrains/jewel/styling/ScrollbarStyle {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarStyle$Companion;
+	public synthetic fun <init> (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarMetrics;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getColors ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarColors;
+	public synthetic fun getColors ()Lorg/jetbrains/jewel/styling/ScrollbarColors;
+	public fun getHoverDuration-UwyO8pc ()J
+	public fun getMetrics ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarMetrics;
+	public synthetic fun getMetrics ()Lorg/jetbrains/jewel/styling/ScrollbarMetrics;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarStyle$Companion {
+	public final fun dark-WPi__2c (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarMetrics;JLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarStyle;
+	public final fun light-WPi__2c (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarMetrics;JLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarStyle;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiSubmenuMetrics : org/jetbrains/jewel/styling/SubmenuMetrics {
+	public static final field $stable I
+	public synthetic fun <init> (JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getOffset-RKDOV3M ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTabColors : org/jetbrains/jewel/styling/TabColors {
+	public static final field $stable I
+	public synthetic fun <init> (JJJJJJJJJJJJJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun backgroundFor-WCiaD9s (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun contentFor-WCiaD9s (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBackground-0d7_KjU ()J
+	public fun getBackgroundDisabled-0d7_KjU ()J
+	public fun getBackgroundFocused-0d7_KjU ()J
+	public fun getBackgroundHovered-0d7_KjU ()J
+	public fun getBackgroundPressed-0d7_KjU ()J
+	public fun getBackgroundSelected-0d7_KjU ()J
+	public fun getContent-0d7_KjU ()J
+	public fun getContentDisabled-0d7_KjU ()J
+	public fun getContentFocused-0d7_KjU ()J
+	public fun getContentHovered-0d7_KjU ()J
+	public fun getContentPressed-0d7_KjU ()J
+	public fun getContentSelected-0d7_KjU ()J
+	public fun getUnderline-0d7_KjU ()J
+	public fun getUnderlineDisabled-0d7_KjU ()J
+	public fun getUnderlineFocused-0d7_KjU ()J
+	public fun getUnderlineHovered-0d7_KjU ()J
+	public fun getUnderlinePressed-0d7_KjU ()J
+	public fun getUnderlineSelected-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public fun underlineFor-WCiaD9s (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTabColors$Default {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabColors$Default;
+	public final fun dark-58FyvDQ (JJJJJJJJJJJJJJJJJJ)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabColors;
+	public static synthetic fun dark-58FyvDQ$default (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabColors$Default;JJJJJJJJJJJJJJJJJJILjava/lang/Object;)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabColors;
+	public final fun light-58FyvDQ (JJJJJJJJJJJJJJJJJJ)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabColors;
+	public static synthetic fun light-58FyvDQ$default (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabColors$Default;JJJJJJJJJJJJJJJJJJILjava/lang/Object;)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabColors;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTabColors$Editor {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabColors$Editor;
+	public final fun dark-58FyvDQ (JJJJJJJJJJJJJJJJJJ)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabColors;
+	public static synthetic fun dark-58FyvDQ$default (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabColors$Editor;JJJJJJJJJJJJJJJJJJILjava/lang/Object;)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabColors;
+	public final fun light-58FyvDQ (JJJJJJJJJJJJJJJJJJ)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabColors;
+	public static synthetic fun light-58FyvDQ$default (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabColors$Editor;JJJJJJJJJJJJJJJJJJILjava/lang/Object;)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabColors;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTabContentAlpha : org/jetbrains/jewel/styling/TabContentAlpha {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabContentAlpha$Companion;
+	public fun <init> (FFFFFFFFFFFF)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getIconDisabled ()F
+	public fun getIconFocused ()F
+	public fun getIconHovered ()F
+	public fun getIconNormal ()F
+	public fun getIconPressed ()F
+	public fun getIconSelected ()F
+	public fun getLabelDisabled ()F
+	public fun getLabelFocused ()F
+	public fun getLabelHovered ()F
+	public fun getLabelNormal ()F
+	public fun getLabelPressed ()F
+	public fun getLabelSelected ()F
+	public fun hashCode ()I
+	public fun iconFor-WCiaD9s (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun labelFor-WCiaD9s (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTabContentAlpha$Companion {
+	public final fun default (FFFFFFFFFFFF)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabContentAlpha;
+	public static synthetic fun default$default (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabContentAlpha$Companion;FFFFFFFFFFFFILjava/lang/Object;)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabContentAlpha;
+	public final fun editor (FFFFFFFFFFFF)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabContentAlpha;
+	public static synthetic fun editor$default (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabContentAlpha$Companion;FFFFFFFFFFFFILjava/lang/Object;)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabContentAlpha;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTabIcons : org/jetbrains/jewel/styling/TabIcons {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabIcons$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/painter/PainterProvider;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getClose ()Lorg/jetbrains/jewel/painter/PainterProvider;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTabIcons$Companion {
+	public final fun close (Ljava/lang/String;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/painter/PainterProvider;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTabMetrics : org/jetbrains/jewel/styling/TabMetrics {
+	public static final field $stable I
+	public synthetic fun <init> (FLandroidx/compose/foundation/layout/PaddingValues;FFILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (FLandroidx/compose/foundation/layout/PaddingValues;FFLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getCloseContentGap-D9Ej5fM ()F
+	public fun getTabHeight-D9Ej5fM ()F
+	public fun getTabPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public fun getUnderlineThickness-D9Ej5fM ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTabStyle : org/jetbrains/jewel/styling/TabStyle {
+	public static final field $stable I
+	public fun <init> (Lorg/jetbrains/jewel/styling/TabColors;Lorg/jetbrains/jewel/styling/TabMetrics;Lorg/jetbrains/jewel/styling/TabIcons;Lorg/jetbrains/jewel/styling/TabContentAlpha;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getColors ()Lorg/jetbrains/jewel/styling/TabColors;
+	public fun getContentAlpha ()Lorg/jetbrains/jewel/styling/TabContentAlpha;
+	public fun getIcons ()Lorg/jetbrains/jewel/styling/TabIcons;
+	public fun getMetrics ()Lorg/jetbrains/jewel/styling/TabMetrics;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTabStyle$Default {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabStyle$Default;
+	public final fun dark (Lorg/jetbrains/jewel/styling/TabColors;Lorg/jetbrains/jewel/styling/TabMetrics;Lorg/jetbrains/jewel/styling/TabIcons;Lorg/jetbrains/jewel/styling/TabContentAlpha;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabStyle;
+	public final fun light (Lorg/jetbrains/jewel/styling/TabColors;Lorg/jetbrains/jewel/styling/TabMetrics;Lorg/jetbrains/jewel/styling/TabIcons;Lorg/jetbrains/jewel/styling/TabContentAlpha;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabStyle;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTabStyle$Editor {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabStyle$Editor;
+	public final fun dark (Lorg/jetbrains/jewel/styling/TabColors;Lorg/jetbrains/jewel/styling/TabMetrics;Lorg/jetbrains/jewel/styling/TabIcons;Lorg/jetbrains/jewel/styling/TabContentAlpha;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabStyle;
+	public final fun light (Lorg/jetbrains/jewel/styling/TabColors;Lorg/jetbrains/jewel/styling/TabMetrics;Lorg/jetbrains/jewel/styling/TabIcons;Lorg/jetbrains/jewel/styling/TabContentAlpha;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabStyle;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTabStylingKt {
+	public static final fun intUiTabIcons (Lorg/jetbrains/jewel/painter/PainterProvider;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTabIcons;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaColors : org/jetbrains/jewel/styling/TextAreaColors {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaColors$Companion;
+	public synthetic fun <init> (JJJJJJJJJJJJJJJJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun backgroundFor-37MyHpk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun borderFor-37MyHpk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun caretFor-37MyHpk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun contentFor-37MyHpk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBackground-0d7_KjU ()J
+	public fun getBackgroundDisabled-0d7_KjU ()J
+	public fun getBackgroundFocused-0d7_KjU ()J
+	public fun getBackgroundHovered-0d7_KjU ()J
+	public fun getBackgroundPressed-0d7_KjU ()J
+	public fun getBorder-0d7_KjU ()J
+	public fun getBorderDisabled-0d7_KjU ()J
+	public fun getBorderFocused-0d7_KjU ()J
+	public fun getBorderHovered-0d7_KjU ()J
+	public fun getBorderPressed-0d7_KjU ()J
+	public fun getCaret-0d7_KjU ()J
+	public fun getCaretDisabled-0d7_KjU ()J
+	public fun getCaretFocused-0d7_KjU ()J
+	public fun getCaretHovered-0d7_KjU ()J
+	public fun getCaretPressed-0d7_KjU ()J
+	public fun getContent-0d7_KjU ()J
+	public fun getContentDisabled-0d7_KjU ()J
+	public fun getContentFocused-0d7_KjU ()J
+	public fun getContentHovered-0d7_KjU ()J
+	public fun getContentPressed-0d7_KjU ()J
+	public fun getPlaceholder-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaColors$Companion {
+	public final fun dark-dx8h9Zs (JJJJJJJJJJJJJJJJJJJJJLandroidx/compose/runtime/Composer;IIII)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaColors;
+	public final fun light-dx8h9Zs (JJJJJJJJJJJJJJJJJJJJJLandroidx/compose/runtime/Composer;IIII)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaColors;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaMetrics : org/jetbrains/jewel/styling/InputFieldMetrics {
+	public static final field $stable I
+	public synthetic fun <init> (Landroidx/compose/foundation/shape/CornerSize;Landroidx/compose/foundation/layout/PaddingValues;JFILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Landroidx/compose/foundation/shape/CornerSize;Landroidx/compose/foundation/layout/PaddingValues;JFLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBorderWidth-D9Ej5fM ()F
+	public fun getContentPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public fun getCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public fun getMinSize-MYxV2XQ ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaStyle : org/jetbrains/jewel/styling/TextAreaStyle {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaStyle$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaMetrics;Landroidx/compose/ui/text/TextStyle;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getColors ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaColors;
+	public synthetic fun getColors ()Lorg/jetbrains/jewel/styling/InputFieldColors;
+	public synthetic fun getColors ()Lorg/jetbrains/jewel/styling/TextAreaColors;
+	public fun getMetrics ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaMetrics;
+	public synthetic fun getMetrics ()Lorg/jetbrains/jewel/styling/InputFieldMetrics;
+	public fun getTextStyle ()Landroidx/compose/ui/text/TextStyle;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaStyle$Companion {
+	public final fun dark (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaMetrics;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaStyle;
+	public final fun light (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaMetrics;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaStyle;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldColors : org/jetbrains/jewel/styling/TextFieldColors {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldColors$Companion;
+	public synthetic fun <init> (JJJJJJJJJJJJJJJJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun backgroundFor-37MyHpk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun borderFor-37MyHpk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun caretFor-37MyHpk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun contentFor-37MyHpk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBackground-0d7_KjU ()J
+	public fun getBackgroundDisabled-0d7_KjU ()J
+	public fun getBackgroundFocused-0d7_KjU ()J
+	public fun getBackgroundHovered-0d7_KjU ()J
+	public fun getBackgroundPressed-0d7_KjU ()J
+	public fun getBorder-0d7_KjU ()J
+	public fun getBorderDisabled-0d7_KjU ()J
+	public fun getBorderFocused-0d7_KjU ()J
+	public fun getBorderHovered-0d7_KjU ()J
+	public fun getBorderPressed-0d7_KjU ()J
+	public fun getCaret-0d7_KjU ()J
+	public fun getCaretDisabled-0d7_KjU ()J
+	public fun getCaretFocused-0d7_KjU ()J
+	public fun getCaretHovered-0d7_KjU ()J
+	public fun getCaretPressed-0d7_KjU ()J
+	public fun getContent-0d7_KjU ()J
+	public fun getContentDisabled-0d7_KjU ()J
+	public fun getContentFocused-0d7_KjU ()J
+	public fun getContentHovered-0d7_KjU ()J
+	public fun getContentPressed-0d7_KjU ()J
+	public fun getPlaceholder-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldColors$Companion {
+	public final fun dark-dx8h9Zs (JJJJJJJJJJJJJJJJJJJJJLandroidx/compose/runtime/Composer;IIII)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldColors;
+	public final fun light-dx8h9Zs (JJJJJJJJJJJJJJJJJJJJJLandroidx/compose/runtime/Composer;IIII)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldColors;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldMetrics : org/jetbrains/jewel/styling/InputFieldMetrics {
+	public static final field $stable I
+	public synthetic fun <init> (Landroidx/compose/foundation/shape/CornerSize;Landroidx/compose/foundation/layout/PaddingValues;JFILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Landroidx/compose/foundation/shape/CornerSize;Landroidx/compose/foundation/layout/PaddingValues;JFLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBorderWidth-D9Ej5fM ()F
+	public fun getContentPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public fun getCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public fun getMinSize-MYxV2XQ ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldStyle : org/jetbrains/jewel/styling/TextFieldStyle {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldStyle$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldMetrics;Landroidx/compose/ui/text/TextStyle;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getColors ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldColors;
+	public synthetic fun getColors ()Lorg/jetbrains/jewel/styling/InputFieldColors;
+	public synthetic fun getColors ()Lorg/jetbrains/jewel/styling/TextFieldColors;
+	public fun getMetrics ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldMetrics;
+	public synthetic fun getMetrics ()Lorg/jetbrains/jewel/styling/InputFieldMetrics;
+	public fun getTextStyle ()Landroidx/compose/ui/text/TextStyle;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldStyle$Companion {
+	public final fun dark (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldMetrics;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldStyle;
+	public final fun light (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldMetrics;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldStyle;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTooltipColors : org/jetbrains/jewel/styling/TooltipColors {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTooltipColors$Companion;
+	public synthetic fun <init> (JJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBackground-0d7_KjU ()J
+	public fun getBorder-0d7_KjU ()J
+	public fun getContent-0d7_KjU ()J
+	public fun getShadow-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTooltipColors$Companion {
+	public final fun dark-ro_MJ88 (JJJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTooltipColors;
+	public final fun light-ro_MJ88 (JJJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTooltipColors;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTooltipMetrics : org/jetbrains/jewel/styling/TooltipMetrics {
+	public static final field $stable I
+	public synthetic fun <init> (Landroidx/compose/foundation/layout/PaddingValues;JLandroidx/compose/foundation/shape/CornerSize;FFJLandroidx/compose/ui/Alignment$Horizontal;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Landroidx/compose/foundation/layout/PaddingValues;JLandroidx/compose/foundation/shape/CornerSize;FFJLandroidx/compose/ui/Alignment$Horizontal;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getBorderWidth-D9Ej5fM ()F
+	public fun getContentPadding ()Landroidx/compose/foundation/layout/PaddingValues;
+	public fun getCornerSize ()Landroidx/compose/foundation/shape/CornerSize;
+	public fun getShadowSize-D9Ej5fM ()F
+	public fun getShowDelay-UwyO8pc ()J
+	public fun getTooltipAlignment ()Landroidx/compose/ui/Alignment$Horizontal;
+	public fun getTooltipOffset-RKDOV3M ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTooltipStyle : org/jetbrains/jewel/styling/TooltipStyle {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTooltipStyle$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTooltipColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTooltipMetrics;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getColors ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTooltipColors;
+	public synthetic fun getColors ()Lorg/jetbrains/jewel/styling/TooltipColors;
+	public fun getMetrics ()Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTooltipMetrics;
+	public synthetic fun getMetrics ()Lorg/jetbrains/jewel/styling/TooltipMetrics;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTooltipStyle$Companion {
+	public final fun dark (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTooltipColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTooltipMetrics;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTooltipStyle;
+	public final fun light (Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTooltipColors;Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTooltipMetrics;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiTooltipStyle;
+}
+

--- a/int-ui/int-ui-standalone/build.gradle.kts
+++ b/int-ui/int-ui-standalone/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     jewel
     `jewel-publish`
+    `jewel-check-public-api`
     alias(libs.plugins.composeDesktop)
 }
 

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiButtonStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiButtonStyling.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.IntUiTheme
@@ -20,7 +19,7 @@ import org.jetbrains.jewel.styling.ButtonMetrics
 import org.jetbrains.jewel.styling.ButtonStyle
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiButtonStyle(
     override val colors: IntUiButtonColors,
     override val metrics: IntUiButtonMetrics,
@@ -58,7 +57,7 @@ class IntUiButtonStyle(
 }
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiButtonColors(
     override val background: Brush,
     override val backgroundDisabled: Brush,
@@ -225,7 +224,7 @@ class IntUiButtonColors(
 }
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiButtonMetrics(
     override val cornerSize: CornerSize,
     override val padding: PaddingValues,

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiButtonStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiButtonStyling.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.IntUiTheme
@@ -19,7 +20,8 @@ import org.jetbrains.jewel.styling.ButtonMetrics
 import org.jetbrains.jewel.styling.ButtonStyle
 
 @Stable
-data class IntUiButtonStyle(
+@Poko
+class IntUiButtonStyle(
     override val colors: IntUiButtonColors,
     override val metrics: IntUiButtonMetrics,
 ) : ButtonStyle {
@@ -56,7 +58,8 @@ data class IntUiButtonStyle(
 }
 
 @Immutable
-data class IntUiButtonColors(
+@Poko
+class IntUiButtonColors(
     override val background: Brush,
     override val backgroundDisabled: Brush,
     override val backgroundFocused: Brush,
@@ -222,7 +225,8 @@ data class IntUiButtonColors(
 }
 
 @Stable
-data class IntUiButtonMetrics(
+@Poko
+class IntUiButtonMetrics(
     override val cornerSize: CornerSize,
     override val padding: PaddingValues,
     override val minSize: DpSize,

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiButtonStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiButtonStyling.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.GenerateDataFunctions
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.IntUiTheme

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxStyling.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.standalonePainterProvider
@@ -19,7 +18,7 @@ import org.jetbrains.jewel.styling.CheckboxMetrics
 import org.jetbrains.jewel.styling.CheckboxStyle
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiCheckboxStyle(
     override val colors: IntUiCheckboxColors,
     override val metrics: IntUiCheckboxMetrics,
@@ -43,7 +42,7 @@ class IntUiCheckboxStyle(
 }
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiCheckboxColors(
     override val checkboxBackground: Color,
     override val checkboxBackgroundDisabled: Color,
@@ -90,7 +89,7 @@ class IntUiCheckboxColors(
 }
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiCheckboxMetrics(
     override val checkboxSize: DpSize = DpSize(19.dp, 19.dp),
     override val checkboxCornerSize: CornerSize = CornerSize(3.dp),
@@ -100,7 +99,7 @@ class IntUiCheckboxMetrics(
 ) : CheckboxMetrics
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiCheckboxIcons(
     override val checkbox: PainterProvider,
 ) : CheckboxIcons {

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxStyling.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.standalonePainterProvider
@@ -17,7 +18,9 @@ import org.jetbrains.jewel.styling.CheckboxIcons
 import org.jetbrains.jewel.styling.CheckboxMetrics
 import org.jetbrains.jewel.styling.CheckboxStyle
 
-@Immutable data class IntUiCheckboxStyle(
+@Immutable
+@Poko
+class IntUiCheckboxStyle(
     override val colors: IntUiCheckboxColors,
     override val metrics: IntUiCheckboxMetrics,
     override val icons: IntUiCheckboxIcons,
@@ -39,7 +42,9 @@ import org.jetbrains.jewel.styling.CheckboxStyle
     }
 }
 
-@Immutable data class IntUiCheckboxColors(
+@Immutable
+@Poko
+class IntUiCheckboxColors(
     override val checkboxBackground: Color,
     override val checkboxBackgroundDisabled: Color,
     override val checkboxBackgroundSelected: Color,
@@ -84,7 +89,9 @@ import org.jetbrains.jewel.styling.CheckboxStyle
     }
 }
 
-@Immutable data class IntUiCheckboxMetrics(
+@Immutable
+@Poko
+class IntUiCheckboxMetrics(
     override val checkboxSize: DpSize = DpSize(19.dp, 19.dp),
     override val checkboxCornerSize: CornerSize = CornerSize(3.dp),
     override val outlineSize: DpSize = DpSize(15.dp, 15.dp),
@@ -92,7 +99,9 @@ import org.jetbrains.jewel.styling.CheckboxStyle
     override val iconContentGap: Dp = 5.dp,
 ) : CheckboxMetrics
 
-@Immutable data class IntUiCheckboxIcons(
+@Immutable
+@Poko
+class IntUiCheckboxIcons(
     override val checkbox: PainterProvider,
 ) : CheckboxIcons {
 

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiCheckboxStyling.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.GenerateDataFunctions
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.standalonePainterProvider

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiChipStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiChipStyling.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.GenerateDataFunctions
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.styling.ChipColors

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiChipStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiChipStyling.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.styling.ChipColors
@@ -18,7 +17,7 @@ import org.jetbrains.jewel.styling.ChipMetrics
 import org.jetbrains.jewel.styling.ChipStyle
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiChipStyle(
     override val colors: IntUiChipColors,
     override val metrics: IntUiChipMetrics,
@@ -41,7 +40,7 @@ class IntUiChipStyle(
 }
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiChipColors(
     override val background: Brush,
     override val backgroundDisabled: Brush,
@@ -210,7 +209,7 @@ class IntUiChipColors(
 }
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiChipMetrics(
     override val cornerSize: CornerSize = CornerSize(100),
     override val padding: PaddingValues = PaddingValues(horizontal = 12.dp, vertical = 8.dp),

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiChipStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiChipStyling.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.styling.ChipColors
@@ -17,7 +18,8 @@ import org.jetbrains.jewel.styling.ChipMetrics
 import org.jetbrains.jewel.styling.ChipStyle
 
 @Stable
-data class IntUiChipStyle(
+@Poko
+class IntUiChipStyle(
     override val colors: IntUiChipColors,
     override val metrics: IntUiChipMetrics,
 ) : ChipStyle {
@@ -39,7 +41,8 @@ data class IntUiChipStyle(
 }
 
 @Immutable
-data class IntUiChipColors(
+@Poko
+class IntUiChipColors(
     override val background: Brush,
     override val backgroundDisabled: Brush,
     override val backgroundFocused: Brush,
@@ -207,7 +210,8 @@ data class IntUiChipColors(
 }
 
 @Stable
-data class IntUiChipMetrics(
+@Poko
+class IntUiChipMetrics(
     override val cornerSize: CornerSize = CornerSize(100),
     override val padding: PaddingValues = PaddingValues(horizontal = 12.dp, vertical = 8.dp),
     override val borderWidth: Dp = 1.dp,

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiCircularProgressStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiCircularProgressStyling.kt
@@ -4,6 +4,7 @@ package org.jetbrains.jewel.intui.standalone.styling
 
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.Color
+import org.jetbrains.jewel.GenerateDataFunctions
 import org.jetbrains.jewel.styling.CircularProgressStyle
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiCircularProgressStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiCircularProgressStyling.kt
@@ -1,13 +1,17 @@
+@file:Suppress("MatchingDeclarationName", "ktlint:standard:filename") // Going for consistency with other files
+
 package org.jetbrains.jewel.intui.standalone.styling
 
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.Color
+import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.styling.CircularProgressStyle
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
 @Stable
-data class IntUiCircularProgressStyle(
+@Poko
+class IntUiCircularProgressStyle(
     override val frameTime: Duration,
     override val color: Color,
 ) : CircularProgressStyle {

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiCircularProgressStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiCircularProgressStyling.kt
@@ -4,13 +4,12 @@ package org.jetbrains.jewel.intui.standalone.styling
 
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.Color
-import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.styling.CircularProgressStyle
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiCircularProgressStyle(
     override val frameTime: Duration,
     override val color: Color,

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiDividerStyle.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiDividerStyle.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.GenerateDataFunctions
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.styling.DividerMetrics

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiDividerStyle.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiDividerStyle.kt
@@ -5,14 +5,13 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.styling.DividerMetrics
 import org.jetbrains.jewel.styling.DividerStyle
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiDividerStyle(
     override val color: Color,
     override val metrics: DividerMetrics,
@@ -35,7 +34,7 @@ class IntUiDividerStyle(
 }
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiDividerMetrics(
     override val thickness: Dp = 1.dp,
     override val startIndent: Dp = 0.dp,

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiDividerStyle.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiDividerStyle.kt
@@ -5,12 +5,14 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.styling.DividerMetrics
 import org.jetbrains.jewel.styling.DividerStyle
 
 @Immutable
+@Poko
 class IntUiDividerStyle(
     override val color: Color,
     override val metrics: DividerMetrics,
@@ -33,6 +35,7 @@ class IntUiDividerStyle(
 }
 
 @Immutable
+@Poko
 class IntUiDividerMetrics(
     override val thickness: Dp = 1.dp,
     override val startIndent: Dp = 0.dp,

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiDropdownStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiDropdownStyling.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.IntUiTheme
@@ -23,7 +22,7 @@ import org.jetbrains.jewel.styling.DropdownStyle
 import org.jetbrains.jewel.styling.MenuStyle
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiDropdownStyle(
     override val colors: IntUiDropdownColors,
     override val metrics: IntUiDropdownMetrics,
@@ -64,7 +63,7 @@ class IntUiDropdownStyle(
 }
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiDropdownColors(
     override val background: Color,
     override val backgroundDisabled: Color,
@@ -214,7 +213,7 @@ class IntUiDropdownColors(
 }
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiDropdownMetrics(
     override val arrowMinSize: DpSize = DpSize((23 + 3).dp, 24.dp),
     override val minSize: DpSize = DpSize((49 + 23 + 6).dp, 24.dp),
@@ -224,7 +223,7 @@ class IntUiDropdownMetrics(
 ) : DropdownMetrics
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiDropdownIcons(
     override val chevronDown: PainterProvider,
 ) : DropdownIcons {

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiDropdownStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiDropdownStyling.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.IntUiTheme
@@ -22,7 +23,8 @@ import org.jetbrains.jewel.styling.DropdownStyle
 import org.jetbrains.jewel.styling.MenuStyle
 
 @Stable
-data class IntUiDropdownStyle(
+@Poko
+class IntUiDropdownStyle(
     override val colors: IntUiDropdownColors,
     override val metrics: IntUiDropdownMetrics,
     override val icons: IntUiDropdownIcons,
@@ -62,7 +64,8 @@ data class IntUiDropdownStyle(
 }
 
 @Immutable
-data class IntUiDropdownColors(
+@Poko
+class IntUiDropdownColors(
     override val background: Color,
     override val backgroundDisabled: Color,
     override val backgroundFocused: Color,
@@ -211,7 +214,8 @@ data class IntUiDropdownColors(
 }
 
 @Stable
-data class IntUiDropdownMetrics(
+@Poko
+class IntUiDropdownMetrics(
     override val arrowMinSize: DpSize = DpSize((23 + 3).dp, 24.dp),
     override val minSize: DpSize = DpSize((49 + 23 + 6).dp, 24.dp),
     override val cornerSize: CornerSize = CornerSize(4.dp),
@@ -220,7 +224,8 @@ data class IntUiDropdownMetrics(
 ) : DropdownMetrics
 
 @Immutable
-data class IntUiDropdownIcons(
+@Poko
+class IntUiDropdownIcons(
     override val chevronDown: PainterProvider,
 ) : DropdownIcons {
 

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiDropdownStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiDropdownStyling.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.GenerateDataFunctions
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.IntUiTheme

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderStyling.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.GenerateDataFunctions
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.styling.GroupHeaderColors

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderStyling.kt
@@ -5,7 +5,6 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.styling.GroupHeaderColors
@@ -13,7 +12,7 @@ import org.jetbrains.jewel.styling.GroupHeaderMetrics
 import org.jetbrains.jewel.styling.GroupHeaderStyle
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiGroupHeaderStyle(
     override val colors: IntUiGroupHeaderColors,
     override val metrics: IntUiGroupHeaderMetrics,
@@ -36,7 +35,7 @@ class IntUiGroupHeaderStyle(
 }
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiGroupHeaderColors(
     override val divider: Color,
 ) : GroupHeaderColors {
@@ -56,7 +55,7 @@ class IntUiGroupHeaderColors(
 }
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiGroupHeaderMetrics(
     override val dividerThickness: Dp = 1.dp,
     override val indent: Dp = 8.dp,

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiGroupHeaderStyling.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.styling.GroupHeaderColors
@@ -12,7 +13,8 @@ import org.jetbrains.jewel.styling.GroupHeaderMetrics
 import org.jetbrains.jewel.styling.GroupHeaderStyle
 
 @Immutable
-data class IntUiGroupHeaderStyle(
+@Poko
+class IntUiGroupHeaderStyle(
     override val colors: IntUiGroupHeaderColors,
     override val metrics: IntUiGroupHeaderMetrics,
 ) : GroupHeaderStyle {
@@ -34,7 +36,8 @@ data class IntUiGroupHeaderStyle(
 }
 
 @Immutable
-data class IntUiGroupHeaderColors(
+@Poko
+class IntUiGroupHeaderColors(
     override val divider: Color,
 ) : GroupHeaderColors {
 
@@ -53,7 +56,8 @@ data class IntUiGroupHeaderColors(
 }
 
 @Immutable
-data class IntUiGroupHeaderMetrics(
+@Poko
+class IntUiGroupHeaderMetrics(
     override val dividerThickness: Dp = 1.dp,
     override val indent: Dp = 8.dp,
 ) : GroupHeaderMetrics

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarStyling.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.GenerateDataFunctions
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.styling.HorizontalProgressBarColors

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarStyling.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.styling.HorizontalProgressBarColors
@@ -16,7 +15,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiHorizontalProgressBarStyle(
     override val colors: IntUiHorizontalProgressBarColors,
     override val metrics: IntUiHorizontalProgressBarMetrics,
@@ -42,7 +41,7 @@ class IntUiHorizontalProgressBarStyle(
 }
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiHorizontalProgressBarColors(
     override val track: Color,
     override val progress: Color,
@@ -71,7 +70,7 @@ class IntUiHorizontalProgressBarColors(
 }
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiHorizontalProgressBarMetrics(
     override val cornerSize: CornerSize = CornerSize(100),
     override val minHeight: Dp = 4.dp,

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiHorizontalProgressBarStyling.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.styling.HorizontalProgressBarColors
@@ -15,7 +16,8 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
 @Immutable
-data class IntUiHorizontalProgressBarStyle(
+@Poko
+class IntUiHorizontalProgressBarStyle(
     override val colors: IntUiHorizontalProgressBarColors,
     override val metrics: IntUiHorizontalProgressBarMetrics,
     override val indeterminateCycleDuration: Duration,
@@ -40,7 +42,8 @@ data class IntUiHorizontalProgressBarStyle(
 }
 
 @Immutable
-data class IntUiHorizontalProgressBarColors(
+@Poko
+class IntUiHorizontalProgressBarColors(
     override val track: Color,
     override val progress: Color,
     override val indeterminateBase: Color,
@@ -68,7 +71,8 @@ data class IntUiHorizontalProgressBarColors(
 }
 
 @Immutable
-data class IntUiHorizontalProgressBarMetrics(
+@Poko
+class IntUiHorizontalProgressBarMetrics(
     override val cornerSize: CornerSize = CornerSize(100),
     override val minHeight: Dp = 4.dp,
     override val indeterminateHighlightWidth: Dp = 140.dp,

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiIconButtonStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiIconButtonStyling.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.styling.IconButtonColors
@@ -17,7 +16,7 @@ import org.jetbrains.jewel.styling.IconButtonMetrics
 import org.jetbrains.jewel.styling.IconButtonStyle
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiIconButtonStyle(
     override val colors: IntUiIconButtonColors,
     override val metrics: IntUiIconButtonMetrics,
@@ -34,7 +33,7 @@ class IntUiIconButtonStyle(
 }
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiIconButtonColors(
     override val background: Color,
     override val backgroundDisabled: Color,
@@ -105,7 +104,7 @@ class IntUiIconButtonColors(
 }
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiIconButtonMetrics(
     override val cornerSize: CornerSize = CornerSize(4.dp),
     override val borderWidth: Dp = 1.dp,

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiIconButtonStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiIconButtonStyling.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.GenerateDataFunctions
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.styling.IconButtonColors

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiIconButtonStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiIconButtonStyling.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.styling.IconButtonColors
@@ -16,7 +17,8 @@ import org.jetbrains.jewel.styling.IconButtonMetrics
 import org.jetbrains.jewel.styling.IconButtonStyle
 
 @Stable
-data class IntUiIconButtonStyle(
+@Poko
+class IntUiIconButtonStyle(
     override val colors: IntUiIconButtonColors,
     override val metrics: IntUiIconButtonMetrics,
 ) : IconButtonStyle {
@@ -32,7 +34,8 @@ data class IntUiIconButtonStyle(
 }
 
 @Immutable
-data class IntUiIconButtonColors(
+@Poko
+class IntUiIconButtonColors(
     override val background: Color,
     override val backgroundDisabled: Color,
     override val backgroundFocused: Color,
@@ -102,7 +105,8 @@ data class IntUiIconButtonColors(
 }
 
 @Stable
-data class IntUiIconButtonMetrics(
+@Poko
+class IntUiIconButtonMetrics(
     override val cornerSize: CornerSize = CornerSize(4.dp),
     override val borderWidth: Dp = 1.dp,
     override val padding: PaddingValues = PaddingValues(0.dp),

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldStyling.kt
@@ -11,7 +11,6 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.IntUiTheme
@@ -21,7 +20,7 @@ import org.jetbrains.jewel.styling.LabelledTextFieldStyle
 import org.jetbrains.jewel.styling.LabelledTextFieldTextStyles
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiLabelledTextFieldStyle(
     override val colors: IntUiLabelledTextFieldColors,
     override val metrics: IntUiLabelledTextFieldMetrics,
@@ -50,7 +49,7 @@ class IntUiLabelledTextFieldStyle(
 }
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiLabelledTextFieldColors(
     override val background: Color,
     override val backgroundDisabled: Color,
@@ -184,7 +183,7 @@ class IntUiLabelledTextFieldColors(
 }
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiLabelledTextFieldMetrics(
     override val cornerSize: CornerSize = CornerSize(4.dp),
     override val contentPadding: PaddingValues = PaddingValues(horizontal = 9.dp, vertical = 6.dp),
@@ -195,7 +194,7 @@ class IntUiLabelledTextFieldMetrics(
 ) : LabelledTextFieldMetrics
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiLabelledTextFieldTextStyles(
     override val label: TextStyle,
     override val hint: TextStyle,

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldStyling.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import org.jetbrains.jewel.GenerateDataFunctions
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.IntUiTheme

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiLabelledTextFieldStyling.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.IntUiTheme
@@ -20,7 +21,8 @@ import org.jetbrains.jewel.styling.LabelledTextFieldStyle
 import org.jetbrains.jewel.styling.LabelledTextFieldTextStyles
 
 @Stable
-data class IntUiLabelledTextFieldStyle(
+@Poko
+class IntUiLabelledTextFieldStyle(
     override val colors: IntUiLabelledTextFieldColors,
     override val metrics: IntUiLabelledTextFieldMetrics,
     override val textStyle: TextStyle,
@@ -48,7 +50,8 @@ data class IntUiLabelledTextFieldStyle(
 }
 
 @Immutable
-data class IntUiLabelledTextFieldColors(
+@Poko
+class IntUiLabelledTextFieldColors(
     override val background: Color,
     override val backgroundDisabled: Color,
     override val backgroundFocused: Color,
@@ -181,7 +184,8 @@ data class IntUiLabelledTextFieldColors(
 }
 
 @Stable
-data class IntUiLabelledTextFieldMetrics(
+@Poko
+class IntUiLabelledTextFieldMetrics(
     override val cornerSize: CornerSize = CornerSize(4.dp),
     override val contentPadding: PaddingValues = PaddingValues(horizontal = 9.dp, vertical = 6.dp),
     override val minSize: DpSize = DpSize(49.dp, 24.dp),
@@ -191,7 +195,8 @@ data class IntUiLabelledTextFieldMetrics(
 ) : LabelledTextFieldMetrics
 
 @Immutable
-data class IntUiLabelledTextFieldTextStyles(
+@Poko
+class IntUiLabelledTextFieldTextStyles(
     override val label: TextStyle,
     override val hint: TextStyle,
 ) : LabelledTextFieldTextStyles {

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeStyling.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.GenerateDataFunctions
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.standalonePainterProvider

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeStyling.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.standalonePainterProvider
@@ -19,7 +18,7 @@ import org.jetbrains.jewel.styling.LazyTreeMetrics
 import org.jetbrains.jewel.styling.LazyTreeStyle
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiLazyTreeStyle(
     override val colors: IntUiLazyTreeColors,
     override val metrics: IntUiLazyTreeMetrics,
@@ -45,7 +44,7 @@ class IntUiLazyTreeStyle(
 }
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiLazyTreeColors(
     override val content: Color,
     override val contentFocused: Color,
@@ -99,7 +98,7 @@ class IntUiLazyTreeColors(
 }
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiLazyTreeMetrics(
     override val indentSize: Dp = 7.dp + 16.dp,
     override val elementBackgroundCornerSize: CornerSize = CornerSize(2.dp),
@@ -110,7 +109,7 @@ class IntUiLazyTreeMetrics(
 ) : LazyTreeMetrics
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiLazyTreeIcons(
     override val chevronCollapsed: PainterProvider,
     override val chevronExpanded: PainterProvider,

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeStyling.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.standalonePainterProvider
@@ -18,7 +19,8 @@ import org.jetbrains.jewel.styling.LazyTreeMetrics
 import org.jetbrains.jewel.styling.LazyTreeStyle
 
 @Stable
-data class IntUiLazyTreeStyle(
+@Poko
+class IntUiLazyTreeStyle(
     override val colors: IntUiLazyTreeColors,
     override val metrics: IntUiLazyTreeMetrics,
     override val icons: IntUiLazyTreeIcons,
@@ -43,7 +45,8 @@ data class IntUiLazyTreeStyle(
 }
 
 @Immutable
-data class IntUiLazyTreeColors(
+@Poko
+class IntUiLazyTreeColors(
     override val content: Color,
     override val contentFocused: Color,
     override val contentSelected: Color,
@@ -96,7 +99,8 @@ data class IntUiLazyTreeColors(
 }
 
 @Stable
-data class IntUiLazyTreeMetrics(
+@Poko
+class IntUiLazyTreeMetrics(
     override val indentSize: Dp = 7.dp + 16.dp,
     override val elementBackgroundCornerSize: CornerSize = CornerSize(2.dp),
     override val elementPadding: PaddingValues = PaddingValues(horizontal = 12.dp),
@@ -106,7 +110,8 @@ data class IntUiLazyTreeMetrics(
 ) : LazyTreeMetrics
 
 @Immutable
-data class IntUiLazyTreeIcons(
+@Poko
+class IntUiLazyTreeIcons(
     override val chevronCollapsed: PainterProvider,
     override val chevronExpanded: PainterProvider,
     override val chevronSelectedCollapsed: PainterProvider,

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiLinkStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiLinkStyling.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.IntUiTheme
@@ -22,7 +21,7 @@ import org.jetbrains.jewel.styling.LinkStyle
 import org.jetbrains.jewel.styling.LinkTextStyles
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiLinkStyle(
     override val colors: IntUiLinkColors,
     override val metrics: IntUiLinkMetrics,
@@ -51,7 +50,7 @@ class IntUiLinkStyle(
 }
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiLinkColors(
     override val content: Color,
     override val contentDisabled: Color,
@@ -100,7 +99,7 @@ class IntUiLinkColors(
 }
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiLinkMetrics(
     override val focusHaloCornerSize: CornerSize = CornerSize(2.dp),
     override val textIconGap: Dp = 0.dp,
@@ -108,7 +107,7 @@ class IntUiLinkMetrics(
 ) : LinkMetrics
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiLinkIcons(
     override val dropdownChevron: PainterProvider,
     override val externalLink: PainterProvider,
@@ -135,7 +134,7 @@ fun intUiLinkIcons(
 ) = IntUiLinkIcons(dropdownChevron, externalLink)
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiLinkTextStyles(
     override val normal: TextStyle,
     override val disabled: TextStyle,

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiLinkStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiLinkStyling.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.IntUiTheme
@@ -21,7 +22,8 @@ import org.jetbrains.jewel.styling.LinkStyle
 import org.jetbrains.jewel.styling.LinkTextStyles
 
 @Immutable
-data class IntUiLinkStyle(
+@Poko
+class IntUiLinkStyle(
     override val colors: IntUiLinkColors,
     override val metrics: IntUiLinkMetrics,
     override val icons: IntUiLinkIcons,
@@ -49,7 +51,8 @@ data class IntUiLinkStyle(
 }
 
 @Immutable
-data class IntUiLinkColors(
+@Poko
+class IntUiLinkColors(
     override val content: Color,
     override val contentDisabled: Color,
     override val contentFocused: Color,
@@ -97,14 +100,16 @@ data class IntUiLinkColors(
 }
 
 @Immutable
-data class IntUiLinkMetrics(
+@Poko
+class IntUiLinkMetrics(
     override val focusHaloCornerSize: CornerSize = CornerSize(2.dp),
     override val textIconGap: Dp = 0.dp,
     override val iconSize: DpSize = DpSize(16.dp, 16.dp),
 ) : LinkMetrics
 
 @Immutable
-data class IntUiLinkIcons(
+@Poko
+class IntUiLinkIcons(
     override val dropdownChevron: PainterProvider,
     override val externalLink: PainterProvider,
 ) : LinkIcons {
@@ -130,7 +135,8 @@ fun intUiLinkIcons(
 ) = IntUiLinkIcons(dropdownChevron, externalLink)
 
 @Immutable
-data class IntUiLinkTextStyles(
+@Poko
+class IntUiLinkTextStyles(
     override val normal: TextStyle,
     override val disabled: TextStyle,
     override val focused: TextStyle,

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiLinkStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiLinkStyling.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.GenerateDataFunctions
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.IntUiTheme

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiMenuStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiMenuStyling.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.standalonePainterProvider
@@ -23,7 +22,7 @@ import org.jetbrains.jewel.styling.MenuStyle
 import org.jetbrains.jewel.styling.SubmenuMetrics
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiMenuStyle(
     override val colors: IntUiMenuColors,
     override val metrics: IntUiMenuMetrics,
@@ -49,7 +48,7 @@ class IntUiMenuStyle(
 }
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiMenuColors(
     override val background: Color,
     override val border: Color,
@@ -78,7 +77,7 @@ class IntUiMenuColors(
 }
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiMenuItemColors(
     override val background: Color,
     override val backgroundDisabled: Color,
@@ -177,7 +176,7 @@ class IntUiMenuItemColors(
 }
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiMenuMetrics(
     override val cornerSize: CornerSize = CornerSize(8.dp),
     override val menuMargin: PaddingValues = PaddingValues(vertical = 6.dp),
@@ -190,7 +189,7 @@ class IntUiMenuMetrics(
 ) : MenuMetrics
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiMenuItemMetrics(
     override val selectionCornerSize: CornerSize = CornerSize(4.dp),
     override val outerPadding: PaddingValues = PaddingValues(horizontal = 4.dp),
@@ -200,13 +199,13 @@ class IntUiMenuItemMetrics(
 ) : MenuItemMetrics
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiSubmenuMetrics(
     override val offset: DpOffset = DpOffset(0.dp, (-8).dp),
 ) : SubmenuMetrics
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiMenuIcons(
     override val submenuChevron: PainterProvider,
 ) : MenuIcons {

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiMenuStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiMenuStyling.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.standalonePainterProvider
@@ -22,7 +23,8 @@ import org.jetbrains.jewel.styling.MenuStyle
 import org.jetbrains.jewel.styling.SubmenuMetrics
 
 @Stable
-data class IntUiMenuStyle(
+@Poko
+class IntUiMenuStyle(
     override val colors: IntUiMenuColors,
     override val metrics: IntUiMenuMetrics,
     override val icons: IntUiMenuIcons,
@@ -47,7 +49,8 @@ data class IntUiMenuStyle(
 }
 
 @Immutable
-data class IntUiMenuColors(
+@Poko
+class IntUiMenuColors(
     override val background: Color,
     override val border: Color,
     override val shadow: Color,
@@ -75,7 +78,8 @@ data class IntUiMenuColors(
 }
 
 @Immutable
-data class IntUiMenuItemColors(
+@Poko
+class IntUiMenuItemColors(
     override val background: Color,
     override val backgroundDisabled: Color,
     override val backgroundFocused: Color,
@@ -173,7 +177,8 @@ data class IntUiMenuItemColors(
 }
 
 @Stable
-data class IntUiMenuMetrics(
+@Poko
+class IntUiMenuMetrics(
     override val cornerSize: CornerSize = CornerSize(8.dp),
     override val menuMargin: PaddingValues = PaddingValues(vertical = 6.dp),
     override val contentPadding: PaddingValues = PaddingValues(vertical = 8.dp),
@@ -185,7 +190,8 @@ data class IntUiMenuMetrics(
 ) : MenuMetrics
 
 @Stable
-data class IntUiMenuItemMetrics(
+@Poko
+class IntUiMenuItemMetrics(
     override val selectionCornerSize: CornerSize = CornerSize(4.dp),
     override val outerPadding: PaddingValues = PaddingValues(horizontal = 4.dp),
     override val contentPadding: PaddingValues = PaddingValues(horizontal = 12.dp, vertical = 4.dp),
@@ -194,12 +200,14 @@ data class IntUiMenuItemMetrics(
 ) : MenuItemMetrics
 
 @Stable
-data class IntUiSubmenuMetrics(
+@Poko
+class IntUiSubmenuMetrics(
     override val offset: DpOffset = DpOffset(0.dp, (-8).dp),
 ) : SubmenuMetrics
 
 @Immutable
-data class IntUiMenuIcons(
+@Poko
+class IntUiMenuIcons(
     override val submenuChevron: PainterProvider,
 ) : MenuIcons {
 

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiMenuStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiMenuStyling.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.GenerateDataFunctions
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.standalonePainterProvider

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonStyling.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.GenerateDataFunctions
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.standalonePainterProvider

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonStyling.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.standalonePainterProvider
@@ -16,7 +17,8 @@ import org.jetbrains.jewel.styling.RadioButtonMetrics
 import org.jetbrains.jewel.styling.RadioButtonStyle
 
 @Immutable
-data class IntUiRadioButtonStyle(
+@Poko
+class IntUiRadioButtonStyle(
     override val colors: IntUiRadioButtonColors,
     override val metrics: IntUiRadioButtonMetrics,
     override val icons: IntUiRadioButtonIcons,
@@ -41,7 +43,8 @@ data class IntUiRadioButtonStyle(
 }
 
 @Immutable
-data class IntUiRadioButtonColors(
+@Poko
+class IntUiRadioButtonColors(
     override val content: Color,
     override val contentHovered: Color,
     override val contentDisabled: Color,
@@ -89,13 +92,15 @@ data class IntUiRadioButtonColors(
 }
 
 @Immutable
-data class IntUiRadioButtonMetrics(
+@Poko
+class IntUiRadioButtonMetrics(
     override val radioButtonSize: DpSize = DpSize(19.dp, 19.dp),
     override val iconContentGap: Dp = 8.dp,
 ) : RadioButtonMetrics
 
 @Immutable
-data class IntUiRadioButtonIcons(
+@Poko
+class IntUiRadioButtonIcons(
     override val radioButton: PainterProvider,
 ) : RadioButtonIcons {
 

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiRadioButtonStyling.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.standalonePainterProvider
@@ -17,7 +16,7 @@ import org.jetbrains.jewel.styling.RadioButtonMetrics
 import org.jetbrains.jewel.styling.RadioButtonStyle
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiRadioButtonStyle(
     override val colors: IntUiRadioButtonColors,
     override val metrics: IntUiRadioButtonMetrics,
@@ -43,7 +42,7 @@ class IntUiRadioButtonStyle(
 }
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiRadioButtonColors(
     override val content: Color,
     override val contentHovered: Color,
@@ -92,14 +91,14 @@ class IntUiRadioButtonColors(
 }
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiRadioButtonMetrics(
     override val radioButtonSize: DpSize = DpSize(19.dp, 19.dp),
     override val iconContentGap: Dp = 8.dp,
 ) : RadioButtonMetrics
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiRadioButtonIcons(
     override val radioButton: PainterProvider,
 ) : RadioButtonIcons {

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarStyling.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.styling.ScrollbarColors
 import org.jetbrains.jewel.styling.ScrollbarMetrics
 import org.jetbrains.jewel.styling.ScrollbarStyle
@@ -16,7 +15,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiScrollbarStyle(
     override val colors: IntUiScrollbarColors,
     override val metrics: IntUiScrollbarMetrics,
@@ -42,7 +41,7 @@ class IntUiScrollbarStyle(
 }
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiScrollbarColors(
     override val thumbBackground: Color,
     override val thumbBackgroundHovered: Color,
@@ -65,7 +64,7 @@ class IntUiScrollbarColors(
 }
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiScrollbarMetrics(
     override val thumbCornerSize: CornerSize = CornerSize(100),
     override val thumbThickness: Dp = 8.dp,

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarStyling.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.styling.ScrollbarColors
 import org.jetbrains.jewel.styling.ScrollbarMetrics
 import org.jetbrains.jewel.styling.ScrollbarStyle
@@ -15,7 +16,8 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
 @Stable
-data class IntUiScrollbarStyle(
+@Poko
+class IntUiScrollbarStyle(
     override val colors: IntUiScrollbarColors,
     override val metrics: IntUiScrollbarMetrics,
     override val hoverDuration: Duration,
@@ -40,7 +42,8 @@ data class IntUiScrollbarStyle(
 }
 
 @Immutable
-data class IntUiScrollbarColors(
+@Poko
+class IntUiScrollbarColors(
     override val thumbBackground: Color,
     override val thumbBackgroundHovered: Color,
 ) : ScrollbarColors {
@@ -62,7 +65,8 @@ data class IntUiScrollbarColors(
 }
 
 @Stable
-data class IntUiScrollbarMetrics(
+@Poko
+class IntUiScrollbarMetrics(
     override val thumbCornerSize: CornerSize = CornerSize(100),
     override val thumbThickness: Dp = 8.dp,
     override val minThumbLength: Dp = 16.dp,

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarStyling.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.GenerateDataFunctions
 import org.jetbrains.jewel.styling.ScrollbarColors
 import org.jetbrains.jewel.styling.ScrollbarMetrics
 import org.jetbrains.jewel.styling.ScrollbarStyle

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTabStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTabStyling.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.standalonePainterProvider
@@ -19,7 +18,7 @@ import org.jetbrains.jewel.styling.TabMetrics
 import org.jetbrains.jewel.styling.TabStyle
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiTabStyle(
     override val colors: TabColors,
     override val metrics: TabMetrics,
@@ -67,7 +66,7 @@ class IntUiTabStyle(
 }
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiTabColors(
     override val background: Color,
     override val backgroundDisabled: Color,
@@ -259,7 +258,7 @@ class IntUiTabColors(
 }
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiTabMetrics(
     override val underlineThickness: Dp = 3.dp,
     override val tabPadding: PaddingValues = PaddingValues(horizontal = 8.dp),
@@ -268,7 +267,7 @@ class IntUiTabMetrics(
 ) : TabMetrics
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiTabContentAlpha(
     override val iconNormal: Float,
     override val iconDisabled: Float,
@@ -346,7 +345,7 @@ class IntUiTabContentAlpha(
 }
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiTabIcons(
     override val close: PainterProvider,
 ) : TabIcons {

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTabStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTabStyling.kt
@@ -3,9 +3,11 @@ package org.jetbrains.jewel.intui.standalone.styling
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.standalonePainterProvider
@@ -16,7 +18,9 @@ import org.jetbrains.jewel.styling.TabIcons
 import org.jetbrains.jewel.styling.TabMetrics
 import org.jetbrains.jewel.styling.TabStyle
 
-data class IntUiTabStyle(
+@Stable
+@Poko
+class IntUiTabStyle(
     override val colors: TabColors,
     override val metrics: TabMetrics,
     override val icons: TabIcons,
@@ -63,7 +67,8 @@ data class IntUiTabStyle(
 }
 
 @Immutable
-data class IntUiTabColors(
+@Poko
+class IntUiTabColors(
     override val background: Color,
     override val backgroundDisabled: Color,
     override val backgroundFocused: Color,
@@ -253,8 +258,9 @@ data class IntUiTabColors(
     }
 }
 
-@Immutable
-data class IntUiTabMetrics(
+@Stable
+@Poko
+class IntUiTabMetrics(
     override val underlineThickness: Dp = 3.dp,
     override val tabPadding: PaddingValues = PaddingValues(horizontal = 8.dp),
     override val closeContentGap: Dp = 8.dp,
@@ -262,7 +268,8 @@ data class IntUiTabMetrics(
 ) : TabMetrics
 
 @Immutable
-data class IntUiTabContentAlpha(
+@Poko
+class IntUiTabContentAlpha(
     override val iconNormal: Float,
     override val iconDisabled: Float,
     override val iconFocused: Float,
@@ -338,7 +345,9 @@ data class IntUiTabContentAlpha(
     }
 }
 
-data class IntUiTabIcons(
+@Immutable
+@Poko
+class IntUiTabIcons(
     override val close: PainterProvider,
 ) : TabIcons {
 

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTabStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTabStyling.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Stable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.GenerateDataFunctions
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.standalonePainterProvider

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaStyling.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.IntUiTheme
@@ -18,7 +19,8 @@ import org.jetbrains.jewel.styling.TextAreaColors
 import org.jetbrains.jewel.styling.TextAreaStyle
 
 @Stable
-data class IntUiTextAreaStyle(
+@Poko
+class IntUiTextAreaStyle(
     override val colors: IntUiTextAreaColors,
     override val metrics: IntUiTextAreaMetrics,
     override val textStyle: TextStyle,
@@ -43,7 +45,8 @@ data class IntUiTextAreaStyle(
 }
 
 @Immutable
-data class IntUiTextAreaColors(
+@Poko
+class IntUiTextAreaColors(
     override val background: Color,
     override val backgroundDisabled: Color,
     override val backgroundFocused: Color,
@@ -166,7 +169,8 @@ data class IntUiTextAreaColors(
 }
 
 @Stable
-data class IntUiTextAreaMetrics(
+@Poko
+class IntUiTextAreaMetrics(
     override val cornerSize: CornerSize = CornerSize(4.dp),
     override val contentPadding: PaddingValues = PaddingValues(horizontal = 6.dp, vertical = 2.dp),
     override val minSize: DpSize = DpSize(144.dp, 28.dp),

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaStyling.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.GenerateDataFunctions
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.IntUiTheme

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTextAreaStyling.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.IntUiTheme
@@ -19,7 +18,7 @@ import org.jetbrains.jewel.styling.TextAreaColors
 import org.jetbrains.jewel.styling.TextAreaStyle
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiTextAreaStyle(
     override val colors: IntUiTextAreaColors,
     override val metrics: IntUiTextAreaMetrics,
@@ -45,7 +44,7 @@ class IntUiTextAreaStyle(
 }
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiTextAreaColors(
     override val background: Color,
     override val backgroundDisabled: Color,
@@ -169,7 +168,7 @@ class IntUiTextAreaColors(
 }
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiTextAreaMetrics(
     override val cornerSize: CornerSize = CornerSize(4.dp),
     override val contentPadding: PaddingValues = PaddingValues(horizontal = 6.dp, vertical = 2.dp),

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldStyling.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.IntUiTheme
@@ -18,7 +19,8 @@ import org.jetbrains.jewel.styling.TextFieldColors
 import org.jetbrains.jewel.styling.TextFieldStyle
 
 @Stable
-data class IntUiTextFieldStyle(
+@Poko
+class IntUiTextFieldStyle(
     override val colors: IntUiTextFieldColors,
     override val metrics: IntUiTextFieldMetrics,
     override val textStyle: TextStyle,
@@ -43,7 +45,8 @@ data class IntUiTextFieldStyle(
 }
 
 @Immutable
-data class IntUiTextFieldColors(
+@Poko
+class IntUiTextFieldColors(
     override val background: Color,
     override val backgroundDisabled: Color,
     override val backgroundFocused: Color,
@@ -166,7 +169,8 @@ data class IntUiTextFieldColors(
 }
 
 @Stable
-data class IntUiTextFieldMetrics(
+@Poko
+class IntUiTextFieldMetrics(
     override val cornerSize: CornerSize = CornerSize(4.dp),
     override val contentPadding: PaddingValues = PaddingValues(horizontal = 9.dp, vertical = 6.dp),
     override val minSize: DpSize = DpSize(144.dp, 28.dp),

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldStyling.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
-import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.IntUiTheme
@@ -19,7 +18,7 @@ import org.jetbrains.jewel.styling.TextFieldColors
 import org.jetbrains.jewel.styling.TextFieldStyle
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiTextFieldStyle(
     override val colors: IntUiTextFieldColors,
     override val metrics: IntUiTextFieldMetrics,
@@ -45,7 +44,7 @@ class IntUiTextFieldStyle(
 }
 
 @Immutable
-@Poko
+@GenerateDataFunctions
 class IntUiTextFieldColors(
     override val background: Color,
     override val backgroundDisabled: Color,
@@ -169,7 +168,7 @@ class IntUiTextFieldColors(
 }
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiTextFieldMetrics(
     override val cornerSize: CornerSize = CornerSize(4.dp),
     override val contentPadding: PaddingValues = PaddingValues(horizontal = 9.dp, vertical = 6.dp),

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTextFieldStyling.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.GenerateDataFunctions
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.intui.standalone.IntUiTheme

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTooltipStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTooltipStyling.kt
@@ -9,7 +9,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.styling.TooltipColors
@@ -19,7 +18,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiTooltipStyle(
     override val colors: IntUiTooltipColors,
     override val metrics: IntUiTooltipMetrics,
@@ -48,7 +47,7 @@ class IntUiTooltipStyle(
 }
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiTooltipColors(
     override val content: Color,
     override val background: Color,
@@ -77,7 +76,7 @@ class IntUiTooltipColors(
 }
 
 @Stable
-@Poko
+@GenerateDataFunctions
 class IntUiTooltipMetrics(
     override val contentPadding: PaddingValues = PaddingValues(vertical = 9.dp, horizontal = 12.dp),
     override val showDelay: Duration = 0.milliseconds,

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTooltipStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTooltipStyling.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import dev.drewhamilton.poko.Poko
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.styling.TooltipColors
@@ -18,7 +19,8 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 
 @Stable
-data class IntUiTooltipStyle(
+@Poko
+class IntUiTooltipStyle(
     override val colors: IntUiTooltipColors,
     override val metrics: IntUiTooltipMetrics,
 ) : TooltipStyle {
@@ -46,7 +48,8 @@ data class IntUiTooltipStyle(
 }
 
 @Stable
-data class IntUiTooltipColors(
+@Poko
+class IntUiTooltipColors(
     override val content: Color,
     override val background: Color,
     override val border: Color,
@@ -74,7 +77,8 @@ data class IntUiTooltipColors(
 }
 
 @Stable
-data class IntUiTooltipMetrics(
+@Poko
+class IntUiTooltipMetrics(
     override val contentPadding: PaddingValues = PaddingValues(vertical = 9.dp, horizontal = 12.dp),
     override val showDelay: Duration = 0.milliseconds,
     override val cornerSize: CornerSize = CornerSize(5.dp),

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTooltipStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTooltipStyling.kt
@@ -9,6 +9,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.GenerateDataFunctions
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 import org.jetbrains.jewel.styling.TooltipColors


### PR DESCRIPTION
This is the first step of "the big refactor".

In this step:
 * We replace data classes in public APIs with [Poko](https://github.com/drewhamilton/Poko) — a compiler plugin that generates `equals`/`hashcode`/`toString` but not methods like `copy` and `componentN` which easily break binary compatibility. This fixes #83 (see issue for more details)
 * We add the kotlinx binary-compatibility-validator plugin, that generates a list of all public APIs exposed by the published modules — the bulk of the changes in this PR are the new `.api` files, that track the current state of the public API (they can be skipped when reviewing). A new `apiCheck` is added to the `check` task that ensures no changes break binary compatibility by mistake.
 * We add a new `validatePublicApi` task to published modules that breaks the `check` task whenever a data class is detected in the public API

---

> [!IMPORTANT]
> After this PR is merged, whenever adding new APIs, you need to run the `apiDump` method to update the `.api` files. If API changes are detected that are not in the `.api` files, the CI will fail.