### PR TITLE
Make lastActiveItemIndex public, so selection on hover can be implemented

### DIFF
--- a/foundation/api/foundation.api
+++ b/foundation/api/foundation.api
@@ -296,6 +296,7 @@ public final class org/jetbrains/jewel/foundation/lazy/SelectableLazyListState :
 	public final fun getFirstVisibleItemIndex ()I
 	public final fun getFirstVisibleItemScrollOffset ()I
 	public final fun getInteractionSource ()Landroidx/compose/foundation/interaction/InteractionSource;
+	public final fun getLastActiveItemIndex ()Ljava/lang/Integer;
 	public final fun getLayoutInfo ()Landroidx/compose/foundation/lazy/LazyListLayoutInfo;
 	public final fun getLazyListState ()Landroidx/compose/foundation/lazy/LazyListState;
 	public fun getSelectedKeys ()Ljava/util/List;
@@ -303,6 +304,7 @@ public final class org/jetbrains/jewel/foundation/lazy/SelectableLazyListState :
 	public fun scroll (Landroidx/compose/foundation/MutatePriority;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun scrollToItem (IZILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun scrollToItem$default (Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;IZILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun setLastActiveItemIndex (Ljava/lang/Integer;)V
 	public fun setSelectedKeys (Ljava/util/List;)V
 }
 

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/SelectableLazyListState.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/SelectableLazyListState.kt
@@ -35,7 +35,7 @@ class SelectableLazyListState(
     internal var lastKeyEventUsedMouse: Boolean = false
 
     override var selectedKeys by mutableStateOf(emptyList<Any>())
-    internal var lastActiveItemIndex: Int? = null
+    var lastActiveItemIndex: Int? = null
 
     /**
      *


### PR DESCRIPTION
For the case of selection on hover it is needed to manually modify lastActiveItemIndex, so let's make it public