### PR TITLE
Fix global border colors on old UI in bridge

### DIFF
--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/BridgeGlobalColors.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/BridgeGlobalColors.kt
@@ -1,6 +1,9 @@
 package org.jetbrains.jewel.bridge.theme
 
+import com.intellij.ide.ui.laf.darcula.DarculaUIUtil
+import com.intellij.ui.JBColor
 import org.jetbrains.jewel.bridge.retrieveColorOrUnspecified
+import org.jetbrains.jewel.bridge.toComposeColorOrUnspecified
 import org.jetbrains.jewel.foundation.BorderColors
 import org.jetbrains.jewel.foundation.GlobalColors
 import org.jetbrains.jewel.foundation.OutlineColors
@@ -15,9 +18,9 @@ fun GlobalColors.Companion.readFromLaF() =
 
 fun BorderColors.Companion.readFromLaF() =
     BorderColors(
-        normal = retrieveColorOrUnspecified("Component.borderColor"),
-        focused = retrieveColorOrUnspecified("Component.focusedBorderColor"),
-        disabled = retrieveColorOrUnspecified("*.disabledBorderColor"),
+        normal = JBColor.border().toComposeColorOrUnspecified(),
+        focused = DarculaUIUtil.getOutlineColor(true, true).toComposeColorOrUnspecified(),
+        disabled = DarculaUIUtil.getOutlineColor(false, false).toComposeColorOrUnspecified(),
     )
 
 fun OutlineColors.Companion.readFromLaF() =


### PR DESCRIPTION
This PR fixes some border consistency issues in old ui themes. Specifically, dividers were using the wrong color. I replaced the direct lookups with the same JBColor/DarculaUIUtil calls that Swing uses.