### PR TITLE
Updated state in Checkbox component to remember checked state.

### DIFF
--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Checkbox.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Checkbox.kt
@@ -67,7 +67,7 @@ fun Checkbox(
     icons: CheckboxIcons = JewelTheme.checkboxStyle.icons,
     textStyle: TextStyle = LocalTextStyle.current,
 ) {
-    val state by remember { mutableStateOf(ToggleableState(checked)) }
+    val state by remember(checked) { mutableStateOf(ToggleableState(checked)) }
     CheckboxImpl(
         state = state,
         onClick = { onCheckedChange.invoke(!checked) },


### PR DESCRIPTION
This PR fixes a subtle bug on the Checkbox composable variant that takes a boolean and doesn't include a label. The remember was missing the key to invalidate its state when the boolean parameter changed.