### PR TITLE
Refactor component styling API for extension components

### DIFF
--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/SwingBridgeTheme.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/SwingBridgeTheme.kt
@@ -21,7 +21,7 @@ fun SwingBridgeTheme(content: @Composable () -> Unit) {
 
     // TODO handle non-Int UI themes, too
     BaseJewelTheme(themeData.themeDefinition, {
-        themeData.componentStyling.providedStyles()
+        provide(providedValues = themeData.componentStyling.providedStyles())
     }, swingCompatMode = true) {
         CompositionLocalProvider(LocalPainterHintsProvider provides BridgePainterHintsProvider(themeData.themeDefinition.isDark)) {
             content()

--- a/int-ui/int-ui-decorated-window/api/int-ui-decorated-window.api
+++ b/int-ui/int-ui-decorated-window/api/int-ui-decorated-window.api
@@ -3,7 +3,7 @@ public final class org/jetbrains/jewel/intui/window/IntUiDecoratedWindowResource
 }
 
 public final class org/jetbrains/jewel/intui/window/IntUiThemeKt {
-	public static final fun decoratedWindowComponentStyling (Lorg/jetbrains/jewel/foundation/theme/ThemeDefinition;Lorg/jetbrains/jewel/window/styling/DecoratedWindowStyle;Lorg/jetbrains/jewel/window/styling/TitleBarStyle;Landroidx/compose/runtime/Composer;II)[Landroidx/compose/runtime/ProvidedValue;
+	public static final fun provideDecoratedWindowComponentStyling (Lorg/jetbrains/jewel/ui/theme/ComponentStyleProviderScope;Lorg/jetbrains/jewel/window/styling/DecoratedWindowStyle;Lorg/jetbrains/jewel/window/styling/TitleBarStyle;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class org/jetbrains/jewel/intui/window/styling/IntUiDecoratedWindowStylingKt {

--- a/int-ui/int-ui-decorated-window/src/main/kotlin/org/jetbrains/jewel/intui/window/IntUiTheme.kt
+++ b/int-ui/int-ui-decorated-window/src/main/kotlin/org/jetbrains/jewel/intui/window/IntUiTheme.kt
@@ -1,28 +1,27 @@
 package org.jetbrains.jewel.intui.window
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ProvidedValue
-import org.jetbrains.jewel.foundation.theme.ThemeDefinition
 import org.jetbrains.jewel.intui.window.styling.dark
 import org.jetbrains.jewel.intui.window.styling.light
+import org.jetbrains.jewel.ui.theme.ComponentStyleProviderScope
 import org.jetbrains.jewel.window.styling.DecoratedWindowStyle
 import org.jetbrains.jewel.window.styling.LocalDecoratedWindowStyle
 import org.jetbrains.jewel.window.styling.LocalTitleBarStyle
 import org.jetbrains.jewel.window.styling.TitleBarStyle
 
 @Composable
-fun ThemeDefinition.decoratedWindowComponentStyling(
-    windowStyle: DecoratedWindowStyle = if (isDark) {
+fun ComponentStyleProviderScope.provideDecoratedWindowComponentStyling(
+    windowStyle: DecoratedWindowStyle = if (theme.isDark) {
         DecoratedWindowStyle.dark()
     } else {
         DecoratedWindowStyle.light()
     },
-    titleBarStyle: TitleBarStyle = if (isDark) {
+    titleBarStyle: TitleBarStyle = if (theme.isDark) {
         TitleBarStyle.dark()
     } else {
         TitleBarStyle.light()
     },
-): Array<ProvidedValue<*>> = arrayOf(
+) = provide(
     LocalDecoratedWindowStyle provides windowStyle,
     LocalTitleBarStyle provides titleBarStyle,
 )

--- a/int-ui/int-ui-decorated-window/src/main/kotlin/org/jetbrains/jewel/intui/window/IntUiTheme.kt
+++ b/int-ui/int-ui-decorated-window/src/main/kotlin/org/jetbrains/jewel/intui/window/IntUiTheme.kt
@@ -21,7 +21,9 @@ fun ComponentStyleProviderScope.provideDecoratedWindowComponentStyling(
     } else {
         TitleBarStyle.light()
     },
-) = provide(
-    LocalDecoratedWindowStyle provides windowStyle,
-    LocalTitleBarStyle provides titleBarStyle,
-)
+) {
+    provide(
+        LocalDecoratedWindowStyle provides windowStyle,
+        LocalTitleBarStyle provides titleBarStyle,
+    )
+}

--- a/int-ui/int-ui-standalone/api/int-ui-standalone.api
+++ b/int-ui/int-ui-standalone/api/int-ui-standalone.api
@@ -321,6 +321,13 @@ public final class org/jetbrains/jewel/intui/standalone/styling/IntUiUndecorated
 	public final fun light (Lorg/jetbrains/jewel/ui/component/styling/DropdownColors;Lorg/jetbrains/jewel/ui/component/styling/DropdownMetrics;Lorg/jetbrains/jewel/ui/component/styling/DropdownIcons;Landroidx/compose/ui/text/TextStyle;Lorg/jetbrains/jewel/ui/component/styling/MenuStyle;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/ui/component/styling/DropdownStyle;
 }
 
+public final class org/jetbrains/jewel/intui/standalone/theme/ComposableSingletons$IntUiThemeKt {
+	public static final field INSTANCE Lorg/jetbrains/jewel/intui/standalone/theme/ComposableSingletons$IntUiThemeKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public fun <init> ()V
+	public final fun getLambda-1$int_ui_standalone ()Lkotlin/jvm/functions/Function3;
+}
+
 public final class org/jetbrains/jewel/intui/standalone/theme/IntUiGlobalColorsKt {
 	public static final fun dark-GyCwops (Lorg/jetbrains/jewel/foundation/BorderColors$Companion;JJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/foundation/BorderColors;
 	public static final fun dark-Hformbs (Lorg/jetbrains/jewel/foundation/OutlineColors$Companion;JJJJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/foundation/OutlineColors;
@@ -336,7 +343,7 @@ public final class org/jetbrains/jewel/intui/standalone/theme/IntUiGlobalMetrics
 }
 
 public final class org/jetbrains/jewel/intui/standalone/theme/IntUiThemeKt {
-	public static final fun IntUiTheme (Lorg/jetbrains/jewel/foundation/theme/ThemeDefinition;Lkotlin/jvm/functions/Function2;ZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun IntUiTheme (Lorg/jetbrains/jewel/foundation/theme/ThemeDefinition;Lkotlin/jvm/functions/Function3;ZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 	public static final fun IntUiTheme (ZZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 	public static final fun darkComponentStyling (Lorg/jetbrains/jewel/foundation/theme/JewelTheme$Companion;Lorg/jetbrains/jewel/ui/component/styling/CheckboxStyle;Lorg/jetbrains/jewel/ui/component/styling/ChipStyle;Lorg/jetbrains/jewel/ui/component/styling/CircularProgressStyle;Lorg/jetbrains/jewel/ui/component/styling/ButtonStyle;Lorg/jetbrains/jewel/ui/component/styling/TabStyle;Lorg/jetbrains/jewel/ui/component/styling/DividerStyle;Lorg/jetbrains/jewel/ui/component/styling/DropdownStyle;Lorg/jetbrains/jewel/ui/component/styling/TabStyle;Lorg/jetbrains/jewel/ui/component/styling/GroupHeaderStyle;Lorg/jetbrains/jewel/ui/component/styling/HorizontalProgressBarStyle;Lorg/jetbrains/jewel/ui/component/styling/IconButtonStyle;Lorg/jetbrains/jewel/ui/component/styling/LabelledTextFieldStyle;Lorg/jetbrains/jewel/ui/component/styling/LazyTreeStyle;Lorg/jetbrains/jewel/ui/component/styling/LinkStyle;Lorg/jetbrains/jewel/ui/component/styling/MenuStyle;Lorg/jetbrains/jewel/ui/component/styling/ButtonStyle;Lorg/jetbrains/jewel/ui/component/styling/RadioButtonStyle;Lorg/jetbrains/jewel/ui/component/styling/ScrollbarStyle;Lorg/jetbrains/jewel/ui/component/styling/TextAreaStyle;Lorg/jetbrains/jewel/ui/component/styling/TextFieldStyle;Lorg/jetbrains/jewel/ui/component/styling/TooltipStyle;Lorg/jetbrains/jewel/ui/component/styling/DropdownStyle;Landroidx/compose/runtime/Composer;IIII)Lorg/jetbrains/jewel/ui/ComponentStyling;
 	public static final fun darkThemeDefinition-RFMEUTM (Lorg/jetbrains/jewel/foundation/theme/JewelTheme$Companion;Lorg/jetbrains/jewel/foundation/GlobalColors;Lorg/jetbrains/jewel/foundation/GlobalMetrics;Lorg/jetbrains/jewel/foundation/theme/ThemeColorPalette;Lorg/jetbrains/jewel/foundation/theme/ThemeIconData;Landroidx/compose/ui/text/TextStyle;JLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/foundation/theme/ThemeDefinition;

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/theme/IntUiTheme.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/theme/IntUiTheme.kt
@@ -2,7 +2,6 @@ package org.jetbrains.jewel.intui.standalone.theme
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.ProvidedValue
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
@@ -47,6 +46,7 @@ import org.jetbrains.jewel.ui.component.styling.TextFieldStyle
 import org.jetbrains.jewel.ui.component.styling.TooltipStyle
 import org.jetbrains.jewel.ui.painter.LocalPainterHintsProvider
 import org.jetbrains.jewel.ui.theme.BaseJewelTheme
+import org.jetbrains.jewel.ui.theme.ComponentStyleProviderScope
 
 val JewelTheme.Companion.defaultTextStyle
     get() = TextStyle.Default.copy(
@@ -193,7 +193,7 @@ fun IntUiTheme(
 
     IntUiTheme(
         theme = themeDefinition,
-        componentStyling = { emptyArray() },
+        componentStyling = { },
         swingCompatMode = swingCompatMode,
         content = content,
     )
@@ -202,13 +202,16 @@ fun IntUiTheme(
 @Composable
 fun IntUiTheme(
     theme: ThemeDefinition,
-    componentStyling: @Composable () -> Array<ProvidedValue<*>>,
+    componentStyling: @Composable ComponentStyleProviderScope.() -> Unit,
     swingCompatMode: Boolean = false,
     content: @Composable () -> Unit,
 ) {
     BaseJewelTheme(
         theme,
-        componentStyling = { JewelTheme.defaultComponentStyling(theme).providedStyles() + componentStyling() },
+        componentStyling = {
+            provide(providedValues = JewelTheme.defaultComponentStyling(theme).providedStyles())
+            componentStyling()
+        },
         swingCompatMode,
     ) {
         CompositionLocalProvider(

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/Main.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/Main.kt
@@ -35,7 +35,7 @@ import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.intui.standalone.theme.IntUiTheme
 import org.jetbrains.jewel.intui.standalone.theme.darkThemeDefinition
 import org.jetbrains.jewel.intui.standalone.theme.lightThemeDefinition
-import org.jetbrains.jewel.intui.window.decoratedWindowComponentStyling
+import org.jetbrains.jewel.intui.window.provideDecoratedWindowComponentStyling
 import org.jetbrains.jewel.intui.window.styling.dark
 import org.jetbrains.jewel.intui.window.styling.light
 import org.jetbrains.jewel.intui.window.styling.lightWithLightHeader
@@ -95,7 +95,7 @@ fun main() {
         IntUiTheme(
             themeDefinition,
             componentStyling = {
-                themeDefinition.decoratedWindowComponentStyling(
+                provideDecoratedWindowComponentStyling(
                     titleBarStyle = when (theme) {
                         IntUiThemes.Light -> TitleBarStyle.light()
                         IntUiThemes.LightWithLightHeader -> TitleBarStyle.lightWithLightHeader()

--- a/ui/api/ui.api
+++ b/ui/api/ui.api
@@ -2227,9 +2227,14 @@ public final class org/jetbrains/jewel/ui/painter/hints/StrokeKt {
 	public static synthetic fun Stroke$default (ZILjava/lang/Object;)Lorg/jetbrains/jewel/ui/painter/PainterHint;
 }
 
+public abstract interface class org/jetbrains/jewel/ui/theme/ComponentStyleProviderScope {
+	public abstract fun getTheme ()Lorg/jetbrains/jewel/foundation/theme/ThemeDefinition;
+	public abstract fun provide ([Landroidx/compose/runtime/ProvidedValue;)V
+}
+
 public final class org/jetbrains/jewel/ui/theme/JewelThemeKt {
-	public static final fun BaseJewelTheme (Lorg/jetbrains/jewel/foundation/theme/ThemeDefinition;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
-	public static final fun BaseJewelTheme (Lorg/jetbrains/jewel/foundation/theme/ThemeDefinition;Lkotlin/jvm/functions/Function2;ZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun BaseJewelTheme (Lorg/jetbrains/jewel/foundation/theme/ThemeDefinition;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+	public static final fun BaseJewelTheme (Lorg/jetbrains/jewel/foundation/theme/ThemeDefinition;Lkotlin/jvm/functions/Function3;ZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 	public static final fun getCheckboxStyle (Lorg/jetbrains/jewel/foundation/theme/JewelTheme$Companion;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/ui/component/styling/CheckboxStyle;
 	public static final fun getChipStyle (Lorg/jetbrains/jewel/foundation/theme/JewelTheme$Companion;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/ui/component/styling/ChipStyle;
 	public static final fun getCircularProgressStyle (Lorg/jetbrains/jewel/foundation/theme/JewelTheme$Companion;Landroidx/compose/runtime/Composer;I)Lorg/jetbrains/jewel/ui/component/styling/CircularProgressStyle;

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/theme/JewelTheme.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/theme/JewelTheme.kt
@@ -175,7 +175,7 @@ val JewelTheme.Companion.iconButtonStyle: IconButtonStyle
 @Composable
 fun BaseJewelTheme(
     theme: ThemeDefinition,
-    componentStyling: @Composable () -> Array<ProvidedValue<*>>,
+    componentStyling: @Composable ComponentStyleProviderScope.() -> Unit,
     content: @Composable () -> Unit,
 ) {
     BaseJewelTheme(theme, componentStyling, swingCompatMode = false, content)
@@ -184,7 +184,7 @@ fun BaseJewelTheme(
 @Composable
 fun BaseJewelTheme(
     theme: ThemeDefinition,
-    componentStyling: @Composable () -> Array<ProvidedValue<*>>,
+    componentStyling: @Composable ComponentStyleProviderScope.() -> Unit,
     swingCompatMode: Boolean = false,
     content: @Composable () -> Unit,
 ) {
@@ -194,7 +194,32 @@ fun BaseJewelTheme(
             LocalIconData provides theme.iconData,
             LocalIndication provides NoIndication,
         ) {
-            CompositionLocalProvider(values = componentStyling(), content = content)
+            val scope = ComponentStyleProviderScopeImpl(theme)
+            scope.componentStyling()
+            CompositionLocalProvider(
+                values = scope.styles(),
+                content = content,
+            )
         }
+    }
+}
+
+interface ComponentStyleProviderScope {
+
+    val theme: ThemeDefinition
+
+    fun provide(vararg providedValues: ProvidedValue<*>)
+}
+
+private class ComponentStyleProviderScopeImpl(override val theme: ThemeDefinition) : ComponentStyleProviderScope {
+
+    private val styles = mutableListOf<ProvidedValue<*>>()
+
+    fun styles(): Array<ProvidedValue<*>> {
+        return styles.toTypedArray()
+    }
+
+    override fun provide(vararg providedValues: ProvidedValue<*>) {
+        styles.addAll(providedValues)
     }
 }

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/theme/JewelTheme.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/theme/JewelTheme.kt
@@ -215,9 +215,7 @@ private class ComponentStyleProviderScopeImpl(override val theme: ThemeDefinitio
 
     private val styles = mutableListOf<ProvidedValue<*>>()
 
-    fun styles(): Array<ProvidedValue<*>> {
-        return styles.toTypedArray()
-    }
+    fun styles(): Array<ProvidedValue<*>> = styles.toTypedArray()
 
     override fun provide(vararg providedValues: ProvidedValue<*>) {
         styles.addAll(providedValues)


### PR DESCRIPTION
This PR improves the theme's ComponentStyling API and provides a more usable and easy-to-understand pattern for extending controls.

Before:
```Kotlin
IntUiTheme(
    themeDefinition,
    componentStyling = {
        themeDefinition.decoratedWindowComponentStyling() + themeDefinition.extensionComponentStyling() + themeDefinition.extensionComponent2Styling() + themeDefinition.extensionComponent3Styling()
    }
) {
    Box {}
}
```

After:
```Kotlin
IntUiTheme(
    themeDefinition,
    componentStyling = {
        provideDecoratedWindowComponentStyling()
        provideExtensionComponentStyling()
        provideExtensionComponent2Styling()
        provideExtensionComponent3Styling()
    }
) {
    Box {}
}
```