### PR TITLE
Update Gradle version and Java toolchain

### DIFF
--- a/buildSrc/src/main/kotlin/IdeaConfiguration.kt
+++ b/buildSrc/src/main/kotlin/IdeaConfiguration.kt
@@ -1,5 +1,7 @@
 import java.util.concurrent.atomic.AtomicBoolean
 import org.gradle.api.Project
+import org.gradle.api.provider.Property
+import org.gradle.jvm.toolchain.JavaLanguageVersion
 
 enum class SupportedIJVersion {
     IJ_232,
@@ -35,3 +37,6 @@ fun Project.supportedIJVersion(): SupportedIJVersion {
         )
     }
 }
+
+fun Property<JavaLanguageVersion>.assign(version: Int) =
+    set(JavaLanguageVersion.of(version))

--- a/buildSrc/src/main/kotlin/jewel.gradle.kts
+++ b/buildSrc/src/main/kotlin/jewel.gradle.kts
@@ -15,8 +15,18 @@ version = when {
     else -> "1.0.0-SNAPSHOT"
 }
 
+java {
+    toolchain {
+        vendor = JvmVendorSpec.JETBRAINS
+        languageVersion = 17
+    }
+}
+
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain {
+        vendor = JvmVendorSpec.JETBRAINS
+        languageVersion = 17
+    }
     target {
         compilations.all {
             kotlinOptions {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/samples/standalone/build.gradle.kts
+++ b/samples/standalone/build.gradle.kts
@@ -37,3 +37,17 @@ compose.desktop {
         }
     }
 }
+
+tasks {
+    withType<JavaExec> {
+        // afterEvaluate is needed because the Compose Gradle Plugin
+        // register the task in the afterEvaluate block
+        afterEvaluate {
+            javaLauncher = project.javaToolchains.launcherFor {
+                languageVersion = 17
+                vendor = JvmVendorSpec.JETBRAINS
+            }
+            setExecutable(javaLauncher.map { it.executablePath.asFile.absolutePath }.get())
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,6 +27,7 @@ dependencyResolutionManagement {
 
 plugins {
     id("com.gradle.enterprise") version "3.15.1"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.7.0"
 }
 
 include(


### PR DESCRIPTION
Updated Gradle version in gradle-wrapper.properties from 8.3 to 8.4. Also, reconfigured the Java and Kotlin JVM toolchains to use JetBrains JDK 17. In addition, added a new plugin "foojay-resolver-convention" in settings.gradle.kts.