### PR TITLE
Refactor key-bindings and pointer event handlers and fixed meta pressed on macos

### DIFF
--- a/foundation/api/foundation.api
+++ b/foundation/api/foundation.api
@@ -128,6 +128,17 @@ public final class org/jetbrains/jewel/foundation/StrokeKt {
 	public static synthetic fun Stroke-nMwvq1g$default (FJLorg/jetbrains/jewel/foundation/Stroke$Alignment;FILjava/lang/Object;)Lorg/jetbrains/jewel/foundation/Stroke;
 }
 
+public class org/jetbrains/jewel/foundation/lazy/DefaultMacOsSelectableColumnKeybindings : org/jetbrains/jewel/foundation/lazy/DefaultSelectableColumnKeybindings {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/foundation/lazy/DefaultMacOsSelectableColumnKeybindings$Companion;
+	public fun <init> ()V
+	public fun isMultiSelectionKeyPressed-5xRPYO0 (I)Z
+	public fun isMultiSelectionKeyPressed-ZmokQxo (Ljava/lang/Object;)Z
+}
+
+public final class org/jetbrains/jewel/foundation/lazy/DefaultMacOsSelectableColumnKeybindings$Companion : org/jetbrains/jewel/foundation/lazy/DefaultMacOsSelectableColumnKeybindings {
+}
+
 public class org/jetbrains/jewel/foundation/lazy/DefaultSelectableColumnKeybindings : org/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings {
 	public static final field $stable I
 	public static final field Companion Lorg/jetbrains/jewel/foundation/lazy/DefaultSelectableColumnKeybindings$Companion;
@@ -137,9 +148,10 @@ public class org/jetbrains/jewel/foundation/lazy/DefaultSelectableColumnKeybindi
 	public fun extendSelectionToLastItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
 	public fun extendSelectionWithNextItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
 	public fun extendSelectionWithPreviousItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public fun isKeyboardCtrlMetaKeyPressed-ZmokQxo (Ljava/lang/Object;)Z
-	public fun isKeyboardMultiSelectionKeyPressed-5xRPYO0 (I)Z
-	public fun isKeyboardMultiSelectionKeyPressed-ZmokQxo (Ljava/lang/Object;)Z
+	public fun isContiguousSelectionKeyPressed-5xRPYO0 (I)Z
+	public fun isContiguousSelectionKeyPressed-ZmokQxo (Ljava/lang/Object;)Z
+	public fun isMultiSelectionKeyPressed-5xRPYO0 (I)Z
+	public fun isMultiSelectionKeyPressed-ZmokQxo (Ljava/lang/Object;)Z
 	public fun scrollPageDownAndExtendSelection-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
 	public fun scrollPageDownAndSelectItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
 	public fun scrollPageUpAndExtendSelection-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
@@ -184,9 +196,10 @@ public abstract interface class org/jetbrains/jewel/foundation/lazy/SelectableCo
 	public abstract fun extendSelectionToLastItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
 	public abstract fun extendSelectionWithNextItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
 	public abstract fun extendSelectionWithPreviousItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public abstract fun isKeyboardCtrlMetaKeyPressed-ZmokQxo (Ljava/lang/Object;)Z
-	public abstract fun isKeyboardMultiSelectionKeyPressed-5xRPYO0 (I)Z
-	public abstract fun isKeyboardMultiSelectionKeyPressed-ZmokQxo (Ljava/lang/Object;)Z
+	public abstract fun isContiguousSelectionKeyPressed-5xRPYO0 (I)Z
+	public abstract fun isContiguousSelectionKeyPressed-ZmokQxo (Ljava/lang/Object;)Z
+	public abstract fun isMultiSelectionKeyPressed-5xRPYO0 (I)Z
+	public abstract fun isMultiSelectionKeyPressed-ZmokQxo (Ljava/lang/Object;)Z
 	public abstract fun scrollPageDownAndExtendSelection-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
 	public abstract fun scrollPageDownAndSelectItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
 	public abstract fun scrollPageUpAndExtendSelection-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
@@ -196,12 +209,6 @@ public abstract interface class org/jetbrains/jewel/foundation/lazy/SelectableCo
 	public abstract fun selectLastItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
 	public abstract fun selectNextItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
 	public abstract fun selectPreviousItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-}
-
-public final class org/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings$DefaultImpls {
-	public static fun isKeyboardCtrlMetaKeyPressed-ZmokQxo (Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;Ljava/lang/Object;)Z
-	public static fun isKeyboardMultiSelectionKeyPressed-5xRPYO0 (Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;I)Z
-	public static fun isKeyboardMultiSelectionKeyPressed-ZmokQxo (Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;Ljava/lang/Object;)Z
 }
 
 public abstract interface class org/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent {
@@ -363,14 +370,14 @@ public class org/jetbrains/jewel/foundation/lazy/tree/DefaultMacOsTreeColumnKeyb
 	public static final field $stable I
 	public static final field Companion Lorg/jetbrains/jewel/foundation/lazy/tree/DefaultMacOsTreeColumnKeybindings$Companion;
 	public fun <init> ()V
-	public fun isKeyboardMultiSelectionKeyPressed-5xRPYO0 (I)Z
-	public fun isKeyboardMultiSelectionKeyPressed-ZmokQxo (Ljava/lang/Object;)Z
+	public fun isMultiSelectionKeyPressed-5xRPYO0 (I)Z
+	public fun isMultiSelectionKeyPressed-ZmokQxo (Ljava/lang/Object;)Z
 }
 
 public final class org/jetbrains/jewel/foundation/lazy/tree/DefaultMacOsTreeColumnKeybindings$Companion : org/jetbrains/jewel/foundation/lazy/tree/DefaultMacOsTreeColumnKeybindings {
 }
 
-public final class org/jetbrains/jewel/foundation/lazy/tree/DefaultSelectableLazyColumnEventAction : org/jetbrains/jewel/foundation/lazy/tree/PointerEventActions {
+public class org/jetbrains/jewel/foundation/lazy/tree/DefaultSelectableLazyColumnEventAction : org/jetbrains/jewel/foundation/lazy/tree/PointerEventActions {
 	public static final field $stable I
 	public fun <init> ()V
 	public fun handlePointerEventPress (Landroidx/compose/ui/input/pointer/PointerEvent;Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;Ljava/util/List;Ljava/lang/Object;)V
@@ -380,15 +387,20 @@ public final class org/jetbrains/jewel/foundation/lazy/tree/DefaultSelectableLaz
 
 public class org/jetbrains/jewel/foundation/lazy/tree/DefaultSelectableLazyColumnKeyActions : org/jetbrains/jewel/foundation/lazy/tree/KeyBindingActions {
 	public static final field $stable I
-	public fun <init> ()V
+	public static final field Companion Lorg/jetbrains/jewel/foundation/lazy/tree/DefaultSelectableLazyColumnKeyActions$Companion;
+	public fun <init> (Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent;)V
+	public synthetic fun <init> (Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getActions ()Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent;
 	public fun getKeybindings ()Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;
 	public fun handleOnKeyEvent-jhbQyNo (Ljava/lang/Object;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;)Lkotlin/jvm/functions/Function1;
 }
 
+public final class org/jetbrains/jewel/foundation/lazy/tree/DefaultSelectableLazyColumnKeyActions$Companion : org/jetbrains/jewel/foundation/lazy/tree/DefaultSelectableLazyColumnKeyActions {
+}
+
 public final class org/jetbrains/jewel/foundation/lazy/tree/DefaultTreeViewKeyActions : org/jetbrains/jewel/foundation/lazy/tree/DefaultSelectableLazyColumnKeyActions {
 	public static final field $stable I
-	public fun <init> (Lorg/jetbrains/jewel/foundation/lazy/tree/TreeState;)V
+	public fun <init> (Lorg/jetbrains/jewel/foundation/lazy/tree/TreeViewKeybindings;Lorg/jetbrains/jewel/foundation/lazy/tree/DefaultTreeViewOnKeyEvent;)V
 	public synthetic fun getActions ()Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent;
 	public fun getActions ()Lorg/jetbrains/jewel/foundation/lazy/tree/DefaultTreeViewOnKeyEvent;
 	public synthetic fun getKeybindings ()Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;
@@ -441,12 +453,10 @@ public class org/jetbrains/jewel/foundation/lazy/tree/DefaultTreeViewOnKeyEvent 
 	public fun onSelectPreviousItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
 }
 
-public final class org/jetbrains/jewel/foundation/lazy/tree/DefaultTreeViewPointerEventAction : org/jetbrains/jewel/foundation/lazy/tree/PointerEventActions {
+public final class org/jetbrains/jewel/foundation/lazy/tree/DefaultTreeViewPointerEventAction : org/jetbrains/jewel/foundation/lazy/tree/DefaultSelectableLazyColumnEventAction {
 	public static final field $stable I
 	public fun <init> (Lorg/jetbrains/jewel/foundation/lazy/tree/TreeState;)V
 	public fun handlePointerEventPress (Landroidx/compose/ui/input/pointer/PointerEvent;Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;Ljava/util/List;Ljava/lang/Object;)V
-	public fun onExtendSelectionToKey (Ljava/lang/Object;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;)V
-	public fun toggleKeySelection (Ljava/lang/Object;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
 }
 
 public abstract interface class org/jetbrains/jewel/foundation/lazy/tree/KeyBindingActions {
@@ -455,16 +465,14 @@ public abstract interface class org/jetbrains/jewel/foundation/lazy/tree/KeyBind
 	public abstract fun handleOnKeyEvent-jhbQyNo (Ljava/lang/Object;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;)Lkotlin/jvm/functions/Function1;
 }
 
+public final class org/jetbrains/jewel/foundation/lazy/tree/KeyBindingActionsKt {
+	public static final fun DefaultTreeViewKeyActions (Lorg/jetbrains/jewel/foundation/lazy/tree/TreeState;)Lorg/jetbrains/jewel/foundation/lazy/tree/DefaultTreeViewKeyActions;
+}
+
 public abstract interface class org/jetbrains/jewel/foundation/lazy/tree/PointerEventActions {
 	public abstract fun handlePointerEventPress (Landroidx/compose/ui/input/pointer/PointerEvent;Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;Ljava/util/List;Ljava/lang/Object;)V
 	public abstract fun onExtendSelectionToKey (Ljava/lang/Object;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;)V
 	public abstract fun toggleKeySelection (Ljava/lang/Object;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
-}
-
-public final class org/jetbrains/jewel/foundation/lazy/tree/PointerEventActions$DefaultImpls {
-	public static fun handlePointerEventPress (Lorg/jetbrains/jewel/foundation/lazy/tree/PointerEventActions;Landroidx/compose/ui/input/pointer/PointerEvent;Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;Ljava/util/List;Ljava/lang/Object;)V
-	public static fun onExtendSelectionToKey (Lorg/jetbrains/jewel/foundation/lazy/tree/PointerEventActions;Ljava/lang/Object;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;)V
-	public static fun toggleKeySelection (Lorg/jetbrains/jewel/foundation/lazy/tree/PointerEventActions;Ljava/lang/Object;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
 }
 
 public final class org/jetbrains/jewel/foundation/lazy/tree/Tree {
@@ -652,12 +660,6 @@ public abstract interface class org/jetbrains/jewel/foundation/lazy/tree/TreeVie
 	public abstract fun selectNextSibling-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
 	public abstract fun selectParent-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
 	public abstract fun selectPreviousSibling-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-}
-
-public final class org/jetbrains/jewel/foundation/lazy/tree/TreeViewKeybindings$DefaultImpls {
-	public static fun isKeyboardCtrlMetaKeyPressed-ZmokQxo (Lorg/jetbrains/jewel/foundation/lazy/tree/TreeViewKeybindings;Ljava/lang/Object;)Z
-	public static fun isKeyboardMultiSelectionKeyPressed-5xRPYO0 (Lorg/jetbrains/jewel/foundation/lazy/tree/TreeViewKeybindings;I)Z
-	public static fun isKeyboardMultiSelectionKeyPressed-ZmokQxo (Lorg/jetbrains/jewel/foundation/lazy/tree/TreeViewKeybindings;Ljava/lang/Object;)Z
 }
 
 public abstract interface class org/jetbrains/jewel/foundation/lazy/tree/TreeViewOnKeyEvent : org/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent {

--- a/foundation/api/foundation.api
+++ b/foundation/api/foundation.api
@@ -143,24 +143,24 @@ public class org/jetbrains/jewel/foundation/lazy/DefaultSelectableColumnKeybindi
 	public static final field $stable I
 	public static final field Companion Lorg/jetbrains/jewel/foundation/lazy/DefaultSelectableColumnKeybindings$Companion;
 	public fun <init> ()V
-	public fun edit-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public fun extendSelectionToFirstItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public fun extendSelectionToLastItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public fun extendSelectionWithNextItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public fun extendSelectionWithPreviousItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
 	public fun isContiguousSelectionKeyPressed-5xRPYO0 (I)Z
 	public fun isContiguousSelectionKeyPressed-ZmokQxo (Ljava/lang/Object;)Z
+	public fun isEdit-ZmokQxo (Ljava/lang/Object;)Z
+	public fun isExtendSelectionToFirstItem-ZmokQxo (Ljava/lang/Object;)Z
+	public fun isExtendSelectionToLastItem-ZmokQxo (Ljava/lang/Object;)Z
+	public fun isExtendSelectionWithNextItem-ZmokQxo (Ljava/lang/Object;)Z
+	public fun isExtendSelectionWithPreviousItem-ZmokQxo (Ljava/lang/Object;)Z
 	public fun isMultiSelectionKeyPressed-5xRPYO0 (I)Z
 	public fun isMultiSelectionKeyPressed-ZmokQxo (Ljava/lang/Object;)Z
-	public fun scrollPageDownAndExtendSelection-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public fun scrollPageDownAndSelectItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public fun scrollPageUpAndExtendSelection-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public fun scrollPageUpAndSelectItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public fun selectAll-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public fun selectFirstItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public fun selectLastItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public fun selectNextItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public fun selectPreviousItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public fun isScrollPageDownAndExtendSelection-ZmokQxo (Ljava/lang/Object;)Z
+	public fun isScrollPageDownAndSelectItem-ZmokQxo (Ljava/lang/Object;)Z
+	public fun isScrollPageUpAndExtendSelection-ZmokQxo (Ljava/lang/Object;)Z
+	public fun isScrollPageUpAndSelectItem-ZmokQxo (Ljava/lang/Object;)Z
+	public fun isSelectAll-ZmokQxo (Ljava/lang/Object;)Z
+	public fun isSelectFirstItem-ZmokQxo (Ljava/lang/Object;)Z
+	public fun isSelectLastItem-ZmokQxo (Ljava/lang/Object;)Z
+	public fun isSelectNextItem-ZmokQxo (Ljava/lang/Object;)Z
+	public fun isSelectPreviousItem-ZmokQxo (Ljava/lang/Object;)Z
 }
 
 public final class org/jetbrains/jewel/foundation/lazy/DefaultSelectableColumnKeybindings$Companion : org/jetbrains/jewel/foundation/lazy/DefaultSelectableColumnKeybindings {
@@ -191,24 +191,24 @@ public final class org/jetbrains/jewel/foundation/lazy/DefaultSelectableOnKeyEve
 }
 
 public abstract interface class org/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings {
-	public abstract fun edit-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public abstract fun extendSelectionToFirstItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public abstract fun extendSelectionToLastItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public abstract fun extendSelectionWithNextItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public abstract fun extendSelectionWithPreviousItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
 	public abstract fun isContiguousSelectionKeyPressed-5xRPYO0 (I)Z
 	public abstract fun isContiguousSelectionKeyPressed-ZmokQxo (Ljava/lang/Object;)Z
+	public abstract fun isEdit-ZmokQxo (Ljava/lang/Object;)Z
+	public abstract fun isExtendSelectionToFirstItem-ZmokQxo (Ljava/lang/Object;)Z
+	public abstract fun isExtendSelectionToLastItem-ZmokQxo (Ljava/lang/Object;)Z
+	public abstract fun isExtendSelectionWithNextItem-ZmokQxo (Ljava/lang/Object;)Z
+	public abstract fun isExtendSelectionWithPreviousItem-ZmokQxo (Ljava/lang/Object;)Z
 	public abstract fun isMultiSelectionKeyPressed-5xRPYO0 (I)Z
 	public abstract fun isMultiSelectionKeyPressed-ZmokQxo (Ljava/lang/Object;)Z
-	public abstract fun scrollPageDownAndExtendSelection-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public abstract fun scrollPageDownAndSelectItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public abstract fun scrollPageUpAndExtendSelection-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public abstract fun scrollPageUpAndSelectItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public abstract fun selectAll-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public abstract fun selectFirstItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public abstract fun selectLastItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public abstract fun selectNextItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public abstract fun selectPreviousItem-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public abstract fun isScrollPageDownAndExtendSelection-ZmokQxo (Ljava/lang/Object;)Z
+	public abstract fun isScrollPageDownAndSelectItem-ZmokQxo (Ljava/lang/Object;)Z
+	public abstract fun isScrollPageUpAndExtendSelection-ZmokQxo (Ljava/lang/Object;)Z
+	public abstract fun isScrollPageUpAndSelectItem-ZmokQxo (Ljava/lang/Object;)Z
+	public abstract fun isSelectAll-ZmokQxo (Ljava/lang/Object;)Z
+	public abstract fun isSelectFirstItem-ZmokQxo (Ljava/lang/Object;)Z
+	public abstract fun isSelectLastItem-ZmokQxo (Ljava/lang/Object;)Z
+	public abstract fun isSelectNextItem-ZmokQxo (Ljava/lang/Object;)Z
+	public abstract fun isSelectPreviousItem-ZmokQxo (Ljava/lang/Object;)Z
 }
 
 public abstract interface class org/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent {
@@ -247,7 +247,7 @@ public final class org/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEven
 }
 
 public final class org/jetbrains/jewel/foundation/lazy/SelectableLazyColumnKt {
-	public static final fun SelectableLazyColumn (Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Landroidx/compose/foundation/layout/PaddingValues;ZLkotlin/jvm/functions/Function1;Landroidx/compose/foundation/layout/Arrangement$Vertical;Landroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/foundation/gestures/FlingBehavior;Lorg/jetbrains/jewel/foundation/lazy/tree/KeyBindingActions;Lorg/jetbrains/jewel/foundation/lazy/tree/PointerEventActions;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)V
+	public static final fun SelectableLazyColumn (Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Landroidx/compose/foundation/layout/PaddingValues;ZLkotlin/jvm/functions/Function1;Landroidx/compose/foundation/layout/Arrangement$Vertical;Landroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/foundation/gestures/FlingBehavior;Lorg/jetbrains/jewel/foundation/lazy/tree/KeyActions;Lorg/jetbrains/jewel/foundation/lazy/tree/PointerEventActions;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)V
 }
 
 public abstract interface class org/jetbrains/jewel/foundation/lazy/SelectableLazyItemScope : androidx/compose/foundation/lazy/LazyItemScope {
@@ -335,7 +335,7 @@ public final class org/jetbrains/jewel/foundation/lazy/SelectionMode : java/lang
 }
 
 public final class org/jetbrains/jewel/foundation/lazy/tree/BasicLazyTreeKt {
-	public static final fun BasicLazyTree-orM9XXQ (Lorg/jetbrains/jewel/foundation/lazy/tree/Tree;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;Lkotlin/jvm/functions/Function1;JJJFLandroidx/compose/foundation/shape/CornerSize;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/foundation/layout/PaddingValues;FFLorg/jetbrains/jewel/foundation/lazy/tree/TreeState;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;JLorg/jetbrains/jewel/foundation/lazy/tree/KeyBindingActions;Lorg/jetbrains/jewel/foundation/lazy/tree/PointerEventActions;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;IIII)V
+	public static final fun BasicLazyTree-orM9XXQ (Lorg/jetbrains/jewel/foundation/lazy/tree/Tree;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;Lkotlin/jvm/functions/Function1;JJJFLandroidx/compose/foundation/shape/CornerSize;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/foundation/layout/PaddingValues;FFLorg/jetbrains/jewel/foundation/lazy/tree/TreeState;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;JLorg/jetbrains/jewel/foundation/lazy/tree/KeyActions;Lorg/jetbrains/jewel/foundation/lazy/tree/PointerEventActions;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;IIII)V
 }
 
 public final class org/jetbrains/jewel/foundation/lazy/tree/BuildTreeKt {
@@ -385,7 +385,7 @@ public class org/jetbrains/jewel/foundation/lazy/tree/DefaultSelectableLazyColum
 	public fun toggleKeySelection (Ljava/lang/Object;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
 }
 
-public class org/jetbrains/jewel/foundation/lazy/tree/DefaultSelectableLazyColumnKeyActions : org/jetbrains/jewel/foundation/lazy/tree/KeyBindingActions {
+public class org/jetbrains/jewel/foundation/lazy/tree/DefaultSelectableLazyColumnKeyActions : org/jetbrains/jewel/foundation/lazy/tree/KeyActions {
 	public static final field $stable I
 	public static final field Companion Lorg/jetbrains/jewel/foundation/lazy/tree/DefaultSelectableLazyColumnKeyActions$Companion;
 	public fun <init> (Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent;)V
@@ -412,15 +412,13 @@ public class org/jetbrains/jewel/foundation/lazy/tree/DefaultTreeViewKeybindings
 	public static final field $stable I
 	public static final field Companion Lorg/jetbrains/jewel/foundation/lazy/tree/DefaultTreeViewKeybindings$Companion;
 	public fun <init> ()V
-	public fun edit-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public fun extendSelectionToChild-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public fun extendSelectionToParent-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public fun selectChild-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public synthetic fun selectNextSibling-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public fun selectNextSibling-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Void;
-	public fun selectParent-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public synthetic fun selectPreviousSibling-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public fun selectPreviousSibling-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Void;
+	public fun isEdit-ZmokQxo (Ljava/lang/Object;)Z
+	public fun isExtendSelectionToChild-ZmokQxo (Ljava/lang/Object;)Z
+	public fun isExtendSelectionToParent-ZmokQxo (Ljava/lang/Object;)Z
+	public fun isSelectChild-ZmokQxo (Ljava/lang/Object;)Z
+	public fun isSelectNextSibling-ZmokQxo (Ljava/lang/Object;)Z
+	public fun isSelectParent-ZmokQxo (Ljava/lang/Object;)Z
+	public fun isSelectPreviousSibling-ZmokQxo (Ljava/lang/Object;)Z
 }
 
 public final class org/jetbrains/jewel/foundation/lazy/tree/DefaultTreeViewKeybindings$Companion : org/jetbrains/jewel/foundation/lazy/tree/DefaultTreeViewKeybindings {
@@ -459,13 +457,13 @@ public final class org/jetbrains/jewel/foundation/lazy/tree/DefaultTreeViewPoint
 	public fun handlePointerEventPress (Landroidx/compose/ui/input/pointer/PointerEvent;Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;Ljava/util/List;Ljava/lang/Object;)V
 }
 
-public abstract interface class org/jetbrains/jewel/foundation/lazy/tree/KeyBindingActions {
+public abstract interface class org/jetbrains/jewel/foundation/lazy/tree/KeyActions {
 	public abstract fun getActions ()Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent;
 	public abstract fun getKeybindings ()Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;
 	public abstract fun handleOnKeyEvent-jhbQyNo (Ljava/lang/Object;Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;)Lkotlin/jvm/functions/Function1;
 }
 
-public final class org/jetbrains/jewel/foundation/lazy/tree/KeyBindingActionsKt {
+public final class org/jetbrains/jewel/foundation/lazy/tree/KeyActionsKt {
 	public static final fun DefaultTreeViewKeyActions (Lorg/jetbrains/jewel/foundation/lazy/tree/TreeState;)Lorg/jetbrains/jewel/foundation/lazy/tree/DefaultTreeViewKeyActions;
 }
 
@@ -654,12 +652,12 @@ public final class org/jetbrains/jewel/foundation/lazy/tree/TreeStateKt {
 }
 
 public abstract interface class org/jetbrains/jewel/foundation/lazy/tree/TreeViewKeybindings : org/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings {
-	public abstract fun extendSelectionToChild-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public abstract fun extendSelectionToParent-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public abstract fun selectChild-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public abstract fun selectNextSibling-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public abstract fun selectParent-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
-	public abstract fun selectPreviousSibling-ZmokQxo (Ljava/lang/Object;)Ljava/lang/Boolean;
+	public abstract fun isExtendSelectionToChild-ZmokQxo (Ljava/lang/Object;)Z
+	public abstract fun isExtendSelectionToParent-ZmokQxo (Ljava/lang/Object;)Z
+	public abstract fun isSelectChild-ZmokQxo (Ljava/lang/Object;)Z
+	public abstract fun isSelectNextSibling-ZmokQxo (Ljava/lang/Object;)Z
+	public abstract fun isSelectParent-ZmokQxo (Ljava/lang/Object;)Z
+	public abstract fun isSelectPreviousSibling-ZmokQxo (Ljava/lang/Object;)Z
 }
 
 public abstract interface class org/jetbrains/jewel/foundation/lazy/tree/TreeViewOnKeyEvent : org/jetbrains/jewel/foundation/lazy/SelectableColumnOnKeyEvent {

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/Keybindings.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/Keybindings.kt
@@ -24,72 +24,72 @@ interface SelectableColumnKeybindings {
     /**
      * Select First Node
      */
-    fun KeyEvent.selectFirstItem(): Boolean?
+    val KeyEvent.isSelectFirstItem: Boolean
 
     /**
      * Extend Selection to First Node inherited from Move Caret to Text Start with Selection
      */
-    fun KeyEvent.extendSelectionToFirstItem(): Boolean?
+    val KeyEvent.isExtendSelectionToFirstItem: Boolean
 
     /**
      * Select Last Node inherited from Move Caret to Text End
      */
-    fun KeyEvent.selectLastItem(): Boolean?
+    val KeyEvent.isSelectLastItem: Boolean
 
     /**
      * Extend Selection to Last Node inherited from Move Caret to Text End with Selection
      */
-    fun KeyEvent.extendSelectionToLastItem(): Boolean?
+    val KeyEvent.isExtendSelectionToLastItem: Boolean
 
     /**
      * Select Previous Node inherited from Up
      */
-    fun KeyEvent.selectPreviousItem(): Boolean?
+    val KeyEvent.isSelectPreviousItem: Boolean
 
     /**
      * Extend Selection with Previous Node inherited from Up with Selection
      */
-    fun KeyEvent.extendSelectionWithPreviousItem(): Boolean?
+    val KeyEvent.isExtendSelectionWithPreviousItem: Boolean
 
     /**
      * Select Next Node inherited from Down
      */
-    fun KeyEvent.selectNextItem(): Boolean?
+    val KeyEvent.isSelectNextItem: Boolean
 
     /**
      * Extend Selection with Next Node inherited from Down with Selection
      */
-    fun KeyEvent.extendSelectionWithNextItem(): Boolean?
+    val KeyEvent.isExtendSelectionWithNextItem: Boolean
 
     /**
      * Scroll Page Up and Select Node inherited from Page Up
      */
-    fun KeyEvent.scrollPageUpAndSelectItem(): Boolean?
+    val KeyEvent.isScrollPageUpAndSelectItem: Boolean
 
     /**
      * Scroll Page Up and Extend Selection inherited from Page Up with Selection
      */
-    fun KeyEvent.scrollPageUpAndExtendSelection(): Boolean?
+    val KeyEvent.isScrollPageUpAndExtendSelection: Boolean
 
     /**
      * Scroll Page Down and Select Node inherited from Page Down
      */
-    fun KeyEvent.scrollPageDownAndSelectItem(): Boolean?
+    val KeyEvent.isScrollPageDownAndSelectItem: Boolean
 
     /**
      * Scroll Page Down and Extend Selection inherited from Page Down with Selection
      */
-    fun KeyEvent.scrollPageDownAndExtendSelection(): Boolean?
+    val KeyEvent.isScrollPageDownAndExtendSelection: Boolean
 
     /**
      * Edit item
      */
-    fun KeyEvent.edit(): Boolean?
+    val KeyEvent.isEdit: Boolean
 
     /**
      * SelectAll
      */
-    fun KeyEvent.selectAll(): Boolean?
+    val KeyEvent.isSelectAll: Boolean
 }
 
 open class DefaultMacOsSelectableColumnKeybindings : DefaultSelectableColumnKeybindings() {
@@ -119,44 +119,45 @@ open class DefaultSelectableColumnKeybindings : SelectableColumnKeybindings {
 
     companion object : DefaultSelectableColumnKeybindings()
 
-    override fun KeyEvent.selectFirstItem() =
-        key == Key.Home && !isContiguousSelectionKeyPressed
+    override val KeyEvent.isSelectFirstItem
+        get() = key == Key.Home && !isContiguousSelectionKeyPressed
 
-    override fun KeyEvent.extendSelectionToFirstItem() =
-        key == Key.Home && isContiguousSelectionKeyPressed
+    override val KeyEvent.isExtendSelectionToFirstItem
+        get() = key == Key.Home && isContiguousSelectionKeyPressed
 
-    override fun KeyEvent.selectLastItem() =
-        key == Key.MoveEnd && !isContiguousSelectionKeyPressed
+    override val KeyEvent.isSelectLastItem
+        get() = key == Key.MoveEnd && !isContiguousSelectionKeyPressed
 
-    override fun KeyEvent.extendSelectionToLastItem() =
-        key == Key.MoveEnd && isContiguousSelectionKeyPressed
+    override val KeyEvent.isExtendSelectionToLastItem
+        get() = key == Key.MoveEnd && isContiguousSelectionKeyPressed
 
-    override fun KeyEvent.selectPreviousItem() =
-        key == Key.DirectionUp && !isContiguousSelectionKeyPressed
+    override val KeyEvent.isSelectPreviousItem
+        get() = key == Key.DirectionUp && !isContiguousSelectionKeyPressed
 
-    override fun KeyEvent.extendSelectionWithPreviousItem() =
-        key == Key.DirectionUp && isContiguousSelectionKeyPressed
+    override val KeyEvent.isExtendSelectionWithPreviousItem
+        get() = key == Key.DirectionUp && isContiguousSelectionKeyPressed
 
-    override fun KeyEvent.selectNextItem() =
-        key == Key.DirectionDown && !isContiguousSelectionKeyPressed
+    override val KeyEvent.isSelectNextItem
+        get() = key == Key.DirectionDown && !isContiguousSelectionKeyPressed
 
-    override fun KeyEvent.extendSelectionWithNextItem() =
-        key == Key.DirectionDown && isContiguousSelectionKeyPressed
+    override val KeyEvent.isExtendSelectionWithNextItem
+        get() = key == Key.DirectionDown && isContiguousSelectionKeyPressed
 
-    override fun KeyEvent.scrollPageUpAndSelectItem() =
-        key == Key.PageUp && !isContiguousSelectionKeyPressed
+    override val KeyEvent.isScrollPageUpAndSelectItem
+        get() = key == Key.PageUp && !isContiguousSelectionKeyPressed
 
-    override fun KeyEvent.scrollPageUpAndExtendSelection() =
-        key == Key.PageUp && isContiguousSelectionKeyPressed
+    override val KeyEvent.isScrollPageUpAndExtendSelection
+        get() = key == Key.PageUp && isContiguousSelectionKeyPressed
 
-    override fun KeyEvent.scrollPageDownAndSelectItem() =
-        key == Key.PageDown && !isContiguousSelectionKeyPressed
+    override val KeyEvent.isScrollPageDownAndSelectItem
+        get() = key == Key.PageDown && !isContiguousSelectionKeyPressed
 
-    override fun KeyEvent.scrollPageDownAndExtendSelection() =
-        key == Key.PageDown && isContiguousSelectionKeyPressed
+    override val KeyEvent.isScrollPageDownAndExtendSelection
+        get() = key == Key.PageDown && isContiguousSelectionKeyPressed
 
-    override fun KeyEvent.edit() = false
+    override val KeyEvent.isEdit
+        get() = false
 
-    override fun KeyEvent.selectAll(): Boolean? =
-        key == Key.A && isMultiSelectionKeyPressed
+    override val KeyEvent.isSelectAll: Boolean
+        get() = key == Key.A && isMultiSelectionKeyPressed
 }

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/Keybindings.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/Keybindings.kt
@@ -7,18 +7,19 @@ import androidx.compose.ui.input.key.isMetaPressed
 import androidx.compose.ui.input.key.isShiftPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.pointer.PointerKeyboardModifiers
+import androidx.compose.ui.input.pointer.isCtrlPressed
+import androidx.compose.ui.input.pointer.isMetaPressed
 import androidx.compose.ui.input.pointer.isShiftPressed
 
 interface SelectableColumnKeybindings {
 
-    val KeyEvent.isKeyboardMultiSelectionKeyPressed: Boolean
-        get() = isShiftPressed
+    val KeyEvent.isContiguousSelectionKeyPressed: Boolean
 
-    val PointerKeyboardModifiers.isKeyboardMultiSelectionKeyPressed: Boolean
-        get() = isShiftPressed
+    val PointerKeyboardModifiers.isContiguousSelectionKeyPressed: Boolean
 
-    val KeyEvent.isKeyboardCtrlMetaKeyPressed: Boolean
-        get() = isCtrlPressed || isMetaPressed
+    val KeyEvent.isMultiSelectionKeyPressed: Boolean
+
+    val PointerKeyboardModifiers.isMultiSelectionKeyPressed: Boolean
 
     /**
      * Select First Node
@@ -91,53 +92,71 @@ interface SelectableColumnKeybindings {
     fun KeyEvent.selectAll(): Boolean?
 }
 
+open class DefaultMacOsSelectableColumnKeybindings : DefaultSelectableColumnKeybindings() {
+
+    companion object : DefaultMacOsSelectableColumnKeybindings()
+
+    override val KeyEvent.isMultiSelectionKeyPressed: Boolean
+        get() = isMetaPressed
+
+    override val PointerKeyboardModifiers.isMultiSelectionKeyPressed: Boolean
+        get() = isMetaPressed
+}
+
 open class DefaultSelectableColumnKeybindings : SelectableColumnKeybindings {
+
+    override val KeyEvent.isContiguousSelectionKeyPressed: Boolean
+        get() = isShiftPressed
+
+    override val PointerKeyboardModifiers.isContiguousSelectionKeyPressed: Boolean
+        get() = isShiftPressed
+
+    override val KeyEvent.isMultiSelectionKeyPressed: Boolean
+        get() = isCtrlPressed
+
+    override val PointerKeyboardModifiers.isMultiSelectionKeyPressed: Boolean
+        get() = isCtrlPressed
+
     companion object : DefaultSelectableColumnKeybindings()
 
-    override val KeyEvent.isKeyboardMultiSelectionKeyPressed: Boolean
-        get() = isShiftPressed
-
-    override val PointerKeyboardModifiers.isKeyboardMultiSelectionKeyPressed: Boolean
-        get() = isShiftPressed
-
     override fun KeyEvent.selectFirstItem() =
-        key == Key.Home && !isKeyboardMultiSelectionKeyPressed
+        key == Key.Home && !isContiguousSelectionKeyPressed
 
     override fun KeyEvent.extendSelectionToFirstItem() =
-        key == Key.Home && isKeyboardMultiSelectionKeyPressed
+        key == Key.Home && isContiguousSelectionKeyPressed
 
     override fun KeyEvent.selectLastItem() =
-        key == Key.MoveEnd && !isKeyboardMultiSelectionKeyPressed
+        key == Key.MoveEnd && !isContiguousSelectionKeyPressed
 
     override fun KeyEvent.extendSelectionToLastItem() =
-        key == Key.MoveEnd && isKeyboardMultiSelectionKeyPressed
+        key == Key.MoveEnd && isContiguousSelectionKeyPressed
 
     override fun KeyEvent.selectPreviousItem() =
-        key == Key.DirectionUp && !isKeyboardMultiSelectionKeyPressed
+        key == Key.DirectionUp && !isContiguousSelectionKeyPressed
 
     override fun KeyEvent.extendSelectionWithPreviousItem() =
-        key == Key.DirectionUp && isKeyboardMultiSelectionKeyPressed
+        key == Key.DirectionUp && isContiguousSelectionKeyPressed
 
     override fun KeyEvent.selectNextItem() =
-        key == Key.DirectionDown && !isKeyboardMultiSelectionKeyPressed
+        key == Key.DirectionDown && !isContiguousSelectionKeyPressed
 
     override fun KeyEvent.extendSelectionWithNextItem() =
-        key == Key.DirectionDown && isKeyboardMultiSelectionKeyPressed
+        key == Key.DirectionDown && isContiguousSelectionKeyPressed
 
     override fun KeyEvent.scrollPageUpAndSelectItem() =
-        key == Key.PageUp && !isKeyboardMultiSelectionKeyPressed
+        key == Key.PageUp && !isContiguousSelectionKeyPressed
 
     override fun KeyEvent.scrollPageUpAndExtendSelection() =
-        key == Key.PageUp && isKeyboardMultiSelectionKeyPressed
+        key == Key.PageUp && isContiguousSelectionKeyPressed
 
     override fun KeyEvent.scrollPageDownAndSelectItem() =
-        key == Key.PageDown && !isKeyboardMultiSelectionKeyPressed
+        key == Key.PageDown && !isContiguousSelectionKeyPressed
 
     override fun KeyEvent.scrollPageDownAndExtendSelection() =
-        key == Key.PageDown && isKeyboardMultiSelectionKeyPressed
+        key == Key.PageDown && isContiguousSelectionKeyPressed
 
     override fun KeyEvent.edit() = false
 
     override fun KeyEvent.selectAll(): Boolean? =
-        key == Key.A && isKeyboardCtrlMetaKeyPressed
+        key == Key.A && isMultiSelectionKeyPressed
 }

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/SelectableLazyColumn.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/SelectableLazyColumn.kt
@@ -45,7 +45,7 @@ fun SelectableLazyColumn(
     verticalArrangement: Arrangement.Vertical = if (!reverseLayout) Arrangement.Top else Arrangement.Bottom,
     horizontalAlignment: Alignment.Horizontal = Alignment.Start,
     flingBehavior: FlingBehavior = ScrollableDefaults.flingBehavior(),
-    keyActions: KeyBindingActions = DefaultSelectableLazyColumnKeyActions(),
+    keyActions: KeyBindingActions = DefaultSelectableLazyColumnKeyActions,
     pointerEventActions: PointerEventActions = DefaultSelectableLazyColumnEventAction(),
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     content: SelectableLazyListScope.() -> Unit,

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/SelectableLazyColumn.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/SelectableLazyColumn.kt
@@ -27,7 +27,7 @@ import kotlinx.coroutines.launch
 import org.jetbrains.jewel.foundation.lazy.SelectableLazyListScopeContainer.Entry
 import org.jetbrains.jewel.foundation.lazy.tree.DefaultSelectableLazyColumnEventAction
 import org.jetbrains.jewel.foundation.lazy.tree.DefaultSelectableLazyColumnKeyActions
-import org.jetbrains.jewel.foundation.lazy.tree.KeyBindingActions
+import org.jetbrains.jewel.foundation.lazy.tree.KeyActions
 import org.jetbrains.jewel.foundation.lazy.tree.PointerEventActions
 
 /**
@@ -45,7 +45,7 @@ fun SelectableLazyColumn(
     verticalArrangement: Arrangement.Vertical = if (!reverseLayout) Arrangement.Top else Arrangement.Bottom,
     horizontalAlignment: Alignment.Horizontal = Alignment.Start,
     flingBehavior: FlingBehavior = ScrollableDefaults.flingBehavior(),
-    keyActions: KeyBindingActions = DefaultSelectableLazyColumnKeyActions,
+    keyActions: KeyActions = DefaultSelectableLazyColumnKeyActions,
     pointerEventActions: PointerEventActions = DefaultSelectableLazyColumnEventAction(),
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     content: SelectableLazyListScope.() -> Unit,

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/tree/BasicLazyTree.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/tree/BasicLazyTree.kt
@@ -89,7 +89,7 @@ fun <T> BasicLazyTree(
     onElementDoubleClick: (Tree.Element<T>) -> Unit,
     onSelectionChange: (List<Tree.Element<T>>) -> Unit,
     platformDoubleClickDelay: Duration = 500.milliseconds,
-    keyActions: KeyBindingActions = DefaultTreeViewKeyActions(treeState),
+    keyActions: KeyActions = DefaultTreeViewKeyActions(treeState),
     pointerEventScopedActions: PointerEventActions = remember {
         DefaultTreeViewPointerEventAction(treeState)
     },

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/tree/DefaultTreeViewKeybindings.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/tree/DefaultTreeViewKeybindings.kt
@@ -16,23 +16,23 @@ open class DefaultTreeViewKeybindings : DefaultSelectableColumnKeybindings(), Tr
     companion object : DefaultTreeViewKeybindings()
 
     override fun KeyEvent.selectParent() =
-        key == Key.DirectionLeft && !isKeyboardMultiSelectionKeyPressed
+        key == Key.DirectionLeft && !isContiguousSelectionKeyPressed
 
     override fun KeyEvent.extendSelectionToParent() =
-        key == Key.DirectionLeft && isKeyboardMultiSelectionKeyPressed
+        key == Key.DirectionLeft && isContiguousSelectionKeyPressed
 
     override fun KeyEvent.selectChild() =
-        key == Key.DirectionRight && !isKeyboardMultiSelectionKeyPressed
+        key == Key.DirectionRight && !isContiguousSelectionKeyPressed
 
     override fun KeyEvent.extendSelectionToChild() =
-        key == Key.DirectionRight && isKeyboardMultiSelectionKeyPressed
+        key == Key.DirectionRight && isContiguousSelectionKeyPressed
 
     override fun KeyEvent.selectNextSibling() = null
 
     override fun KeyEvent.selectPreviousSibling() = null
 
     override fun KeyEvent.edit() =
-        key == Key.F2 && !isKeyboardMultiSelectionKeyPressed
+        key == Key.F2 && !isContiguousSelectionKeyPressed
 }
 
 interface TreeViewKeybindings : SelectableColumnKeybindings {
@@ -83,9 +83,9 @@ typealias TreeViewClickModifierHandler = PointerKeyboardModifiers.() -> Boolean
 open class DefaultMacOsTreeColumnKeybindings : DefaultTreeViewKeybindings() {
     companion object : DefaultMacOsTreeColumnKeybindings()
 
-    override val KeyEvent.isKeyboardMultiSelectionKeyPressed: Boolean
+    override val KeyEvent.isMultiSelectionKeyPressed: Boolean
         get() = isMetaPressed
 
-    override val PointerKeyboardModifiers.isKeyboardMultiSelectionKeyPressed: Boolean
+    override val PointerKeyboardModifiers.isMultiSelectionKeyPressed: Boolean
         get() = isMetaPressed
 }

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/tree/DefaultTreeViewKeybindings.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/tree/DefaultTreeViewKeybindings.kt
@@ -15,24 +15,25 @@ open class DefaultTreeViewKeybindings : DefaultSelectableColumnKeybindings(), Tr
 
     companion object : DefaultTreeViewKeybindings()
 
-    override fun KeyEvent.selectParent() =
-        key == Key.DirectionLeft && !isContiguousSelectionKeyPressed
+    override val KeyEvent.isSelectParent
+        get() = key == Key.DirectionLeft && !isContiguousSelectionKeyPressed
 
-    override fun KeyEvent.extendSelectionToParent() =
-        key == Key.DirectionLeft && isContiguousSelectionKeyPressed
+    override val KeyEvent.isExtendSelectionToParent
+        get() = key == Key.DirectionLeft && isContiguousSelectionKeyPressed
 
-    override fun KeyEvent.selectChild() =
-        key == Key.DirectionRight && !isContiguousSelectionKeyPressed
+    override val KeyEvent.isSelectChild
+        get() = key == Key.DirectionRight && !isContiguousSelectionKeyPressed
 
-    override fun KeyEvent.extendSelectionToChild() =
-        key == Key.DirectionRight && isContiguousSelectionKeyPressed
+    override val KeyEvent.isExtendSelectionToChild
+        get() = key == Key.DirectionRight && isContiguousSelectionKeyPressed
 
-    override fun KeyEvent.selectNextSibling() = null
+    override val KeyEvent.isSelectNextSibling
+        get() = false
 
-    override fun KeyEvent.selectPreviousSibling() = null
+    override val KeyEvent.isSelectPreviousSibling
+        get() = false
 
-    override fun KeyEvent.edit() =
-        key == Key.F2 && !isContiguousSelectionKeyPressed
+    override val KeyEvent.isEdit get() = key == Key.F2 && !isContiguousSelectionKeyPressed
 }
 
 interface TreeViewKeybindings : SelectableColumnKeybindings {
@@ -40,32 +41,32 @@ interface TreeViewKeybindings : SelectableColumnKeybindings {
     /**
      * Select Parent Node
      */
-    fun KeyEvent.selectParent(): Boolean?
+    val KeyEvent.isSelectParent: Boolean
 
     /**
      * Extend Selection to Parent Node inherited from Left with Selection
      */
-    fun KeyEvent.extendSelectionToParent(): Boolean?
+    val KeyEvent.isExtendSelectionToParent: Boolean
 
     /**
      * Select Child Node inherited from Right
      */
-    fun KeyEvent.selectChild(): Boolean?
+    val KeyEvent.isSelectChild: Boolean
 
     /**
      * Extend Selection to Child Node inherited from Right with Selection
      */
-    fun KeyEvent.extendSelectionToChild(): Boolean?
+    val KeyEvent.isExtendSelectionToChild: Boolean
 
     /**
      * Select Next Sibling Node
      */
-    fun KeyEvent.selectNextSibling(): Boolean?
+    val KeyEvent.isSelectNextSibling: Boolean
 
     /**
      * Select Previous Sibling Node
      */
-    fun KeyEvent.selectPreviousSibling(): Boolean?
+    val KeyEvent.isSelectPreviousSibling: Boolean
 }
 
 @Suppress("unused")

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/tree/KeyActions.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/tree/KeyActions.kt
@@ -20,7 +20,7 @@ import org.jetbrains.jewel.foundation.lazy.SelectionMode
 import org.jetbrains.jewel.foundation.utils.Log
 import org.jetbrains.skiko.hostOs
 
-interface KeyBindingActions {
+interface KeyActions {
 
     val keybindings: SelectableColumnKeybindings
     val actions: SelectableColumnOnKeyEvent
@@ -249,7 +249,7 @@ class DefaultTreeViewKeyActions(
 open class DefaultSelectableLazyColumnKeyActions(
     override val keybindings: SelectableColumnKeybindings,
     override val actions: SelectableColumnOnKeyEvent = DefaultSelectableOnKeyEvent(keybindings),
-) : KeyBindingActions {
+) : KeyActions {
 
     companion object : DefaultSelectableLazyColumnKeyActions(
         when {

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/tree/KeyBindingActions.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/tree/KeyBindingActions.kt
@@ -233,8 +233,8 @@ class DefaultTreeViewKeyActions(
                 Log.d(keyEvent.key.keyCode.toString())
                 if (selectionMode == SelectionMode.None) return@lambda false
                 when {
-                    selectParent() ?: false -> onSelectParent(keys, state)
-                    selectChild() ?: false -> onSelectChild(keys, state)
+                    isSelectParent -> onSelectParent(keys, state)
+                    isSelectChild -> onSelectChild(keys, state)
                     super.handleOnKeyEvent(event, keys, state, selectionMode)
                         .invoke(keyEvent) -> return@lambda true
 
@@ -280,51 +280,25 @@ open class DefaultSelectableLazyColumnKeyActions(
         selectionMode: SelectionMode,
     ): Boolean {
         when {
-            selectNextItem() ?: false -> {
-                onSelectNextItem(keys, state)
+            isSelectNextItem -> onSelectNextItem(keys, state)
+            isSelectPreviousItem -> onSelectPreviousItem(keys, state)
+            isSelectFirstItem -> onSelectFirstItem(keys, state)
+            isSelectLastItem -> onSelectLastItem(keys, state)
+            isEdit -> onEdit()
+        }
+        if (selectionMode == SelectionMode.Single) {
+            when {
+                isExtendSelectionToFirstItem -> onExtendSelectionToFirst(keys, state)
+                isExtendSelectionToLastItem -> onExtendSelectionToLastItem(keys, state)
+                isExtendSelectionWithNextItem -> onExtendSelectionWithNextItem(keys, state)
+                isExtendSelectionWithPreviousItem -> onExtendSelectionWithPreviousItem(keys, state)
+                isScrollPageDownAndExtendSelection -> onScrollPageDownAndExtendSelection(keys, state)
+                isScrollPageDownAndSelectItem -> onScrollPageDownAndSelectItem(keys, state)
+                isScrollPageUpAndExtendSelection -> onScrollPageUpAndExtendSelection(keys, state)
+                isScrollPageUpAndSelectItem -> onScrollPageUpAndSelectItem(keys, state)
+                isSelectAll -> onSelectAll(keys, state)
+                else -> return false
             }
-
-            selectPreviousItem() ?: false -> onSelectPreviousItem(keys, state)
-            selectFirstItem() ?: false -> onSelectFirstItem(keys, state)
-            selectLastItem() ?: false -> onSelectLastItem(keys, state)
-            edit() ?: false -> onEdit()
-            extendSelectionToFirstItem() ?: false -> {
-                if (selectionMode == SelectionMode.Multiple) onExtendSelectionToFirst(keys, state)
-            }
-
-            extendSelectionToLastItem() ?: false -> {
-                if (selectionMode == SelectionMode.Multiple) onExtendSelectionToLastItem(keys, state)
-            }
-
-            extendSelectionWithNextItem() ?: false -> {
-                if (selectionMode == SelectionMode.Multiple) onExtendSelectionWithNextItem(keys, state)
-            }
-
-            extendSelectionWithPreviousItem() ?: false -> {
-                if (selectionMode == SelectionMode.Multiple) onExtendSelectionWithPreviousItem(keys, state)
-            }
-
-            scrollPageDownAndExtendSelection() ?: false -> {
-                if (selectionMode == SelectionMode.Multiple) onScrollPageDownAndExtendSelection(keys, state)
-            }
-
-            scrollPageDownAndSelectItem() ?: false -> {
-                if (selectionMode == SelectionMode.Multiple) onScrollPageDownAndSelectItem(keys, state)
-            }
-
-            scrollPageUpAndExtendSelection() ?: false -> {
-                if (selectionMode == SelectionMode.Multiple) onScrollPageUpAndExtendSelection(keys, state)
-            }
-
-            scrollPageUpAndSelectItem() ?: false -> {
-                if (selectionMode == SelectionMode.Multiple) onScrollPageUpAndSelectItem(keys, state)
-            }
-
-            selectAll() ?: false -> {
-                if (selectionMode == SelectionMode.Multiple) onSelectAll(keys, state)
-            }
-
-            else -> return false
         }
         return true
     }

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/tree/KeyBindingActions.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/tree/KeyBindingActions.kt
@@ -6,10 +6,10 @@ import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
 import androidx.compose.ui.input.pointer.PointerEvent
 import androidx.compose.ui.input.pointer.isCtrlPressed
-import androidx.compose.ui.input.pointer.isMetaPressed
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import org.jetbrains.jewel.foundation.lazy.DefaultMacOsSelectableColumnKeybindings
 import org.jetbrains.jewel.foundation.lazy.DefaultSelectableColumnKeybindings
 import org.jetbrains.jewel.foundation.lazy.DefaultSelectableOnKeyEvent
 import org.jetbrains.jewel.foundation.lazy.SelectableColumnKeybindings
@@ -18,6 +18,7 @@ import org.jetbrains.jewel.foundation.lazy.SelectableLazyListKey
 import org.jetbrains.jewel.foundation.lazy.SelectableLazyListState
 import org.jetbrains.jewel.foundation.lazy.SelectionMode
 import org.jetbrains.jewel.foundation.utils.Log
+import org.jetbrains.skiko.hostOs
 
 interface KeyBindingActions {
 
@@ -41,20 +42,45 @@ interface PointerEventActions {
         selectionMode: SelectionMode,
         allKeys: List<SelectableLazyListKey>,
         key: Any,
+    )
+
+    fun toggleKeySelection(
+        key: Any,
+        allKeys: List<SelectableLazyListKey>,
+        selectableLazyListState: SelectableLazyListState,
+    )
+
+    fun onExtendSelectionToKey(
+        key: Any,
+        allKeys: List<SelectableLazyListKey>,
+        state: SelectableLazyListState,
+        selectionMode: SelectionMode,
+    )
+}
+
+open class DefaultSelectableLazyColumnEventAction : PointerEventActions {
+
+    override fun handlePointerEventPress(
+        pointerEvent: PointerEvent,
+        keyBindings: SelectableColumnKeybindings,
+        selectableLazyListState: SelectableLazyListState,
+        selectionMode: SelectionMode,
+        allKeys: List<SelectableLazyListKey>,
+        key: Any,
     ) {
         with(keyBindings) {
             when {
-                pointerEvent.keyboardModifiers.isKeyboardMultiSelectionKeyPressed && pointerEvent.keyboardModifiers.isCtrlPressed -> {
+                pointerEvent.keyboardModifiers.isContiguousSelectionKeyPressed && pointerEvent.keyboardModifiers.isCtrlPressed -> {
                     Log.i("ctrl and shift pressed on click")
                     // do nothing
                 }
 
-                pointerEvent.keyboardModifiers.isKeyboardMultiSelectionKeyPressed -> {
+                pointerEvent.keyboardModifiers.isContiguousSelectionKeyPressed -> {
                     Log.i("shift pressed on click")
                     onExtendSelectionToKey(key, allKeys, selectableLazyListState, selectionMode)
                 }
 
-                pointerEvent.keyboardModifiers.isCtrlPressed || pointerEvent.keyboardModifiers.isMetaPressed -> {
+                pointerEvent.keyboardModifiers.isMultiSelectionKeyPressed -> {
                     Log.i("ctrl pressed on click")
                     toggleKeySelection(key, allKeys, selectableLazyListState)
                 }
@@ -68,7 +94,7 @@ interface PointerEventActions {
         }
     }
 
-    fun toggleKeySelection(
+    override fun toggleKeySelection(
         key: Any,
         allKeys: List<SelectableLazyListKey>,
         selectableLazyListState: SelectableLazyListState,
@@ -83,7 +109,7 @@ interface PointerEventActions {
         selectableLazyListState.lastActiveItemIndex = allKeys.indexOfFirst { it == key }
     }
 
-    fun onExtendSelectionToKey(
+    override fun onExtendSelectionToKey(
         key: Any,
         allKeys: List<SelectableLazyListKey>,
         state: SelectableLazyListState,
@@ -114,11 +140,9 @@ interface PointerEventActions {
     }
 }
 
-class DefaultSelectableLazyColumnEventAction : PointerEventActions
-
 class DefaultTreeViewPointerEventAction(
     private val treeState: TreeState,
-) : PointerEventActions {
+) : DefaultSelectableLazyColumnEventAction() {
 
     override fun handlePointerEventPress(
         pointerEvent: PointerEvent,
@@ -130,16 +154,16 @@ class DefaultTreeViewPointerEventAction(
     ) {
         with(keyBindings) {
             when {
-                pointerEvent.keyboardModifiers.isKeyboardMultiSelectionKeyPressed && pointerEvent.keyboardModifiers.isCtrlPressed -> {
+                pointerEvent.keyboardModifiers.isContiguousSelectionKeyPressed && pointerEvent.keyboardModifiers.isCtrlPressed -> {
                     Log.t("ctrl and shift pressed on click")
                 }
 
-                pointerEvent.keyboardModifiers.isKeyboardMultiSelectionKeyPressed -> {
+                pointerEvent.keyboardModifiers.isContiguousSelectionKeyPressed -> {
                     super.onExtendSelectionToKey(key, allKeys, selectableLazyListState, selectionMode)
                 }
 
-                pointerEvent.keyboardModifiers.isCtrlPressed -> {
-                    Log.t("control pressed")
+                pointerEvent.keyboardModifiers.isMultiSelectionKeyPressed -> {
+                    Log.t("multi selection pressed")
                     selectableLazyListState.lastKeyEventUsedMouse = false
                     super.toggleKeySelection(key, allKeys, selectableLazyListState)
                 }
@@ -183,10 +207,18 @@ class DefaultTreeViewPointerEventAction(
     }
 }
 
-class DefaultTreeViewKeyActions(treeState: TreeState) : DefaultSelectableLazyColumnKeyActions() {
+fun DefaultTreeViewKeyActions(treeState: TreeState): DefaultTreeViewKeyActions {
+    val keybindings = when {
+        hostOs.isMacOS -> DefaultMacOsTreeColumnKeybindings
+        else -> DefaultTreeViewKeybindings
+    }
+    return DefaultTreeViewKeyActions(keybindings, DefaultTreeViewOnKeyEvent(keybindings, treeState))
+}
 
-    override val keybindings: TreeViewKeybindings = DefaultTreeViewKeybindings
-    override val actions: DefaultTreeViewOnKeyEvent = DefaultTreeViewOnKeyEvent(keybindings, treeState = treeState)
+class DefaultTreeViewKeyActions(
+    override val keybindings: TreeViewKeybindings,
+    override val actions: DefaultTreeViewOnKeyEvent,
+) : DefaultSelectableLazyColumnKeyActions(keybindings, actions) {
 
     override fun handleOnKeyEvent(
         event: KeyEvent,
@@ -214,13 +246,17 @@ class DefaultTreeViewKeyActions(treeState: TreeState) : DefaultSelectableLazyCol
     }
 }
 
-open class DefaultSelectableLazyColumnKeyActions : KeyBindingActions {
+open class DefaultSelectableLazyColumnKeyActions(
+    override val keybindings: SelectableColumnKeybindings,
+    override val actions: SelectableColumnOnKeyEvent = DefaultSelectableOnKeyEvent(keybindings),
+) : KeyBindingActions {
 
-    override val keybindings: SelectableColumnKeybindings
-        get() = DefaultSelectableColumnKeybindings
-
-    override val actions: SelectableColumnOnKeyEvent
-        get() = DefaultSelectableOnKeyEvent(keybindings)
+    companion object : DefaultSelectableLazyColumnKeyActions(
+        when {
+            hostOs.isMacOS -> DefaultMacOsSelectableColumnKeybindings
+            else -> DefaultSelectableColumnKeybindings
+        },
+    )
 
     override fun handleOnKeyEvent(
         event: KeyEvent,

--- a/ui/api/ui.api
+++ b/ui/api/ui.api
@@ -386,7 +386,7 @@ public final class org/jetbrains/jewel/ui/component/LabelledTextFieldKt {
 }
 
 public final class org/jetbrains/jewel/ui/component/LazyTreeKt {
-	public static final fun LazyTree (Lorg/jetbrains/jewel/foundation/lazy/tree/Tree;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/jewel/foundation/lazy/tree/TreeState;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/jewel/foundation/lazy/tree/KeyBindingActions;Lorg/jetbrains/jewel/ui/component/styling/LazyTreeStyle;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
+	public static final fun LazyTree (Lorg/jetbrains/jewel/foundation/lazy/tree/Tree;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/jewel/foundation/lazy/tree/TreeState;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lorg/jetbrains/jewel/foundation/lazy/tree/KeyActions;Lorg/jetbrains/jewel/ui/component/styling/LazyTreeStyle;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class org/jetbrains/jewel/ui/component/LinearProgressBarKt {

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/LazyTree.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/LazyTree.kt
@@ -9,7 +9,7 @@ import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.foundation.lazy.SelectableLazyItemScope
 import org.jetbrains.jewel.foundation.lazy.tree.BasicLazyTree
 import org.jetbrains.jewel.foundation.lazy.tree.DefaultTreeViewKeyActions
-import org.jetbrains.jewel.foundation.lazy.tree.KeyBindingActions
+import org.jetbrains.jewel.foundation.lazy.tree.KeyActions
 import org.jetbrains.jewel.foundation.lazy.tree.Tree
 import org.jetbrains.jewel.foundation.lazy.tree.TreeElementState
 import org.jetbrains.jewel.foundation.lazy.tree.TreeState
@@ -28,7 +28,7 @@ fun <T> LazyTree(
     treeState: TreeState = rememberTreeState(),
     onElementDoubleClick: (Tree.Element<T>) -> Unit = {},
     onSelectionChange: (List<Tree.Element<T>>) -> Unit = {},
-    keyActions: KeyBindingActions = DefaultTreeViewKeyActions(treeState),
+    keyActions: KeyActions = DefaultTreeViewKeyActions(treeState),
     style: LazyTreeStyle = JewelTheme.treeStyle,
     nodeContent: @Composable (SelectableLazyItemScope.(Tree.Element<T>) -> Unit),
 ) {


### PR DESCRIPTION
Key-bindings and pointer event handlers in SelectableLazyColumn and related tree views have been refactored for improved clarity and usability. This includes changes in default keybindings for selectable columns and adjustments in the hierarchical structure of key event handling for better organization and logic flow. Pivotal changes were made in the naming and function calls related to multi-selection and contiguous selection key events.