### PR TITLE
Fix index out of bounds for items call in SelectableLazyColumn

### DIFF
--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/SelectableLazyColumn.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/SelectableLazyColumn.kt
@@ -125,7 +125,7 @@ fun SelectableLazyColumn(
 
                 is Entry.Items -> items(
                     count = entry.count,
-                    key = { entry.key(entry.startIndex + it) },
+                    key = { entry.key(it) },
                     contentType = { entry.contentType(it) },
                 ) { index ->
                     val itemScope = SelectableLazyItemScope(entry.key(index) in state.selectedKeys, isFocused)

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/SelectableLazyListScope.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/SelectableLazyListScope.kt
@@ -64,9 +64,6 @@ interface SelectableLazyListScope {
 }
 
 internal class SelectableLazyListScopeContainer : SelectableLazyListScope {
-
-    private var entriesCount = 0
-
     private val keys = mutableListOf<SelectableLazyListKey>()
     private val entries = mutableListOf<Entry>()
 
@@ -78,7 +75,6 @@ internal class SelectableLazyListScopeContainer : SelectableLazyListScope {
             val key: Any,
             val contentType: Any?,
             val content: @Composable (SelectableLazyItemScope.() -> Unit),
-            val index: Int,
         ) : Entry
 
         data class Items(
@@ -86,14 +82,12 @@ internal class SelectableLazyListScopeContainer : SelectableLazyListScope {
             val key: (index: Int) -> Any,
             val contentType: (index: Int) -> Any?,
             val itemContent: @Composable (SelectableLazyItemScope.(index: Int) -> Unit),
-            val startIndex: Int,
         ) : Entry
 
         data class StickyHeader(
             val key: Any,
             val contentType: Any?,
             val content: @Composable (SelectableLazyItemScope.() -> Unit),
-            val index: Int,
         ) : Entry
     }
 
@@ -104,8 +98,7 @@ internal class SelectableLazyListScopeContainer : SelectableLazyListScope {
         content: @Composable (SelectableLazyItemScope.() -> Unit),
     ) {
         keys.add(if (selectable) Selectable(key) else NotSelectable(key))
-        entries.add(Entry.Item(key, contentType, content, entriesCount))
-        entriesCount++
+        entries.add(Entry.Item(key, contentType, content))
     }
 
     override fun items(
@@ -123,8 +116,7 @@ internal class SelectableLazyListScopeContainer : SelectableLazyListScope {
             }
         }
         keys.addAll(selectableKeys)
-        entries.add(Entry.Items(count, key, contentType, itemContent, entriesCount))
-        entriesCount += count
+        entries.add(Entry.Items(count, key, contentType, itemContent))
     }
 
     @ExperimentalFoundationApi
@@ -135,8 +127,7 @@ internal class SelectableLazyListScopeContainer : SelectableLazyListScope {
         content: @Composable (SelectableLazyItemScope.() -> Unit),
     ) {
         keys.add(if (selectable) Selectable(key) else NotSelectable(key))
-        entries.add(Entry.StickyHeader(key, contentType, content, entriesCount))
-        entriesCount++
+        entries.add(Entry.StickyHeader(key, contentType, content))
     }
 }
 

--- a/foundation/src/test/kotlin/org/jetbrains/jewel/foundation/lazy/SelectableLazyColumnTest.kt
+++ b/foundation/src/test/kotlin/org/jetbrains/jewel/foundation/lazy/SelectableLazyColumnTest.kt
@@ -1,0 +1,56 @@
+package org.jetbrains.jewel.foundation.lazy
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.requiredHeight
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+
+internal class SelectableLazyColumnTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun `column with multiple items`() = runBlocking<Unit> {
+        val items1 = (0..10).toList()
+        val items2 = (11..50).toList()
+        val scrollState = SelectableLazyListState(LazyListState())
+        composeRule.setContent {
+            Box(modifier = Modifier.requiredHeight(100.dp)) {
+                SelectableLazyColumn(state = scrollState) {
+                    items(
+                        items1.size,
+                        key = {
+                            items1[it]
+                        },
+                    ) {
+                        val itemText = "Item ${items1[it]}"
+                        BasicText(itemText, modifier = Modifier.testTag(itemText))
+                    }
+
+                    items(
+                        items2.size,
+                        key = {
+                            items2[it]
+                        },
+                    ) {
+                        val itemText = "Item ${items2[it]}"
+                        BasicText(itemText, modifier = Modifier.testTag(itemText))
+                    }
+                }
+            }
+        }
+        composeRule.awaitIdle()
+        composeRule.onNodeWithTag("Item 20").assertDoesNotExist()
+        scrollState.scrollToItem(20)
+        composeRule.onNodeWithTag("Item 20").assertExists()
+    }
+}


### PR DESCRIPTION
Before the PR when multiple `items` blocks are used, index out of bounds exception is thrown because of the `startIndex` addition. See attached test for the reproducer