### PR TITLE
Extend TabStrip API to support custom behaviours

### DIFF
--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridge.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridge.kt
@@ -807,6 +807,7 @@ private fun readDefaultTabStyle(): TabStyle {
                 .takeOrElse { 2.dp },
             tabPadding = retrieveInsetsAsPaddingValues("TabbedPane.tabInsets"),
             closeContentGap = 4.dp,
+            tabContentSpacing = 4.dp,
             tabHeight = retrieveIntAsDpOrUnspecified("TabbedPane.tabHeight").takeOrElse { 24.dp },
         ),
         icons = TabIcons(close = bridgePainterProvider("expui/general/closeSmall.svg")),
@@ -856,6 +857,7 @@ private fun readEditorTabStyle(): TabStyle {
                 .takeOrElse { 2.dp },
             tabPadding = retrieveInsetsAsPaddingValues("TabbedPane.tabInsets"),
             closeContentGap = 4.dp,
+            tabContentSpacing = 4.dp,
             tabHeight = retrieveIntAsDpOrUnspecified("TabbedPane.tabHeight")
                 .takeOrElse { 24.dp },
         ),

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridge.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridge.kt
@@ -816,11 +816,11 @@ private fun readDefaultTabStyle(): TabStyle {
             iconPressed = 1f,
             iconHovered = 1f,
             iconSelected = 1f,
-            labelNormal = 1f,
-            labelDisabled = 1f,
-            labelPressed = 1f,
-            labelHovered = 1f,
-            labelSelected = 1f,
+            contentNormal = 1f,
+            contentDisabled = 1f,
+            contentPressed = 1f,
+            contentHovered = 1f,
+            contentSelected = 1f,
         ),
     )
 }
@@ -866,11 +866,11 @@ private fun readEditorTabStyle(): TabStyle {
             iconPressed = 1f,
             iconHovered = 1f,
             iconSelected = 1f,
-            labelNormal = .7f,
-            labelDisabled = .7f,
-            labelPressed = 1f,
-            labelHovered = 1f,
-            labelSelected = 1f,
+            contentNormal = .7f,
+            contentDisabled = .7f,
+            contentPressed = 1f,
+            contentHovered = 1f,
+            contentSelected = 1f,
         ),
     )
 }

--- a/int-ui/int-ui-standalone/api/int-ui-standalone.api
+++ b/int-ui/int-ui-standalone/api/int-ui-standalone.api
@@ -267,8 +267,6 @@ public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTabStylingK
 	public static synthetic fun default$default (Lorg/jetbrains/jewel/ui/component/styling/TabContentAlpha$Companion;FFFFFFFFFFILjava/lang/Object;)Lorg/jetbrains/jewel/ui/component/styling/TabContentAlpha;
 	public static final fun defaults (Lorg/jetbrains/jewel/ui/component/styling/TabIcons$Companion;Lorg/jetbrains/jewel/ui/painter/PainterProvider;)Lorg/jetbrains/jewel/ui/component/styling/TabIcons;
 	public static synthetic fun defaults$default (Lorg/jetbrains/jewel/ui/component/styling/TabIcons$Companion;Lorg/jetbrains/jewel/ui/painter/PainterProvider;ILjava/lang/Object;)Lorg/jetbrains/jewel/ui/component/styling/TabIcons;
-	public static final fun defaults-u_T4Ytw (Lorg/jetbrains/jewel/ui/component/styling/TabMetrics$Companion;FLandroidx/compose/foundation/layout/PaddingValues;FF)Lorg/jetbrains/jewel/ui/component/styling/TabMetrics;
-	public static synthetic fun defaults-u_T4Ytw$default (Lorg/jetbrains/jewel/ui/component/styling/TabMetrics$Companion;FLandroidx/compose/foundation/layout/PaddingValues;FFILjava/lang/Object;)Lorg/jetbrains/jewel/ui/component/styling/TabMetrics;
 	public static final fun editor (Lorg/jetbrains/jewel/ui/component/styling/TabContentAlpha$Companion;FFFFFFFFFF)Lorg/jetbrains/jewel/ui/component/styling/TabContentAlpha;
 	public static synthetic fun editor$default (Lorg/jetbrains/jewel/ui/component/styling/TabContentAlpha$Companion;FFFFFFFFFFILjava/lang/Object;)Lorg/jetbrains/jewel/ui/component/styling/TabContentAlpha;
 	public static final fun getDefault (Lorg/jetbrains/jewel/ui/component/styling/TabColors$Companion;)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDefaultTabColorsFactory;

--- a/int-ui/int-ui-standalone/api/int-ui-standalone.api
+++ b/int-ui/int-ui-standalone/api/int-ui-standalone.api
@@ -267,6 +267,8 @@ public final class org/jetbrains/jewel/intui/standalone/styling/IntUiTabStylingK
 	public static synthetic fun default$default (Lorg/jetbrains/jewel/ui/component/styling/TabContentAlpha$Companion;FFFFFFFFFFILjava/lang/Object;)Lorg/jetbrains/jewel/ui/component/styling/TabContentAlpha;
 	public static final fun defaults (Lorg/jetbrains/jewel/ui/component/styling/TabIcons$Companion;Lorg/jetbrains/jewel/ui/painter/PainterProvider;)Lorg/jetbrains/jewel/ui/component/styling/TabIcons;
 	public static synthetic fun defaults$default (Lorg/jetbrains/jewel/ui/component/styling/TabIcons$Companion;Lorg/jetbrains/jewel/ui/painter/PainterProvider;ILjava/lang/Object;)Lorg/jetbrains/jewel/ui/component/styling/TabIcons;
+	public static final fun defaults-t6ZgxxQ (Lorg/jetbrains/jewel/ui/component/styling/TabMetrics$Companion;FLandroidx/compose/foundation/layout/PaddingValues;FFF)Lorg/jetbrains/jewel/ui/component/styling/TabMetrics;
+	public static synthetic fun defaults-t6ZgxxQ$default (Lorg/jetbrains/jewel/ui/component/styling/TabMetrics$Companion;FLandroidx/compose/foundation/layout/PaddingValues;FFFILjava/lang/Object;)Lorg/jetbrains/jewel/ui/component/styling/TabMetrics;
 	public static final fun editor (Lorg/jetbrains/jewel/ui/component/styling/TabContentAlpha$Companion;FFFFFFFFFF)Lorg/jetbrains/jewel/ui/component/styling/TabContentAlpha;
 	public static synthetic fun editor$default (Lorg/jetbrains/jewel/ui/component/styling/TabContentAlpha$Companion;FFFFFFFFFFILjava/lang/Object;)Lorg/jetbrains/jewel/ui/component/styling/TabContentAlpha;
 	public static final fun getDefault (Lorg/jetbrains/jewel/ui/component/styling/TabColors$Companion;)Lorg/jetbrains/jewel/intui/standalone/styling/IntUiDefaultTabColorsFactory;

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTabStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTabStyling.kt
@@ -229,11 +229,11 @@ public fun TabContentAlpha.Companion.default(
     iconPressed: Float = iconNormal,
     iconHovered: Float = iconNormal,
     iconSelected: Float = iconNormal,
-    labelNormal: Float = iconNormal,
-    labelDisabled: Float = iconNormal,
-    labelPressed: Float = iconNormal,
-    labelHovered: Float = iconNormal,
-    labelSelected: Float = iconNormal,
+    contentNormal: Float = iconNormal,
+    contentDisabled: Float = iconNormal,
+    contentPressed: Float = iconNormal,
+    contentHovered: Float = iconNormal,
+    contentSelected: Float = iconNormal,
 ): TabContentAlpha =
     TabContentAlpha(
         iconNormal = iconNormal,
@@ -241,11 +241,11 @@ public fun TabContentAlpha.Companion.default(
         iconPressed = iconPressed,
         iconHovered = iconHovered,
         iconSelected = iconSelected,
-        labelNormal = labelNormal,
-        labelDisabled = labelDisabled,
-        labelPressed = labelPressed,
-        labelHovered = labelHovered,
-        labelSelected = labelSelected,
+        contentNormal = contentNormal,
+        contentDisabled = contentDisabled,
+        contentPressed = contentPressed,
+        contentHovered = contentHovered,
+        contentSelected = contentSelected,
     )
 
 public fun TabContentAlpha.Companion.editor(
@@ -254,11 +254,11 @@ public fun TabContentAlpha.Companion.editor(
     iconPressed: Float = 1f,
     iconHovered: Float = iconPressed,
     iconSelected: Float = iconPressed,
-    labelNormal: Float = .9f,
-    labelDisabled: Float = labelNormal,
-    labelPressed: Float = 1f,
-    labelHovered: Float = labelPressed,
-    labelSelected: Float = labelPressed,
+    contentNormal: Float = .9f,
+    contentDisabled: Float = contentNormal,
+    contentPressed: Float = 1f,
+    contentHovered: Float = contentPressed,
+    contentSelected: Float = contentPressed,
 ): TabContentAlpha =
     TabContentAlpha(
         iconNormal = iconNormal,
@@ -266,11 +266,11 @@ public fun TabContentAlpha.Companion.editor(
         iconPressed = iconPressed,
         iconHovered = iconHovered,
         iconSelected = iconSelected,
-        labelNormal = labelNormal,
-        labelDisabled = labelDisabled,
-        labelPressed = labelPressed,
-        labelHovered = labelHovered,
-        labelSelected = labelSelected,
+        contentNormal = contentNormal,
+        contentDisabled = contentDisabled,
+        contentPressed = contentPressed,
+        contentHovered = contentHovered,
+        contentSelected = contentSelected,
     )
 
 public fun TabIcons.Companion.defaults(

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTabStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiTabStyling.kt
@@ -219,9 +219,10 @@ public fun TabMetrics.Companion.defaults(
     underlineThickness: Dp = 3.dp,
     tabPadding: PaddingValues = PaddingValues(horizontal = 8.dp),
     closeContentGap: Dp = 8.dp,
+    tabContentSpacing: Dp = 4.dp,
     tabHeight: Dp = 40.dp,
 ): TabMetrics =
-    TabMetrics(underlineThickness, tabPadding, tabHeight, closeContentGap)
+    TabMetrics(underlineThickness, tabPadding, tabHeight, tabContentSpacing, closeContentGap)
 
 public fun TabContentAlpha.Companion.default(
     iconNormal: Float = 1f,

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/component/Tabs.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/component/Tabs.kt
@@ -2,6 +2,7 @@
 
 package org.jetbrains.jewel.samples.standalone.view.component
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -14,16 +15,21 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.samples.standalone.StandaloneSampleIcons
 import org.jetbrains.jewel.samples.standalone.viewmodel.View
 import org.jetbrains.jewel.ui.component.Icon
 import org.jetbrains.jewel.ui.component.IconButton
+import org.jetbrains.jewel.ui.component.SimpleTabContent
 import org.jetbrains.jewel.ui.component.TabData
 import org.jetbrains.jewel.ui.component.TabStrip
 import org.jetbrains.jewel.ui.component.Text
+import org.jetbrains.jewel.ui.painter.rememberResourcePainterProvider
 import org.jetbrains.jewel.ui.theme.defaultTabStyle
+import org.jetbrains.jewel.ui.util.thenIf
 import kotlin.math.max
 
 @Composable
@@ -48,7 +54,16 @@ private fun DefaultTabShowcase() {
         tabIds.mapIndexed { index, id ->
             TabData.Default(
                 selected = index == selectedTabIndex,
-                content = { Text(text = "Default tab $id") },
+                content = {
+                    val iconProvider =
+                        rememberResourcePainterProvider("icons/search.svg", StandaloneSampleIcons::class.java)
+                    val icon by iconProvider.getPainter()
+                    SimpleTabContent(
+                        state = it,
+                        title = "Default Tab $id",
+                        icon = icon,
+                    )
+                },
                 onClose = {
                     tabIds = tabIds.toMutableList().apply { removeAt(index) }
                     if (selectedTabIndex >= index) {
@@ -83,7 +98,35 @@ private fun EditorTabShowcase() {
         tabIds.mapIndexed { index, id ->
             TabData.Editor(
                 selected = index == selectedTabIndex,
-                content = { Text("Editor tab $id") },
+                content = { tabState ->
+                    Row {
+                        SimpleTabContent(
+                            modifier = Modifier,
+                            state = tabState,
+                            label = { Text("Editor tab $id") },
+                            icon = {
+                                Icon(
+                                    resource = "icons/search.svg",
+                                    contentDescription = "SearchIcon",
+                                    iconClass = StandaloneSampleIcons::class.java,
+                                    modifier = Modifier.size(16.dp).tabContentAlpha(state = tabState),
+                                    tint = Color.Magenta
+                                )
+                            }
+                        )
+                    }
+                    Box(
+                        modifier = Modifier
+                            .size(12.dp)
+                            .thenIf(tabState.isHovered) {
+                                drawWithCache {
+                                    onDrawBehind {
+                                        drawCircle(color = Color.Magenta.copy(alpha = .4f), radius = 6.dp.toPx())
+                                    }
+                                }
+                            }
+                    )
+                },
                 onClose = {
                     tabIds = tabIds.toMutableList().apply { removeAt(index) }
                     if (selectedTabIndex >= index) {

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/component/Tabs.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/component/Tabs.kt
@@ -110,9 +110,9 @@ private fun EditorTabShowcase() {
                                     contentDescription = "SearchIcon",
                                     iconClass = StandaloneSampleIcons::class.java,
                                     modifier = Modifier.size(16.dp).tabContentAlpha(state = tabState),
-                                    tint = Color.Magenta
+                                    tint = Color.Magenta,
                                 )
-                            }
+                            },
                         )
                     }
                     Box(
@@ -124,7 +124,7 @@ private fun EditorTabShowcase() {
                                         drawCircle(color = Color.Magenta.copy(alpha = .4f), radius = 6.dp.toPx())
                                     }
                                 }
-                            }
+                            },
                     )
                 },
                 onClose = {

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/component/Tabs.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/component/Tabs.kt
@@ -21,7 +21,6 @@ import org.jetbrains.jewel.samples.standalone.viewmodel.View
 import org.jetbrains.jewel.ui.component.Icon
 import org.jetbrains.jewel.ui.component.IconButton
 import org.jetbrains.jewel.ui.component.TabData
-import org.jetbrains.jewel.ui.component.TabData.Default
 import org.jetbrains.jewel.ui.component.TabStrip
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.theme.defaultTabStyle
@@ -47,7 +46,7 @@ private fun DefaultTabShowcase() {
 
     val tabs = remember(tabIds, selectedTabIndex) {
         tabIds.mapIndexed { index, id ->
-            Default(
+            TabData.Default(
                 selected = index == selectedTabIndex,
                 content = { Text(text = "Default tab $id") },
                 onClose = {

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/component/Tabs.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/component/Tabs.kt
@@ -21,6 +21,7 @@ import org.jetbrains.jewel.samples.standalone.viewmodel.View
 import org.jetbrains.jewel.ui.component.Icon
 import org.jetbrains.jewel.ui.component.IconButton
 import org.jetbrains.jewel.ui.component.TabData
+import org.jetbrains.jewel.ui.component.TabData.Default
 import org.jetbrains.jewel.ui.component.TabStrip
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.theme.defaultTabStyle
@@ -46,9 +47,9 @@ private fun DefaultTabShowcase() {
 
     val tabs = remember(tabIds, selectedTabIndex) {
         tabIds.mapIndexed { index, id ->
-            TabData.Default(
+            Default(
                 selected = index == selectedTabIndex,
-                label = "Default tab $id",
+                content = { Text(text = "Default tab $id") },
                 onClose = {
                     tabIds = tabIds.toMutableList().apply { removeAt(index) }
                     if (selectedTabIndex >= index) {
@@ -83,7 +84,7 @@ private fun EditorTabShowcase() {
         tabIds.mapIndexed { index, id ->
             TabData.Editor(
                 selected = index == selectedTabIndex,
-                label = "Editor tab $id",
+                content = { Text("Editor tab $id") },
                 onClose = {
                     tabIds = tabIds.toMutableList().apply { removeAt(index) }
                     if (selectedTabIndex >= index) {

--- a/ui/api/ui.api
+++ b/ui/api/ui.api
@@ -594,11 +594,18 @@ public final class org/jetbrains/jewel/ui/component/SplitLayoutKt {
 	public static final fun VerticalSplitLayout-BssWTFQ (Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Landroidx/compose/ui/Modifier;JFFFFFFLandroidx/compose/runtime/Composer;II)V
 }
 
+public abstract interface class org/jetbrains/jewel/ui/component/TabContentScope {
+	public abstract fun tabContentAlpha-A_ZS63w (Landroidx/compose/ui/Modifier;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/ui/Modifier;
+}
+
+public final class org/jetbrains/jewel/ui/component/TabContentScope$DefaultImpls {
+	public static fun tabContentAlpha-A_ZS63w (Lorg/jetbrains/jewel/ui/component/TabContentScope;Landroidx/compose/ui/Modifier;JLandroidx/compose/runtime/Composer;I)Landroidx/compose/ui/Modifier;
+}
+
 public abstract class org/jetbrains/jewel/ui/component/TabData {
 	public static final field $stable I
 	public abstract fun getClosable ()Z
-	public abstract fun getContent ()Lkotlin/jvm/functions/Function3;
-	public abstract fun getIcon ()Landroidx/compose/ui/graphics/painter/Painter;
+	public abstract fun getContent ()Lkotlin/jvm/functions/Function4;
 	public abstract fun getOnClick ()Lkotlin/jvm/functions/Function0;
 	public abstract fun getOnClose ()Lkotlin/jvm/functions/Function0;
 	public abstract fun getSelected ()Z
@@ -606,14 +613,11 @@ public abstract class org/jetbrains/jewel/ui/component/TabData {
 
 public final class org/jetbrains/jewel/ui/component/TabData$Default : org/jetbrains/jewel/ui/component/TabData {
 	public static final field $stable I
-	public fun <init> (ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
-	public synthetic fun <init> (ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (ZLkotlin/jvm/functions/Function3;Landroidx/compose/ui/graphics/painter/Painter;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
-	public synthetic fun <init> (ZLkotlin/jvm/functions/Function3;Landroidx/compose/ui/graphics/painter/Painter;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZLkotlin/jvm/functions/Function4;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (ZLkotlin/jvm/functions/Function4;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getClosable ()Z
-	public fun getContent ()Lkotlin/jvm/functions/Function3;
-	public fun getIcon ()Landroidx/compose/ui/graphics/painter/Painter;
+	public fun getContent ()Lkotlin/jvm/functions/Function4;
 	public fun getOnClick ()Lkotlin/jvm/functions/Function0;
 	public fun getOnClose ()Lkotlin/jvm/functions/Function0;
 	public fun getSelected ()Z
@@ -623,13 +627,11 @@ public final class org/jetbrains/jewel/ui/component/TabData$Default : org/jetbra
 
 public final class org/jetbrains/jewel/ui/component/TabData$Editor : org/jetbrains/jewel/ui/component/TabData {
 	public static final field $stable I
-	public fun <init> (ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
-	public fun <init> (ZLkotlin/jvm/functions/Function3;Landroidx/compose/ui/graphics/painter/Painter;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
-	public synthetic fun <init> (ZLkotlin/jvm/functions/Function3;Landroidx/compose/ui/graphics/painter/Painter;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZLkotlin/jvm/functions/Function4;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (ZLkotlin/jvm/functions/Function4;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getClosable ()Z
-	public fun getContent ()Lkotlin/jvm/functions/Function3;
-	public fun getIcon ()Landroidx/compose/ui/graphics/painter/Painter;
+	public fun getContent ()Lkotlin/jvm/functions/Function4;
 	public fun getOnClick ()Lkotlin/jvm/functions/Function0;
 	public fun getOnClose ()Lkotlin/jvm/functions/Function0;
 	public fun getSelected ()Z
@@ -705,6 +707,11 @@ public final class org/jetbrains/jewel/ui/component/TabStripState : org/jetbrain
 public final class org/jetbrains/jewel/ui/component/TabStripState$Companion {
 	public final fun of-zFr0jqg (ZZZZZ)J
 	public static synthetic fun of-zFr0jqg$default (Lorg/jetbrains/jewel/ui/component/TabStripState$Companion;ZZZZZILjava/lang/Object;)J
+}
+
+public final class org/jetbrains/jewel/ui/component/TabsKt {
+	public static final fun SimpleTabContent-A5h6_LM (Lorg/jetbrains/jewel/ui/component/TabContentScope;Landroidx/compose/ui/Modifier;JLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun SimpleTabContent-A5h6_LM (Lorg/jetbrains/jewel/ui/component/TabContentScope;Ljava/lang/String;JLandroidx/compose/ui/graphics/painter/Painter;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class org/jetbrains/jewel/ui/component/TextAreaKt {
@@ -1799,20 +1806,20 @@ public final class org/jetbrains/jewel/ui/component/styling/TabContentAlpha {
 	public static final field $stable I
 	public static final field Companion Lorg/jetbrains/jewel/ui/component/styling/TabContentAlpha$Companion;
 	public fun <init> (FFFFFFFFFF)V
+	public final fun contentFor-UXw_FYk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContentDisabled ()F
+	public final fun getContentHovered ()F
+	public final fun getContentNormal ()F
+	public final fun getContentPressed ()F
+	public final fun getContentSelected ()F
 	public final fun getIconDisabled ()F
 	public final fun getIconHovered ()F
 	public final fun getIconNormal ()F
 	public final fun getIconPressed ()F
 	public final fun getIconSelected ()F
-	public final fun getLabelDisabled ()F
-	public final fun getLabelHovered ()F
-	public final fun getLabelNormal ()F
-	public final fun getLabelPressed ()F
-	public final fun getLabelSelected ()F
 	public fun hashCode ()I
 	public final fun iconFor-UXw_FYk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
-	public final fun labelFor-UXw_FYk (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/runtime/State;
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -1835,9 +1842,10 @@ public final class org/jetbrains/jewel/ui/component/styling/TabIcons$Companion {
 public final class org/jetbrains/jewel/ui/component/styling/TabMetrics {
 	public static final field $stable I
 	public static final field Companion Lorg/jetbrains/jewel/ui/component/styling/TabMetrics$Companion;
-	public synthetic fun <init> (FLandroidx/compose/foundation/layout/PaddingValues;FFLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (FLandroidx/compose/foundation/layout/PaddingValues;FFFLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCloseContentGap-D9Ej5fM ()F
+	public final fun getTabContentSpacing-D9Ej5fM ()F
 	public final fun getTabHeight-D9Ej5fM ()F
 	public final fun getTabPadding ()Landroidx/compose/foundation/layout/PaddingValues;
 	public final fun getUnderlineThickness-D9Ej5fM ()F

--- a/ui/api/ui.api
+++ b/ui/api/ui.api
@@ -50,10 +50,12 @@ public final class org/jetbrains/jewel/ui/DefaultComponentStyling : org/jetbrain
 	public final fun getTooltipStyle ()Lorg/jetbrains/jewel/ui/component/styling/TooltipStyle;
 	public final fun getUndecoratedDropdownStyle ()Lorg/jetbrains/jewel/ui/component/styling/DropdownStyle;
 	public fun hashCode ()I
+	public synthetic fun provide (Lkotlin/jvm/functions/Function0;)Lorg/jetbrains/jewel/ui/ComponentStyling;
 	public fun provide (Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/jewel/ui/ComponentStyling;
 	public fun provide ([Landroidx/compose/runtime/ProvidedValue;)Lorg/jetbrains/jewel/ui/ComponentStyling;
 	public fun styles (Landroidx/compose/runtime/Composer;I)[Landroidx/compose/runtime/ProvidedValue;
 	public fun toString ()Ljava/lang/String;
+	public synthetic fun with (Lkotlin/jvm/functions/Function0;)Lorg/jetbrains/jewel/ui/ComponentStyling;
 	public fun with (Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/jewel/ui/ComponentStyling;
 	public fun with (Lorg/jetbrains/jewel/ui/ComponentStyling;)Lorg/jetbrains/jewel/ui/ComponentStyling;
 }
@@ -597,8 +599,8 @@ public final class org/jetbrains/jewel/ui/component/SplitLayoutKt {
 public abstract class org/jetbrains/jewel/ui/component/TabData {
 	public static final field $stable I
 	public abstract fun getClosable ()Z
+	public abstract fun getContent ()Lkotlin/jvm/functions/Function3;
 	public abstract fun getIcon ()Landroidx/compose/ui/graphics/painter/Painter;
-	public abstract fun getLabel ()Ljava/lang/String;
 	public abstract fun getOnClick ()Lkotlin/jvm/functions/Function0;
 	public abstract fun getOnClose ()Lkotlin/jvm/functions/Function0;
 	public abstract fun getSelected ()Z
@@ -608,10 +610,12 @@ public final class org/jetbrains/jewel/ui/component/TabData$Default : org/jetbra
 	public static final field $stable I
 	public fun <init> (ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
 	public synthetic fun <init> (ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZLkotlin/jvm/functions/Function3;Landroidx/compose/ui/graphics/painter/Painter;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (ZLkotlin/jvm/functions/Function3;Landroidx/compose/ui/graphics/painter/Painter;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getClosable ()Z
+	public fun getContent ()Lkotlin/jvm/functions/Function3;
 	public fun getIcon ()Landroidx/compose/ui/graphics/painter/Painter;
-	public fun getLabel ()Ljava/lang/String;
 	public fun getOnClick ()Lkotlin/jvm/functions/Function0;
 	public fun getOnClose ()Lkotlin/jvm/functions/Function0;
 	public fun getSelected ()Z
@@ -622,11 +626,12 @@ public final class org/jetbrains/jewel/ui/component/TabData$Default : org/jetbra
 public final class org/jetbrains/jewel/ui/component/TabData$Editor : org/jetbrains/jewel/ui/component/TabData {
 	public static final field $stable I
 	public fun <init> (ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
-	public synthetic fun <init> (ZLjava/lang/String;Landroidx/compose/ui/graphics/painter/Painter;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZLkotlin/jvm/functions/Function3;Landroidx/compose/ui/graphics/painter/Painter;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (ZLkotlin/jvm/functions/Function3;Landroidx/compose/ui/graphics/painter/Painter;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getClosable ()Z
+	public fun getContent ()Lkotlin/jvm/functions/Function3;
 	public fun getIcon ()Landroidx/compose/ui/graphics/painter/Painter;
-	public fun getLabel ()Ljava/lang/String;
 	public fun getOnClick ()Lkotlin/jvm/functions/Function0;
 	public fun getOnClose ()Lkotlin/jvm/functions/Function0;
 	public fun getSelected ()Z

--- a/ui/api/ui.api
+++ b/ui/api/ui.api
@@ -50,12 +50,10 @@ public final class org/jetbrains/jewel/ui/DefaultComponentStyling : org/jetbrain
 	public final fun getTooltipStyle ()Lorg/jetbrains/jewel/ui/component/styling/TooltipStyle;
 	public final fun getUndecoratedDropdownStyle ()Lorg/jetbrains/jewel/ui/component/styling/DropdownStyle;
 	public fun hashCode ()I
-	public synthetic fun provide (Lkotlin/jvm/functions/Function0;)Lorg/jetbrains/jewel/ui/ComponentStyling;
 	public fun provide (Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/jewel/ui/ComponentStyling;
 	public fun provide ([Landroidx/compose/runtime/ProvidedValue;)Lorg/jetbrains/jewel/ui/ComponentStyling;
 	public fun styles (Landroidx/compose/runtime/Composer;I)[Landroidx/compose/runtime/ProvidedValue;
 	public fun toString ()Ljava/lang/String;
-	public synthetic fun with (Lkotlin/jvm/functions/Function0;)Lorg/jetbrains/jewel/ui/ComponentStyling;
 	public fun with (Lkotlin/jvm/functions/Function2;)Lorg/jetbrains/jewel/ui/ComponentStyling;
 	public fun with (Lorg/jetbrains/jewel/ui/ComponentStyling;)Lorg/jetbrains/jewel/ui/ComponentStyling;
 }

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TabStrip.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TabStrip.kt
@@ -137,7 +137,7 @@ public sealed class TabData {
             "Use the primary constructor instead",
             ReplaceWith(
                 "Editor(selected = selected, content = { Text(text) }, icon = icon, closable = closable, onClose = onClose, onClick = onClick)",
-                "org.jetbrains.jewel.ui.component.TabData.Default",
+                "org.jetbrains.jewel.ui.component.TabData.Editor",
             ),
         )
         public constructor(

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TabStrip.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TabStrip.kt
@@ -24,13 +24,11 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.platform.LocalLayoutDirection
 import org.jetbrains.jewel.foundation.GenerateDataFunctions
 import org.jetbrains.jewel.foundation.modifier.onHover
 import org.jetbrains.jewel.foundation.state.CommonStateBitMask
 import org.jetbrains.jewel.foundation.state.FocusableComponentState
-import org.jetbrains.jewel.foundation.state.InteractiveComponentState
 
 @Composable
 public fun TabStrip(
@@ -81,8 +79,7 @@ public fun TabStrip(
 public sealed class TabData {
 
     public abstract val selected: Boolean
-    public abstract val content: @Composable (tabState: InteractiveComponentState) -> Unit
-    public abstract val icon: Painter?
+    public abstract val content: @Composable TabContentScope.(tabState: TabState) -> Unit
     public abstract val closable: Boolean
     public abstract val onClose: () -> Unit
     public abstract val onClick: () -> Unit
@@ -91,71 +88,21 @@ public sealed class TabData {
     @GenerateDataFunctions
     public class Default(
         override val selected: Boolean,
-        override val content: @Composable (tabState: InteractiveComponentState) -> Unit,
-        override val icon: Painter? = null,
+        override val content: @Composable TabContentScope.(tabState: TabState) -> Unit,
         override val closable: Boolean = true,
         override val onClose: () -> Unit = {},
         override val onClick: () -> Unit = {},
-    ) : TabData() {
-
-        @Deprecated(
-            "Use the primary constructor instead",
-            ReplaceWith(
-                "Default(selected = selected, content = { Text(text) }, icon = icon, closable = closable, onClose = onClose, onClick = onClick)",
-                "org.jetbrains.jewel.ui.component.TabData.Default",
-            ),
-        )
-        public constructor(
-            selected: Boolean,
-            text: String,
-            icon: Painter? = null,
-            closable: Boolean = true,
-            onClose: () -> Unit,
-            onClick: () -> Unit,
-        ) : this(
-            selected = selected,
-            content = { Text(text) },
-            icon = icon,
-            closable = closable,
-            onClose = onClose,
-            onClick = onClick,
-        )
-    }
+    ) : TabData()
 
     @Immutable
     @GenerateDataFunctions
     public class Editor(
         override val selected: Boolean,
-        override val content: @Composable (tabState: InteractiveComponentState) -> Unit,
-        override val icon: Painter? = null,
+        override val content: @Composable TabContentScope.(tabState: TabState) -> Unit,
         override val closable: Boolean = true,
         override val onClose: () -> Unit = {},
         override val onClick: () -> Unit = {},
-    ) : TabData() {
-
-        @Deprecated(
-            "Use the primary constructor instead",
-            ReplaceWith(
-                "Editor(selected = selected, content = { Text(text) }, icon = icon, closable = closable, onClose = onClose, onClick = onClick)",
-                "org.jetbrains.jewel.ui.component.TabData.Editor",
-            ),
-        )
-        public constructor(
-            selected: Boolean,
-            text: String,
-            icon: Painter?,
-            closable: Boolean,
-            onClose: () -> Unit,
-            onClick: () -> Unit,
-        ) : this(
-            selected = selected,
-            content = { Text(text) },
-            icon = icon,
-            closable = closable,
-            onClose = onClose,
-            onClick = onClick,
-        )
-    }
+    ) : TabData()
 }
 
 @Immutable

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TabStrip.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TabStrip.kt
@@ -48,16 +48,18 @@ public fun TabStrip(
             .onHover { tabStripState = tabStripState.copy(hovered = it) },
     ) {
         Row(
-            modifier = Modifier.horizontalScroll(scrollState).scrollable(
-                orientation = Orientation.Vertical,
-                reverseDirection = ScrollableDefaults.reverseDirection(
-                    LocalLayoutDirection.current,
-                    Orientation.Vertical,
-                    false,
-                ),
-                state = scrollState,
-                interactionSource = remember { MutableInteractionSource() },
-            ).selectableGroup(),
+            modifier = Modifier.horizontalScroll(scrollState)
+                .scrollable(
+                    orientation = Orientation.Vertical,
+                    reverseDirection = ScrollableDefaults.reverseDirection(
+                        LocalLayoutDirection.current,
+                        Orientation.Vertical,
+                        false,
+                    ),
+                    state = scrollState,
+                    interactionSource = remember { MutableInteractionSource() },
+                )
+                .selectableGroup(),
         ) {
             tabs.forEach { TabImpl(isActive = tabStripState.isActive, tabData = it) }
         }

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Tabs.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Tabs.kt
@@ -88,7 +88,7 @@ internal fun TabImpl(
         .value.takeOrElse { LocalContentColor.current }
 
     CompositionLocalProvider(LocalContentColor provides resolvedContentColor) {
-        val labelAlpha by tabStyle.contentAlpha.labelFor(tabState)
+        val contentAlpha by tabStyle.contentAlpha.contentFor(tabState)
         val iconAlpha by tabStyle.contentAlpha.iconFor(tabState)
 
         Row(
@@ -125,7 +125,7 @@ internal fun TabImpl(
                 Image(modifier = Modifier.alpha(iconAlpha), painter = icon, contentDescription = null)
             }
 
-            Box(Modifier.alpha(labelAlpha)) {
+            Box(Modifier.alpha(contentAlpha)) {
                 tabData.content(tabState)
             }
 

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Tabs.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Tabs.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.interaction.HoverInteraction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
@@ -72,10 +73,7 @@ internal fun TabImpl(
         interactionSource.interactions.collect { interaction ->
             when (interaction) {
                 is PressInteraction.Press -> tabState = tabState.copy(pressed = true)
-                is PressInteraction.Cancel,
-                is PressInteraction.Release,
-                -> tabState = tabState.copy(pressed = false)
-
+                is PressInteraction.Cancel, is PressInteraction.Release -> tabState = tabState.copy(pressed = false)
                 is HoverInteraction.Enter -> tabState = tabState.copy(hovered = true)
                 is HoverInteraction.Exit -> tabState = tabState.copy(hovered = false)
             }
@@ -127,11 +125,10 @@ internal fun TabImpl(
                 Image(modifier = Modifier.alpha(iconAlpha), painter = icon, contentDescription = null)
             }
 
-            Text(
-                modifier = Modifier.alpha(labelAlpha),
-                text = tabData.label,
-                color = tabStyle.colors.contentFor(tabState).value,
-            )
+            Box(Modifier.alpha(labelAlpha)) {
+                tabData.content(tabState)
+            }
+
             val showCloseIcon =
                 when (tabData) {
                     is TabData.Default -> tabData.closable
@@ -166,7 +163,7 @@ internal fun TabImpl(
                         )
                         .size(16.dp),
                     painter = closePainter,
-                    contentDescription = "Close tab ${tabData.label}",
+                    contentDescription = "Close tab",
                 )
             } else if (tabData.closable) {
                 Spacer(Modifier.size(16.dp))

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/styling/TabStyling.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/styling/TabStyling.kt
@@ -121,11 +121,11 @@ public class TabContentAlpha(
     public val iconPressed: Float,
     public val iconHovered: Float,
     public val iconSelected: Float,
-    public val labelNormal: Float,
-    public val labelDisabled: Float,
-    public val labelPressed: Float,
-    public val labelHovered: Float,
-    public val labelSelected: Float,
+    public val contentNormal: Float,
+    public val contentDisabled: Float,
+    public val contentPressed: Float,
+    public val contentHovered: Float,
+    public val contentSelected: Float,
 ) {
 
     @Composable
@@ -145,17 +145,17 @@ public class TabContentAlpha(
         )
 
     @Composable
-    public fun labelFor(state: TabState): State<Float> =
+    public fun contentFor(state: TabState): State<Float> =
         rememberUpdatedState(
             when {
-                state.isSelected -> labelSelected
+                state.isSelected -> contentSelected
                 else ->
                     state.chooseValueIgnoreCompat(
-                        normal = labelNormal,
-                        disabled = labelDisabled,
-                        pressed = labelPressed,
-                        hovered = labelHovered,
-                        active = labelNormal,
+                        normal = contentNormal,
+                        disabled = contentDisabled,
+                        pressed = contentPressed,
+                        hovered = contentHovered,
+                        active = contentNormal,
                     )
             },
         )

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/styling/TabStyling.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/styling/TabStyling.kt
@@ -32,6 +32,7 @@ public class TabMetrics(
     public val underlineThickness: Dp,
     public val tabPadding: PaddingValues,
     public val tabHeight: Dp,
+    public val tabContentSpacing: Dp,
     public val closeContentGap: Dp,
 ) {
 


### PR DESCRIPTION
In the IDE and in some specs, you can find some kind of fanciful Tabs usage...

as an example, using a composite tabHeader content that has a title made by two different texts with different styles or icons

![image](https://github.com/JetBrains/jewel/assets/36624359/51b09925-a663-4f0f-913a-0e3e956b5cea)

![image](https://github.com/JetBrains/jewel/assets/36624359/737c99f8-5644-4090-8183-cb252ff809fb)

we can change the api for to allow users to provide content for tabs, allowing users to solve their own problems

migrating to a new DSL:

```
    public class TabData.Editor(
        override val selected: Boolean,
        override val content: @Composable TabContentScope.(tabState: TabState) -> Unit,
        override val closable: Boolean = true,
        override val onClose: () -> Unit = {},
        override val onClick: () -> Unit = {},
    ) : TabData()
```

and exposing the following methods:

```
@Composable
public fun TabContentScope.SimpleTabContent(
    title: String,
    state: TabState,
    icon: Painter?,
    modifier: Modifier = Modifier,
) 

@Composable
public fun TabContentScope.SimpleTabContent(
    modifier: Modifier = Modifier,
    state: TabState,
    icon: (@Composable () -> Unit)? = null,
    label: @Composable () -> Unit,
)
```

this will allow achieving custom behavior for the tab, as we show in the standalone sample
<img width="529" alt="image" src="https://github.com/JetBrains/jewel/assets/36624359/bed6b3e3-91e4-4aa2-b195-0bb6176b781b">
