### PR TITLE
Fix crash on JBR 17.0.9-b1087.9+ on Linux

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-composeDesktop = "1.5.11"
+composeDesktop = "1.6.0-dev1362"
 detekt = "1.23.1"
 dokka = "1.8.20"
 idea232 = "232.10227.8"


### PR DESCRIPTION
The fix is updating to Compose Multiplatform 1.6.0-dev1362, which contains the compose-multiplatform-core#973 fix. It also contains some Swing interop fixes which users might need.

Fixes #281 