### PR TITLE
Add derived TextStyle APIs under Typography

### DIFF
--- a/ide-laf-bridge/api/ide-laf-bridge.api
+++ b/ide-laf-bridge/api/ide-laf-bridge.api
@@ -57,6 +57,12 @@ public abstract interface class org/jetbrains/jewel/bridge/ToolWindowScope {
 	public abstract fun getToolWindow ()Lcom/intellij/openapi/wm/ToolWindow;
 }
 
+public final class org/jetbrains/jewel/bridge/TypographyKt {
+	public static final fun medium (Lorg/jetbrains/jewel/ui/component/Typography;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/text/TextStyle;
+	public static final fun regular (Lorg/jetbrains/jewel/ui/component/Typography;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/text/TextStyle;
+	public static final fun small (Lorg/jetbrains/jewel/ui/component/Typography;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/text/TextStyle;
+}
+
 public final class org/jetbrains/jewel/bridge/actionSystem/ProvideDataKt {
 	public static final fun ComponentDataProviderBridge (Ljavax/swing/JComponent;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 	public static final fun provideData (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;)Landroidx/compose/ui/Modifier;

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/Typography.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/Typography.kt
@@ -1,0 +1,59 @@
+package org.jetbrains.jewel.bridge
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.sp
+import com.intellij.openapi.util.SystemInfo
+import com.intellij.ui.NewUiValue
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.Typography
+import org.jetbrains.jewel.ui.component.minus
+
+/**
+ * The text style to use for regular text. Identical to
+ * [JewelTheme.textStyle].
+ *
+ * Only available when running in the IntelliJ Platform.
+ */
+@Composable
+public fun Typography.regular(): TextStyle = labelTextStyle()
+
+/**
+ * The text style to use for medium text. Smaller than [regular].
+ *
+ * Only available when running in the IntelliJ Platform.
+ *
+ * **Note:** when using the Classic UI on Windows, this returns the same
+ * value as [regular] (the default TextStyle from the theme). This is the
+ * same behavior implemented by [com.intellij.util.ui.JBFont].
+ */
+@Composable
+public fun Typography.medium(): TextStyle =
+    if (mediumAndSmallFontsAsRegular()) {
+        labelTextStyle()
+    } else {
+        labelTextStyle().copy(fontSize = labelTextSize() - 1.sp)
+    }
+
+/**
+ * The text style to use for small text. Smaller than [medium]. Should be
+ * avoided when running in the New UI, in favor of [medium], unless it's
+ * absolutely necessary.
+ *
+ * Only available when running in the IntelliJ Platform.
+ *
+ * **Note:** when using the Classic UI on Windows, this returns the same
+ * value as [regular] (the default TextStyle from the theme). This is the
+ * same behavior implemented by [com.intellij.util.ui.JBFont].
+ */
+@Composable
+public fun Typography.small(): TextStyle =
+    if (mediumAndSmallFontsAsRegular()) {
+        labelTextStyle()
+    } else {
+        labelTextStyle().copy(fontSize = labelTextSize() - 2.sp)
+    }
+
+// Copied from JBFont — current as of IJP 233.
+private fun mediumAndSmallFontsAsRegular(): Boolean =
+    SystemInfo.isWindows && !NewUiValue.isEnabled()

--- a/ui/api/ui.api
+++ b/ui/api/ui.api
@@ -741,6 +741,23 @@ public final class org/jetbrains/jewel/ui/component/TooltipPlacement : androidx/
 	public fun positionProvider-9KIMszo (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/ui/window/PopupPositionProvider;
 }
 
+public final class org/jetbrains/jewel/ui/component/Typography {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/ui/component/Typography;
+	public final fun h0TextStyle (Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/text/TextStyle;
+	public final fun h1TextStyle (Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/text/TextStyle;
+	public final fun h2TextStyle (Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/text/TextStyle;
+	public final fun h3TextStyle (Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/text/TextStyle;
+	public final fun h4TextStyle (Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/text/TextStyle;
+	public final fun labelTextSize-5XXgJZs (Landroidx/compose/runtime/Composer;I)J
+	public final fun labelTextStyle (Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/text/TextStyle;
+}
+
+public final class org/jetbrains/jewel/ui/component/TypographyKt {
+	public static final fun minus-NB67dxo (JJ)J
+	public static final fun plus-NB67dxo (JJ)J
+}
+
 public final class org/jetbrains/jewel/ui/component/styling/ButtonColors {
 	public static final field $stable I
 	public static final field Companion Lorg/jetbrains/jewel/ui/component/styling/ButtonColors$Companion;

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Typography.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Typography.kt
@@ -1,0 +1,85 @@
+package org.jetbrains.jewel.ui.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.TextUnitType
+import androidx.compose.ui.unit.isUnspecified
+import androidx.compose.ui.unit.sp
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+
+/**
+ * A quick way to obtain text styles derived from
+ * [the default `TextStyle`][JewelTheme.textStyle]. These match the
+ * functionality provided by `JBFont` in the IntelliJ Platform.
+ */
+public object Typography {
+
+    /** The text style to use for labels. Identical to [JewelTheme.textStyle]. */
+    @Composable
+    public fun labelTextStyle(): TextStyle = JewelTheme.textStyle
+
+    /**
+     * The text size to use for labels. Identical to the size set in
+     * [JewelTheme.textStyle].
+     */
+    @Composable
+    public fun labelTextSize(): TextUnit = JewelTheme.textStyle.fontSize
+
+    /**
+     * The text style to use for h0 titles. Derived from
+     * [JewelTheme.textStyle].
+     */
+    @Composable
+    public fun h0TextStyle(): TextStyle =
+        JewelTheme.textStyle.copy(fontSize = labelTextSize() + 12.sp, fontWeight = FontWeight.Bold)
+
+    /**
+     * The text style to use for h1 titles. Derived from
+     * [JewelTheme.textStyle].
+     */
+    @Composable
+    public fun h1TextStyle(): TextStyle =
+        JewelTheme.textStyle.copy(fontSize = labelTextSize() + 9.sp, fontWeight = FontWeight.Bold)
+
+    /**
+     * The text style to use for h2 titles. Derived from
+     * [JewelTheme.textStyle].
+     */
+    @Composable
+    public fun h2TextStyle(): TextStyle =
+        JewelTheme.textStyle.copy(fontSize = labelTextSize() + 5.sp)
+
+    /**
+     * The text style to use for h3 titles. Derived from
+     * [JewelTheme.textStyle].
+     */
+    @Composable
+    public fun h3TextStyle(): TextStyle =
+        JewelTheme.textStyle.copy(fontSize = labelTextSize() + 3.sp)
+
+    /**
+     * The text style to use for h4 titles. Derived from
+     * [JewelTheme.textStyle].
+     */
+    @Composable
+    public fun h4TextStyle(): TextStyle =
+        JewelTheme.textStyle.copy(fontSize = labelTextSize() + 1.sp, fontWeight = FontWeight.Bold)
+}
+
+public operator fun TextUnit.plus(other: TextUnit): TextUnit =
+    when {
+        isSp && other.isSp -> TextUnit(value + other.value, TextUnitType.Sp)
+        isEm && other.isEm -> TextUnit(value + other.value, TextUnitType.Em)
+        isUnspecified && other.isUnspecified -> TextUnit(value + other.value, TextUnitType.Unspecified)
+        else -> error("Can't add together different TextUnits. Got $type and ${other.type}")
+    }
+
+public operator fun TextUnit.minus(other: TextUnit): TextUnit =
+    when {
+        isSp && other.isSp -> TextUnit(value - other.value, TextUnitType.Sp)
+        isEm && other.isEm -> TextUnit(value - other.value, TextUnitType.Em)
+        isUnspecified && other.isUnspecified -> TextUnit(value - other.value, TextUnitType.Unspecified)
+        else -> error("Can't subtract different TextUnits. Got $type and ${other.type}")
+    }


### PR DESCRIPTION
Closes #279 by adding a `Typography` API that exposes equivalent functionality to what `JBFont` offers.

These are available both in standalone and on the IJP:
* `label` (the default text style accessible also from `JewelTheme.textStyle`)
* `h0` (label + size increased by 12 + bold)
* `h1` (label + size increased by 9 + bold)
* `h2` (label + size increased by 5)
* `h3` (label + size increased by 3)
* `h4` (label + size increased by 1 + bold)

There are also these size-only variants, that are only available on the IJP:

* `regular` (same as `label()`)
* `medium` (regular + size decreased by 1)
* `small` (regular + size decreased by 2)

The reason these latter are only available on the IJP is that `medium` and `small` return the same as `regular` on Windows when using the old UI — following what `JBFont` does. This wouldn't make sense on standalone.