### PR TITLE
Make Markdown components not show I-Beams on hover

### DIFF
--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
@@ -290,7 +290,8 @@ public open class DefaultMarkdownBlockRenderer(
                     Text(
                         text = "$number${block.delimiter}",
                         style = styling.numberStyle,
-                        modifier = Modifier.widthIn(min = styling.numberMinWidth),
+                        modifier = Modifier.widthIn(min = styling.numberMinWidth)
+                            .pointerHoverIcon(PointerIcon.Default, overrideDescendants = true),
                         textAlign = styling.numberTextAlign,
                     )
 
@@ -317,7 +318,11 @@ public open class DefaultMarkdownBlockRenderer(
         ) {
             for (item in block.items) {
                 Row {
-                    Text(text = styling.bullet.toString(), style = styling.bulletStyle)
+                    Text(
+                        text = styling.bullet.toString(),
+                        style = styling.bulletStyle,
+                        modifier = Modifier.pointerHoverIcon(PointerIcon.Default, overrideDescendants = true),
+                    )
 
                     Spacer(Modifier.width(styling.bulletContentGap))
 
@@ -348,10 +353,14 @@ public open class DefaultMarkdownBlockRenderer(
             isScrollable = styling.scrollsHorizontally,
             Modifier.background(styling.background, styling.shape)
                 .border(styling.borderWidth, styling.borderColor, styling.shape)
-                .pointerHoverIcon(PointerIcon.Default, true)
                 .then(if (styling.fillWidth) Modifier.fillMaxWidth() else Modifier),
         ) {
-            Text(block.content, style = styling.textStyle, modifier = Modifier.padding(styling.padding))
+            Text(
+                text = block.content,
+                style = styling.textStyle,
+                modifier = Modifier.padding(styling.padding)
+                    .pointerHoverIcon(PointerIcon.Default, overrideDescendants = true),
+            )
         }
     }
 
@@ -361,7 +370,6 @@ public open class DefaultMarkdownBlockRenderer(
             isScrollable = styling.scrollsHorizontally,
             Modifier.background(styling.background, styling.shape)
                 .border(styling.borderWidth, styling.borderColor, styling.shape)
-                .pointerHoverIcon(PointerIcon.Default, true)
                 .then(if (styling.fillWidth) Modifier.fillMaxWidth() else Modifier),
         ) {
             Column(Modifier.padding(styling.padding)) {
@@ -375,7 +383,11 @@ public open class DefaultMarkdownBlockRenderer(
                     )
                 }
 
-                Text(block.content, style = styling.textStyle)
+                Text(
+                    text = block.content,
+                    style = styling.textStyle,
+                    modifier = Modifier.pointerHoverIcon(PointerIcon.Default, overrideDescendants = true),
+                )
 
                 if (block.mimeType != null && styling.infoPosition.verticalAlignment == Alignment.Bottom) {
                     FencedBlockInfo(
@@ -407,7 +419,9 @@ public open class DefaultMarkdownBlockRenderer(
         // TODO implement image rendering support (will require image loading)
         Text(
             "⚠️ Images are not supported yet",
-            Modifier.border(1.dp, Color.Red).padding(horizontal = 8.dp, vertical = 4.dp),
+            Modifier.border(1.dp, Color.Red)
+                .padding(horizontal = 8.dp, vertical = 4.dp)
+                .pointerHoverIcon(PointerIcon.Default, overrideDescendants = true),
             color = Color.Red,
         )
     }

--- a/markdown/extension-gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertBlockRenderer.kt
+++ b/markdown/extension-gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertBlockRenderer.kt
@@ -14,6 +14,8 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.input.pointer.PointerIcon
+import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.unit.LayoutDirection.Ltr
 import androidx.compose.ui.unit.dp
 import org.jetbrains.jewel.foundation.theme.LocalContentColor
@@ -106,7 +108,11 @@ public class GitHubAlertBlockRenderer(
                     LocalContentColor provides
                         styling.titleTextStyle.color.takeOrElse { LocalContentColor.current },
                 ) {
-                    Text(block.javaClass.simpleName, style = styling.titleTextStyle)
+                    Text(
+                        text = block.javaClass.simpleName,
+                        style = styling.titleTextStyle,
+                        modifier = Modifier.pointerHoverIcon(PointerIcon.Default, overrideDescendants = true),
+                    )
                 }
             }
             CompositionLocalProvider(


### PR DESCRIPTION
We had some cases where the MD Preview was showing the I-Beam cursors. This happens because the `Text` composable sets a hardcoded I-Beam if the internal `SelectionRegistrar` is not null:

https://github.com/JetBrains/compose-multiplatform-core/blob/adabe8200876f07a39722774a8d0840da195bef8/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/BasicText.skiko.kt#L23-L25

and

https://github.com/JetBrains/compose-multiplatform-core/blob/adabe8200876f07a39722774a8d0840da195bef8/compose/foundation/foundation/src/skikoMain/kotlin/androidx/compose/foundation/text/TextPointerIcon.skiko.kt#L21

This PR sets the pointer icon on the Text composables — all of them — and makes sure the overrideDescendants flag is set to true, since otherwise this gets trumped by the internal modifier.