### PR TITLE
Fix cpu usage from TexField caret animation by updating compose dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 commonmark = "0.21.0"
-composeDesktop = "1.6.0-dev1397"
+composeDesktop = "1.6.0-dev1440"
 detekt = "1.23.4"
 dokka = "1.8.20"
 idea = "241.12662.62-EAP-SNAPSHOT"

--- a/samples/ide-plugin/build.gradle.kts
+++ b/samples/ide-plugin/build.gradle.kts
@@ -17,7 +17,9 @@ repositories {
     maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
     maven("https://www.jetbrains.com/intellij-repository/releases")
     maven("https://cache-redirector.jetbrains.com/intellij-dependencies")
+    google()
     mavenCentral()
+
 }
 
 dependencies {

--- a/ui/api/ui.api
+++ b/ui/api/ui.api
@@ -737,7 +737,6 @@ public final class org/jetbrains/jewel/ui/component/TooltipPlacement : androidx/
 	public static final field $stable I
 	public synthetic fun <init> (JLandroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/ui/unit/Density;FILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (JLandroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/ui/unit/Density;FLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun positionProvider (Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/window/PopupPositionProvider;
 	public fun positionProvider-9KIMszo (JLandroidx/compose/runtime/Composer;I)Landroidx/compose/ui/window/PopupPositionProvider;
 }
 

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Tooltip.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Tooltip.kt
@@ -89,13 +89,7 @@ public class TooltipPlacement(
 ) : TooltipPlacement {
 
     @Composable
-    @Suppress("OVERRIDE_DEPRECATION")
-    override fun positionProvider(): PopupPositionProvider {
-        error("Not supported")
-    }
-
-    @Composable
-    override fun positionProvider(cursorPosition: Offset): PopupPositionProvider =
+    public override fun positionProvider(cursorPosition: Offset): PopupPositionProvider =
         rememberTooltipPositionProvider(
             cursorPosition = cursorPosition,
             contentOffset = contentOffset,


### PR DESCRIPTION
Refer to CMP: TextField cursor animation uses a lot of CPU [#4225](https://github.com/JetBrains/compose-multiplatform/issues/4225)