### PR TITLE
Use typography APIs in samples, reduce duplication in bridge

### DIFF
--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/SwingBridgeService.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/SwingBridgeService.kt
@@ -55,7 +55,7 @@ internal class SwingBridgeService(scope: CoroutineScope) {
                 val themeDefinition = createBridgeThemeDefinition(TextStyle.Default)
 
                 BridgeThemeData(
-                    themeDefinition = createBridgeThemeDefinition(TextStyle.Default),
+                    themeDefinition = themeDefinition,
                     componentStyling =
                     createBridgeComponentStyling(
                         theme = themeDefinition,

--- a/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/releasessample/ReleasesSampleCompose.kt
+++ b/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/releasessample/ReleasesSampleCompose.kt
@@ -70,10 +70,10 @@ import com.intellij.util.ui.JBUI
 import icons.JewelIcons
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.toJavaLocalDate
+import org.jetbrains.jewel.bridge.medium
+import org.jetbrains.jewel.bridge.regular
 import org.jetbrains.jewel.bridge.retrieveColorOrUnspecified
-import org.jetbrains.jewel.bridge.retrieveTextStyle
 import org.jetbrains.jewel.bridge.toComposeColor
 import org.jetbrains.jewel.foundation.lazy.SelectableLazyColumn
 import org.jetbrains.jewel.foundation.lazy.SelectionMode
@@ -87,6 +87,7 @@ import org.jetbrains.jewel.ui.component.IconButton
 import org.jetbrains.jewel.ui.component.PopupMenu
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.component.TextField
+import org.jetbrains.jewel.ui.component.Typography
 import org.jetbrains.jewel.ui.component.VerticalScrollbar
 import org.jetbrains.jewel.ui.component.items
 import org.jetbrains.jewel.ui.painter.rememberResourcePainterProvider
@@ -253,7 +254,7 @@ private fun ItemTag(
 ) {
     Text(
         text = text,
-        fontSize = JBFont.medium().size2D.sp,
+        style = Typography.medium(),
         color = foregroundColor,
         modifier = modifier
             .background(backgroundColor, shape)
@@ -506,16 +507,7 @@ private fun ItemDetailsText(selectedItem: ContentItem) {
         Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
         verticalArrangement = Arrangement.spacedBy(6.dp),
     ) {
-        Text(
-            selectedItem.displayText,
-            style = runBlocking {
-                retrieveTextStyle(
-                    key = "Label.font",
-                    bold = true,
-                    size = JBFont.h1().size2D.sp,
-                )
-            },
-        )
+        Text(selectedItem.displayText, style = Typography.h1TextStyle())
 
         val formatter =
             remember(Locale.current) { DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM) }
@@ -523,7 +515,7 @@ private fun ItemDetailsText(selectedItem: ContentItem) {
         if (releaseDate != null) {
             Text(
                 text = "Released on ${formatter.format(releaseDate.toJavaLocalDate())}",
-                fontSize = getCommentFontSize(),
+                style = Typography.medium(),
                 color = JBUI.CurrentTheme.Label.disabledForeground().toComposeColor(),
             )
         }
@@ -558,7 +550,7 @@ private fun AndroidStudioReleaseDetails(item: ContentItem.AndroidStudio) {
 private fun TextWithLabel(labelText: String, valueText: String) {
     Row(horizontalArrangement = Arrangement.spacedBy(16.dp)) {
         Text(labelText)
-        Text(valueText, fontWeight = FontWeight.W600)
+        Text(valueText, style = Typography.regular().copy(fontWeight = FontWeight.Bold))
     }
 }
 

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/ComponentsView.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/ComponentsView.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import org.jetbrains.jewel.foundation.modifier.trackActivation
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.samples.standalone.StandaloneSampleIcons
@@ -26,6 +25,7 @@ import org.jetbrains.jewel.ui.component.Icon
 import org.jetbrains.jewel.ui.component.SelectableIconButton
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.component.Tooltip
+import org.jetbrains.jewel.ui.component.Typography
 import org.jetbrains.jewel.ui.component.styling.LocalIconButtonStyle
 import org.jetbrains.jewel.ui.painter.hints.Size
 import org.jetbrains.jewel.ui.painter.hints.Stroke
@@ -64,7 +64,7 @@ fun ComponentsToolBar() {
 @Composable
 fun ComponentView(view: ViewInfo) {
     Column(Modifier.fillMaxSize().padding(24.dp), verticalArrangement = Arrangement.spacedBy(24.dp)) {
-        Text(view.title, fontSize = 20.sp)
+        Text(view.title, style = Typography.h1TextStyle())
         view.content()
     }
 }

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/WelcomeView.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/WelcomeView.kt
@@ -15,7 +15,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import org.jetbrains.jewel.foundation.modifier.trackActivation
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.samples.standalone.IntUiThemes
@@ -26,6 +25,7 @@ import org.jetbrains.jewel.ui.component.CheckboxRow
 import org.jetbrains.jewel.ui.component.Icon
 import org.jetbrains.jewel.ui.component.RadioButtonChip
 import org.jetbrains.jewel.ui.component.Text
+import org.jetbrains.jewel.ui.component.Typography
 import org.jetbrains.jewel.ui.component.styling.LocalCheckboxStyle
 import org.jetbrains.jewel.ui.painter.hints.Selected
 import org.jetbrains.jewel.ui.painter.rememberResourcePainterProvider
@@ -51,7 +51,7 @@ fun WelcomeView() {
             contentScale = ContentScale.Crop,
         )
 
-        Text("Meet Jewel", fontSize = 20.sp)
+        Text("Meet Jewel", style = Typography.h1TextStyle())
 
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             Text("Theme:")


### PR DESCRIPTION
We have the typography APIs but don't really use them in the samples — this fixes that.

There is also a small tweak to avoid a double construction in the bridge init.