### PR TITLE
Update Compose to 1.6.10-dev1549

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 commonmark = "0.22.0"
-composeDesktop = "1.6.10-dev1514"
+composeDesktop = "1.6.10-dev1549"
 detekt = "1.23.4"
 dokka = "1.8.20"
 idea = "241.14494.17-EAP-SNAPSHOT"


### PR DESCRIPTION
This CfD update includes an important fix for tests, which is the ability to tell Skiko where to extract its native libraries: https://github.com/JetBrains/skiko/issues/885