### PR TITLE
Clean up Commonmark API conventions

### DIFF
--- a/markdown/core/api/core.api
+++ b/markdown/core/api/core.api
@@ -4,7 +4,7 @@ public abstract interface class org/jetbrains/jewel/markdown/BlockWithInlineMark
 
 public abstract interface class org/jetbrains/jewel/markdown/InlineMarkdown {
 	public abstract fun getChildren ()Ljava/util/Iterator;
-	public abstract fun getValue ()Lorg/commonmark/node/Node;
+	public abstract fun getNativeNode ()Lorg/commonmark/node/Node;
 }
 
 public final class org/jetbrains/jewel/markdown/InlineMarkdown$Code : org/jetbrains/jewel/markdown/InlineMarkdown {
@@ -15,8 +15,8 @@ public final class org/jetbrains/jewel/markdown/InlineMarkdown$Code : org/jetbra
 	public static final fun equals-impl0 (Lorg/commonmark/node/Code;Lorg/commonmark/node/Code;)Z
 	public fun getChildren ()Ljava/util/Iterator;
 	public static fun getChildren-impl (Lorg/commonmark/node/Code;)Ljava/util/Iterator;
-	public fun getValue ()Lorg/commonmark/node/Code;
-	public synthetic fun getValue ()Lorg/commonmark/node/Node;
+	public fun getNativeNode ()Lorg/commonmark/node/Code;
+	public synthetic fun getNativeNode ()Lorg/commonmark/node/Node;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Lorg/commonmark/node/Code;)I
 	public fun toString ()Ljava/lang/String;
@@ -32,8 +32,8 @@ public final class org/jetbrains/jewel/markdown/InlineMarkdown$CustomNode : org/
 	public static final fun equals-impl0 (Lorg/commonmark/node/CustomNode;Lorg/commonmark/node/CustomNode;)Z
 	public fun getChildren ()Ljava/util/Iterator;
 	public static fun getChildren-impl (Lorg/commonmark/node/CustomNode;)Ljava/util/Iterator;
-	public fun getValue ()Lorg/commonmark/node/CustomNode;
-	public synthetic fun getValue ()Lorg/commonmark/node/Node;
+	public fun getNativeNode ()Lorg/commonmark/node/CustomNode;
+	public synthetic fun getNativeNode ()Lorg/commonmark/node/Node;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Lorg/commonmark/node/CustomNode;)I
 	public fun toString ()Ljava/lang/String;
@@ -53,8 +53,8 @@ public final class org/jetbrains/jewel/markdown/InlineMarkdown$Emphasis : org/je
 	public static final fun equals-impl0 (Lorg/commonmark/node/Emphasis;Lorg/commonmark/node/Emphasis;)Z
 	public fun getChildren ()Ljava/util/Iterator;
 	public static fun getChildren-impl (Lorg/commonmark/node/Emphasis;)Ljava/util/Iterator;
-	public fun getValue ()Lorg/commonmark/node/Emphasis;
-	public synthetic fun getValue ()Lorg/commonmark/node/Node;
+	public fun getNativeNode ()Lorg/commonmark/node/Emphasis;
+	public synthetic fun getNativeNode ()Lorg/commonmark/node/Node;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Lorg/commonmark/node/Emphasis;)I
 	public fun toString ()Ljava/lang/String;
@@ -70,8 +70,8 @@ public final class org/jetbrains/jewel/markdown/InlineMarkdown$HardLineBreak : o
 	public static final fun equals-impl0 (Lorg/commonmark/node/HardLineBreak;Lorg/commonmark/node/HardLineBreak;)Z
 	public fun getChildren ()Ljava/util/Iterator;
 	public static fun getChildren-impl (Lorg/commonmark/node/HardLineBreak;)Ljava/util/Iterator;
-	public fun getValue ()Lorg/commonmark/node/HardLineBreak;
-	public synthetic fun getValue ()Lorg/commonmark/node/Node;
+	public fun getNativeNode ()Lorg/commonmark/node/HardLineBreak;
+	public synthetic fun getNativeNode ()Lorg/commonmark/node/Node;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Lorg/commonmark/node/HardLineBreak;)I
 	public fun toString ()Ljava/lang/String;
@@ -87,8 +87,8 @@ public final class org/jetbrains/jewel/markdown/InlineMarkdown$HtmlInline : org/
 	public static final fun equals-impl0 (Lorg/commonmark/node/HtmlInline;Lorg/commonmark/node/HtmlInline;)Z
 	public fun getChildren ()Ljava/util/Iterator;
 	public static fun getChildren-impl (Lorg/commonmark/node/HtmlInline;)Ljava/util/Iterator;
-	public fun getValue ()Lorg/commonmark/node/HtmlInline;
-	public synthetic fun getValue ()Lorg/commonmark/node/Node;
+	public fun getNativeNode ()Lorg/commonmark/node/HtmlInline;
+	public synthetic fun getNativeNode ()Lorg/commonmark/node/Node;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Lorg/commonmark/node/HtmlInline;)I
 	public fun toString ()Ljava/lang/String;
@@ -104,8 +104,8 @@ public final class org/jetbrains/jewel/markdown/InlineMarkdown$Image : org/jetbr
 	public static final fun equals-impl0 (Lorg/commonmark/node/Image;Lorg/commonmark/node/Image;)Z
 	public fun getChildren ()Ljava/util/Iterator;
 	public static fun getChildren-impl (Lorg/commonmark/node/Image;)Ljava/util/Iterator;
-	public fun getValue ()Lorg/commonmark/node/Image;
-	public synthetic fun getValue ()Lorg/commonmark/node/Node;
+	public fun getNativeNode ()Lorg/commonmark/node/Image;
+	public synthetic fun getNativeNode ()Lorg/commonmark/node/Node;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Lorg/commonmark/node/Image;)I
 	public fun toString ()Ljava/lang/String;
@@ -121,8 +121,8 @@ public final class org/jetbrains/jewel/markdown/InlineMarkdown$Link : org/jetbra
 	public static final fun equals-impl0 (Lorg/commonmark/node/Link;Lorg/commonmark/node/Link;)Z
 	public fun getChildren ()Ljava/util/Iterator;
 	public static fun getChildren-impl (Lorg/commonmark/node/Link;)Ljava/util/Iterator;
-	public fun getValue ()Lorg/commonmark/node/Link;
-	public synthetic fun getValue ()Lorg/commonmark/node/Node;
+	public fun getNativeNode ()Lorg/commonmark/node/Link;
+	public synthetic fun getNativeNode ()Lorg/commonmark/node/Node;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Lorg/commonmark/node/Link;)I
 	public fun toString ()Ljava/lang/String;
@@ -138,8 +138,8 @@ public final class org/jetbrains/jewel/markdown/InlineMarkdown$Paragraph : org/j
 	public static final fun equals-impl0 (Lorg/commonmark/node/Paragraph;Lorg/commonmark/node/Paragraph;)Z
 	public fun getChildren ()Ljava/util/Iterator;
 	public static fun getChildren-impl (Lorg/commonmark/node/Paragraph;)Ljava/util/Iterator;
-	public synthetic fun getValue ()Lorg/commonmark/node/Node;
-	public fun getValue ()Lorg/commonmark/node/Paragraph;
+	public synthetic fun getNativeNode ()Lorg/commonmark/node/Node;
+	public fun getNativeNode ()Lorg/commonmark/node/Paragraph;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Lorg/commonmark/node/Paragraph;)I
 	public fun toString ()Ljava/lang/String;
@@ -155,8 +155,8 @@ public final class org/jetbrains/jewel/markdown/InlineMarkdown$SoftLineBreak : o
 	public static final fun equals-impl0 (Lorg/commonmark/node/SoftLineBreak;Lorg/commonmark/node/SoftLineBreak;)Z
 	public fun getChildren ()Ljava/util/Iterator;
 	public static fun getChildren-impl (Lorg/commonmark/node/SoftLineBreak;)Ljava/util/Iterator;
-	public synthetic fun getValue ()Lorg/commonmark/node/Node;
-	public fun getValue ()Lorg/commonmark/node/SoftLineBreak;
+	public synthetic fun getNativeNode ()Lorg/commonmark/node/Node;
+	public fun getNativeNode ()Lorg/commonmark/node/SoftLineBreak;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Lorg/commonmark/node/SoftLineBreak;)I
 	public fun toString ()Ljava/lang/String;
@@ -172,8 +172,8 @@ public final class org/jetbrains/jewel/markdown/InlineMarkdown$StrongEmphasis : 
 	public static final fun equals-impl0 (Lorg/commonmark/node/StrongEmphasis;Lorg/commonmark/node/StrongEmphasis;)Z
 	public fun getChildren ()Ljava/util/Iterator;
 	public static fun getChildren-impl (Lorg/commonmark/node/StrongEmphasis;)Ljava/util/Iterator;
-	public synthetic fun getValue ()Lorg/commonmark/node/Node;
-	public fun getValue ()Lorg/commonmark/node/StrongEmphasis;
+	public synthetic fun getNativeNode ()Lorg/commonmark/node/Node;
+	public fun getNativeNode ()Lorg/commonmark/node/StrongEmphasis;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Lorg/commonmark/node/StrongEmphasis;)I
 	public fun toString ()Ljava/lang/String;
@@ -189,8 +189,8 @@ public final class org/jetbrains/jewel/markdown/InlineMarkdown$Text : org/jetbra
 	public static final fun equals-impl0 (Lorg/commonmark/node/Text;Lorg/commonmark/node/Text;)Z
 	public fun getChildren ()Ljava/util/Iterator;
 	public static fun getChildren-impl (Lorg/commonmark/node/Text;)Ljava/util/Iterator;
-	public synthetic fun getValue ()Lorg/commonmark/node/Node;
-	public fun getValue ()Lorg/commonmark/node/Text;
+	public synthetic fun getNativeNode ()Lorg/commonmark/node/Node;
+	public fun getNativeNode ()Lorg/commonmark/node/Text;
 	public fun hashCode ()I
 	public static fun hashCode-impl (Lorg/commonmark/node/Text;)I
 	public fun toString ()Ljava/lang/String;
@@ -212,7 +212,7 @@ public final class org/jetbrains/jewel/markdown/MarkdownBlock$BlockQuote : org/j
 	public final fun copy (Ljava/util/List;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$BlockQuote;
 	public static synthetic fun copy$default (Lorg/jetbrains/jewel/markdown/MarkdownBlock$BlockQuote;Ljava/util/List;ILjava/lang/Object;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$BlockQuote;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getContent ()Ljava/util/List;
+	public final fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -277,24 +277,8 @@ public final class org/jetbrains/jewel/markdown/MarkdownBlock$HtmlBlock : org/je
 }
 
 public abstract interface class org/jetbrains/jewel/markdown/MarkdownBlock$ListBlock : org/jetbrains/jewel/markdown/MarkdownBlock {
-	public abstract fun getItems ()Ljava/util/List;
+	public abstract fun getChildren ()Ljava/util/List;
 	public abstract fun isTight ()Z
-}
-
-public final class org/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$BulletList : org/jetbrains/jewel/markdown/MarkdownBlock$ListBlock {
-	public static final field $stable I
-	public fun <init> (Ljava/util/List;ZLjava/lang/String;)V
-	public final fun component1 ()Ljava/util/List;
-	public final fun component2 ()Z
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/util/List;ZLjava/lang/String;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$BulletList;
-	public static synthetic fun copy$default (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$BulletList;Ljava/util/List;ZLjava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$BulletList;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBulletMarker ()Ljava/lang/String;
-	public fun getItems ()Ljava/util/List;
-	public fun hashCode ()I
-	public fun isTight ()Z
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class org/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$OrderedList : org/jetbrains/jewel/markdown/MarkdownBlock$ListBlock {
@@ -307,9 +291,25 @@ public final class org/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$OrderedL
 	public final fun copy (Ljava/util/List;ZILjava/lang/String;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$OrderedList;
 	public static synthetic fun copy$default (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$OrderedList;Ljava/util/List;ZILjava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$OrderedList;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
 	public final fun getDelimiter ()Ljava/lang/String;
-	public fun getItems ()Ljava/util/List;
 	public final fun getStartFrom ()I
+	public fun hashCode ()I
+	public fun isTight ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$UnorderedList : org/jetbrains/jewel/markdown/MarkdownBlock$ListBlock {
+	public static final field $stable I
+	public fun <init> (Ljava/util/List;ZLjava/lang/String;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;ZLjava/lang/String;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$UnorderedList;
+	public static synthetic fun copy$default (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$UnorderedList;Ljava/util/List;ZLjava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$UnorderedList;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getChildren ()Ljava/util/List;
+	public final fun getMarker ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun isTight ()Z
 	public fun toString ()Ljava/lang/String;
@@ -322,7 +322,7 @@ public final class org/jetbrains/jewel/markdown/MarkdownBlock$ListItem : org/jet
 	public final fun copy (Ljava/util/List;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListItem;
 	public static synthetic fun copy$default (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListItem;Ljava/util/List;ILjava/lang/Object;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListItem;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getContent ()Ljava/util/List;
+	public final fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -465,8 +465,8 @@ public class org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer
 	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading$HN;Landroidx/compose/runtime/Composer;I)V
 	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading;Landroidx/compose/runtime/Composer;I)V
 	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$HtmlBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$HtmlBlock;Landroidx/compose/runtime/Composer;I)V
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$BulletList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Unordered;Landroidx/compose/runtime/Composer;I)V
 	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$OrderedList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Ordered;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$UnorderedList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Unordered;Landroidx/compose/runtime/Composer;I)V
 	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List;Landroidx/compose/runtime/Composer;I)V
 	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListItem;Landroidx/compose/runtime/Composer;I)V
 	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Paragraph;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Paragraph;Landroidx/compose/runtime/Composer;I)V
@@ -513,8 +513,8 @@ public abstract interface class org/jetbrains/jewel/markdown/rendering/MarkdownB
 	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading$HN;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$HtmlBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$HtmlBlock;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$BulletList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Unordered;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$OrderedList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Ordered;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$UnorderedList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Unordered;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListItem;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Paragraph;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Paragraph;Landroidx/compose/runtime/Composer;I)V

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/InlineMarkdown.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/InlineMarkdown.kt
@@ -29,44 +29,44 @@ import org.commonmark.node.Text as CMText
  */
 public sealed interface InlineMarkdown {
 
-    public val value: Node
+    public val nativeNode: Node
 
     @JvmInline
-    public value class Emphasis(override val value: CMEmphasis) : InlineMarkdown
+    public value class Code(override val nativeNode: CMCode) : InlineMarkdown
 
     @JvmInline
-    public value class Image(override val value: CMImage) : InlineMarkdown
+    public value class CustomNode(override val nativeNode: CMCustomNode) : InlineMarkdown
 
     @JvmInline
-    public value class Code(override val value: CMCode) : InlineMarkdown
+    public value class Emphasis(override val nativeNode: CMEmphasis) : InlineMarkdown
 
     @JvmInline
-    public value class CustomNode(override val value: CMCustomNode) : InlineMarkdown
+    public value class HardLineBreak(override val nativeNode: CMHardLineBreak) : InlineMarkdown
 
     @JvmInline
-    public value class HardLineBreak(override val value: CMHardLineBreak) : InlineMarkdown
+    public value class HtmlInline(override val nativeNode: CMHtmlInline) : InlineMarkdown
 
     @JvmInline
-    public value class SoftLineBreak(override val value: CMSoftLineBreak) : InlineMarkdown
+    public value class Image(override val nativeNode: CMImage) : InlineMarkdown
 
     @JvmInline
-    public value class HtmlInline(override val value: CMHtmlInline) : InlineMarkdown
+    public value class Link(override val nativeNode: CMLink) : InlineMarkdown
 
     @JvmInline
-    public value class Link(override val value: CMLink) : InlineMarkdown
+    public value class Paragraph(override val nativeNode: CMParagraph) : InlineMarkdown
 
     @JvmInline
-    public value class StrongEmphasis(override val value: CMStrongEmphasis) : InlineMarkdown
+    public value class SoftLineBreak(override val nativeNode: CMSoftLineBreak) : InlineMarkdown
 
     @JvmInline
-    public value class Paragraph(override val value: CMParagraph) : InlineMarkdown
+    public value class StrongEmphasis(override val nativeNode: CMStrongEmphasis) : InlineMarkdown
 
     @JvmInline
-    public value class Text(override val value: CMText) : InlineMarkdown
+    public value class Text(override val nativeNode: CMText) : InlineMarkdown
 
     public val children: Iterator<InlineMarkdown>
         get() = object : Iterator<InlineMarkdown> {
-            var current = this@InlineMarkdown.value.firstChild
+            var current = this@InlineMarkdown.nativeNode.firstChild
 
             override fun hasNext(): Boolean = current != null
 
@@ -83,14 +83,14 @@ public sealed interface InlineMarkdown {
 
 public fun Node.toInlineNode(): InlineMarkdown = when (this) {
     is CMText -> Text(this)
+    is CMLink -> Link(this)
     is CMEmphasis -> Emphasis(this)
-    is CMImage -> Image(this)
+    is CMStrongEmphasis -> StrongEmphasis(this)
     is CMCode -> Code(this)
-    is CMCustomNode -> CustomNode(this)
+    is CMHtmlInline -> HtmlInline(this)
+    is CMImage -> Image(this)
     is CMHardLineBreak -> HardLineBreak(this)
     is CMSoftLineBreak -> SoftLineBreak(this)
-    is CMHtmlInline -> HtmlInline(this)
-    is CMLink -> Link(this)
-    is CMStrongEmphasis -> StrongEmphasis(this)
+    is CMCustomNode -> CustomNode(this)
     else -> error("Unexpected block $this")
 }

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/MarkdownBlock.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/MarkdownBlock.kt
@@ -2,9 +2,7 @@ package org.jetbrains.jewel.markdown
 
 public sealed interface MarkdownBlock {
 
-    public data class BlockQuote(val content: List<MarkdownBlock>) : MarkdownBlock
-
-    public interface CustomBlock : MarkdownBlock
+    public data class BlockQuote(val children: List<MarkdownBlock>) : MarkdownBlock
 
     public sealed interface CodeBlock : MarkdownBlock {
 
@@ -20,6 +18,8 @@ public sealed interface MarkdownBlock {
         ) : CodeBlock
     }
 
+    public interface CustomBlock : MarkdownBlock
+
     public data class Heading(
         override val inlineContent: List<InlineMarkdown>,
         val level: Int,
@@ -29,25 +29,25 @@ public sealed interface MarkdownBlock {
 
     public sealed interface ListBlock : MarkdownBlock {
 
-        public val items: List<ListItem>
+        public val children: List<ListItem>
         public val isTight: Boolean
 
-        public data class BulletList(
-            override val items: List<ListItem>,
-            override val isTight: Boolean,
-            val bulletMarker: String,
-        ) : ListBlock
-
         public data class OrderedList(
-            override val items: List<ListItem>,
+            override val children: List<ListItem>,
             override val isTight: Boolean,
             val startFrom: Int,
             val delimiter: String,
         ) : ListBlock
+
+        public data class UnorderedList(
+            override val children: List<ListItem>,
+            override val isTight: Boolean,
+            val marker: String,
+        ) : ListBlock
     }
 
     public data class ListItem(
-        val content: List<MarkdownBlock>,
+        val children: List<MarkdownBlock>,
     ) : MarkdownBlock
 
     public object ThematicBreak : MarkdownBlock

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultInlineMarkdownRenderer.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultInlineMarkdownRenderer.kt
@@ -38,7 +38,7 @@ public open class DefaultInlineMarkdownRenderer(rendererExtensions: List<Markdow
                     appendInlineMarkdownFrom(child.children, styling)
                 }
 
-                is InlineMarkdown.Text -> append(child.value.literal)
+                is InlineMarkdown.Text -> append(child.nativeNode.literal)
 
                 is InlineMarkdown.Emphasis -> {
                     withStyles(styling.emphasis, child) { appendInlineMarkdownFrom(it.children, styling) }
@@ -50,13 +50,13 @@ public open class DefaultInlineMarkdownRenderer(rendererExtensions: List<Markdow
 
                 is InlineMarkdown.Link -> {
                     withStyles(styling.link, child) {
-                        pushUrlAnnotation(UrlAnnotation(it.value.destination))
+                        pushUrlAnnotation(UrlAnnotation(it.nativeNode.destination))
                         appendInlineMarkdownFrom(it.children, styling)
                     }
                 }
 
                 is InlineMarkdown.Code -> {
-                    withStyles(styling.inlineCode, child) { append(it.value.literal) }
+                    withStyles(styling.inlineCode, child) { append(it.nativeNode.literal) }
                 }
 
                 is InlineMarkdown.HardLineBreak,
@@ -65,14 +65,14 @@ public open class DefaultInlineMarkdownRenderer(rendererExtensions: List<Markdow
 
                 is InlineMarkdown.HtmlInline -> {
                     if (styling.renderInlineHtml) {
-                        withStyles(styling.inlineHtml, child) { append(it.value.literal.trim()) }
+                        withStyles(styling.inlineHtml, child) { append(it.nativeNode.literal.trim()) }
                     }
                 }
 
                 is InlineMarkdown.Image -> {
                     appendInlineContent(
                         INLINE_IMAGE,
-                        child.value.destination + "\n" + plainTextRenderer.render(child.value),
+                        child.nativeNode.destination + "\n" + plainTextRenderer.render(child.nativeNode),
                     )
                 }
 

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
@@ -59,8 +59,8 @@ import org.jetbrains.jewel.markdown.MarkdownBlock.CustomBlock
 import org.jetbrains.jewel.markdown.MarkdownBlock.Heading
 import org.jetbrains.jewel.markdown.MarkdownBlock.HtmlBlock
 import org.jetbrains.jewel.markdown.MarkdownBlock.ListBlock
-import org.jetbrains.jewel.markdown.MarkdownBlock.ListBlock.BulletList
 import org.jetbrains.jewel.markdown.MarkdownBlock.ListBlock.OrderedList
+import org.jetbrains.jewel.markdown.MarkdownBlock.ListBlock.UnorderedList
 import org.jetbrains.jewel.markdown.MarkdownBlock.ListItem
 import org.jetbrains.jewel.markdown.MarkdownBlock.Paragraph
 import org.jetbrains.jewel.markdown.MarkdownBlock.ThematicBreak
@@ -96,7 +96,7 @@ public open class DefaultMarkdownBlockRenderer(
             is Heading -> render(block, rootStyling.heading)
             is HtmlBlock -> render(block, rootStyling.htmlBlock)
             is OrderedList -> render(block, rootStyling.list.ordered)
-            is BulletList -> render(block, rootStyling.list.unordered)
+            is UnorderedList -> render(block, rootStyling.list.unordered)
             is ListItem -> render(block)
             is Paragraph -> render(block, rootStyling.paragraph)
             ThematicBreak -> renderThematicBreak(rootStyling.thematicBreak)
@@ -182,7 +182,7 @@ public open class DefaultMarkdownBlockRenderer(
             verticalArrangement = Arrangement.spacedBy(rootStyling.blockVerticalSpacing),
         ) {
             CompositionLocalProvider(LocalContentColor provides styling.textColor) {
-                render(block.content)
+                render(block.children)
             }
         }
     }
@@ -191,7 +191,7 @@ public open class DefaultMarkdownBlockRenderer(
     override fun render(block: ListBlock, styling: MarkdownStyling.List) {
         when (block) {
             is OrderedList -> render(block, styling.ordered)
-            is BulletList -> render(block, styling.unordered)
+            is UnorderedList -> render(block, styling.unordered)
         }
     }
 
@@ -208,7 +208,7 @@ public open class DefaultMarkdownBlockRenderer(
             modifier = Modifier.padding(styling.padding),
             verticalArrangement = Arrangement.spacedBy(itemSpacing),
         ) {
-            for ((index, item) in block.items.withIndex()) {
+            for ((index, item) in block.children.withIndex()) {
                 Row {
                     val number = block.startFrom + index
                     Text(
@@ -228,7 +228,7 @@ public open class DefaultMarkdownBlockRenderer(
     }
 
     @Composable
-    override fun render(block: BulletList, styling: MarkdownStyling.List.Unordered) {
+    override fun render(block: UnorderedList, styling: MarkdownStyling.List.Unordered) {
         val itemSpacing =
             if (block.isTight) {
                 styling.itemVerticalSpacingTight
@@ -240,7 +240,7 @@ public open class DefaultMarkdownBlockRenderer(
             modifier = Modifier.padding(styling.padding),
             verticalArrangement = Arrangement.spacedBy(itemSpacing),
         ) {
-            for (item in block.items) {
+            for (item in block.children) {
                 Row {
                     Text(
                         text = styling.bullet.toString(),
@@ -259,7 +259,7 @@ public open class DefaultMarkdownBlockRenderer(
     @Composable
     override fun render(block: ListItem) {
         Column(verticalArrangement = Arrangement.spacedBy(rootStyling.blockVerticalSpacing)) {
-            render(block.content)
+            render(block.children)
         }
     }
 

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer.kt
@@ -9,8 +9,8 @@ import org.jetbrains.jewel.markdown.MarkdownBlock.CodeBlock.FencedCodeBlock
 import org.jetbrains.jewel.markdown.MarkdownBlock.CodeBlock.IndentedCodeBlock
 import org.jetbrains.jewel.markdown.MarkdownBlock.HtmlBlock
 import org.jetbrains.jewel.markdown.MarkdownBlock.ListBlock
-import org.jetbrains.jewel.markdown.MarkdownBlock.ListBlock.BulletList
 import org.jetbrains.jewel.markdown.MarkdownBlock.ListBlock.OrderedList
+import org.jetbrains.jewel.markdown.MarkdownBlock.ListBlock.UnorderedList
 import org.jetbrains.jewel.markdown.MarkdownBlock.ListItem
 
 @ExperimentalJewelApi
@@ -41,7 +41,7 @@ public interface MarkdownBlockRenderer {
     public fun render(block: OrderedList, styling: MarkdownStyling.List.Ordered)
 
     @Composable
-    public fun render(block: BulletList, styling: MarkdownStyling.List.Unordered)
+    public fun render(block: UnorderedList, styling: MarkdownStyling.List.Unordered)
 
     @Composable
     public fun render(block: ListItem)

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/MarkdownStyling.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/MarkdownStyling.kt
@@ -52,7 +52,7 @@ public class MarkdownStyling(
         public val h6: H6,
     ) {
 
-        public interface HN : WithInlinesStyling, WithUnderline {
+        public sealed interface HN : WithInlinesStyling, WithUnderline {
             public val padding: PaddingValues
         }
 

--- a/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/MarkdownProcessorDocumentParsingExtraTest.kt
+++ b/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/MarkdownProcessorDocumentParsingExtraTest.kt
@@ -19,7 +19,7 @@ class MarkdownProcessorDocumentParsingExtraTest {
     }
 
     @Test
-    fun `should parse spec sample 461b correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 461b correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*_foo *bar*_*")
 
         /*
@@ -30,7 +30,7 @@ class MarkdownProcessorDocumentParsingExtraTest {
     }
 
     @Test
-    fun `should parse spec sample 461c correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 461c correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("**foo *bar***")
 
         /*
@@ -41,7 +41,7 @@ class MarkdownProcessorDocumentParsingExtraTest {
     }
 
     @Test
-    fun `should parse spec sample 461d correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 461d correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*_foo *bar* a_*")
 
         /*
@@ -52,7 +52,7 @@ class MarkdownProcessorDocumentParsingExtraTest {
     }
 
     @Test
-    fun `should parse spec sample 461e correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 461e correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("**foo *bar* a**")
 
         /*
@@ -63,7 +63,7 @@ class MarkdownProcessorDocumentParsingExtraTest {
     }
 
     @Test
-    fun `should parse spec sample 461f correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 461f correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*_*foo *bar* a*_*")
 
         /*

--- a/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/MarkdownProcessorDocumentParsingTest.kt
+++ b/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/MarkdownProcessorDocumentParsingTest.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.jewel.markdown
 
-import org.jetbrains.jewel.markdown.MarkdownBlock.ThematicBreak
 import org.jetbrains.jewel.markdown.processing.MarkdownProcessor
 import org.junit.Ignore
 import org.junit.Test
@@ -31,7 +30,7 @@ class MarkdownProcessorDocumentParsingTest {
     private val processor = MarkdownProcessor()
 
     @Test
-    fun `should parse spec sample 1 correctly (Tabs)`() {
+    fun `should parse spec sample 1 correctly {Tabs}`() {
         val parsed = processor.processMarkdownDocument("\tfoo\tbaz\t\tbim")
 
         /*
@@ -43,7 +42,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 2 correctly (Tabs)`() {
+    fun `should parse spec sample 2 correctly {Tabs}`() {
         val parsed = processor.processMarkdownDocument("  \tfoo\tbaz\t\tbim")
 
         /*
@@ -55,7 +54,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 3 correctly (Tabs)`() {
+    fun `should parse spec sample 3 correctly {Tabs}`() {
         val parsed = processor.processMarkdownDocument("    a\ta\n    ὐ\ta")
 
         /*
@@ -68,7 +67,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 4 correctly (Tabs)`() {
+    fun `should parse spec sample 4 correctly {Tabs}`() {
         val parsed = processor.processMarkdownDocument("  - foo\n\n\tbar")
 
         /*
@@ -92,7 +91,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 5 correctly (Tabs)`() {
+    fun `should parse spec sample 5 correctly {Tabs}`() {
         val parsed = processor.processMarkdownDocument("- foo\n\n\t\tbar")
 
         /*
@@ -117,7 +116,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 6 correctly (Tabs)`() {
+    fun `should parse spec sample 6 correctly {Tabs}`() {
         val parsed = processor.processMarkdownDocument(">\t\tfoo")
 
         /*
@@ -131,7 +130,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 7 correctly (Tabs)`() {
+    fun `should parse spec sample 7 correctly {Tabs}`() {
         val parsed = processor.processMarkdownDocument("-\t\tfoo")
 
         /*
@@ -147,7 +146,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 8 correctly (Tabs)`() {
+    fun `should parse spec sample 8 correctly {Tabs}`() {
         val parsed = processor.processMarkdownDocument("    foo\n\tbar")
 
         /*
@@ -160,7 +159,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 9 correctly (Tabs)`() {
+    fun `should parse spec sample 9 correctly {Tabs}`() {
         val parsed = processor.processMarkdownDocument(" - foo\n   - bar\n\t - baz")
 
         /*
@@ -193,7 +192,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 10 correctly (Tabs)`() {
+    fun `should parse spec sample 10 correctly {Tabs}`() {
         val parsed = processor.processMarkdownDocument("#\tFoo")
 
         /*
@@ -204,18 +203,18 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 11 correctly (Tabs)`() {
+    fun `should parse spec sample 11 correctly {Tabs}`() {
         val parsed = processor.processMarkdownDocument("*\t*\t*\t")
 
         /*
          * Expected HTML:
          * <hr />
          */
-        parsed.assertEquals(ThematicBreak)
+        parsed.assertEquals(thematicBreak())
     }
 
     @Test
-    fun `should parse spec sample 12 correctly (Backslash escapes)`() {
+    fun `should parse spec sample 12 correctly {Backslash escapes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 "\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\n",
@@ -229,7 +228,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 13 correctly (Backslash escapes)`() {
+    fun `should parse spec sample 13 correctly {Backslash escapes}`() {
         val parsed = processor.processMarkdownDocument("\\\t\\A\\a\\ \\3\\φ\\«")
 
         /*
@@ -240,7 +239,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 14 correctly (Backslash escapes)`() {
+    fun `should parse spec sample 14 correctly {Backslash escapes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -285,7 +284,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 15 correctly (Backslash escapes)`() {
+    fun `should parse spec sample 15 correctly {Backslash escapes}`() {
         val parsed = processor.processMarkdownDocument("\\\\*emphasis*")
 
         /*
@@ -296,7 +295,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 16 correctly (Backslash escapes)`() {
+    fun `should parse spec sample 16 correctly {Backslash escapes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -315,7 +314,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 17 correctly (Backslash escapes)`() {
+    fun `should parse spec sample 17 correctly {Backslash escapes}`() {
         val parsed = processor.processMarkdownDocument("`` \\[\\` ``")
 
         /*
@@ -326,7 +325,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 18 correctly (Backslash escapes)`() {
+    fun `should parse spec sample 18 correctly {Backslash escapes}`() {
         val parsed = processor.processMarkdownDocument("    \\[\\]")
 
         /*
@@ -338,7 +337,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 19 correctly (Backslash escapes)`() {
+    fun `should parse spec sample 19 correctly {Backslash escapes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -358,7 +357,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 20 correctly (Backslash escapes)`() {
+    fun `should parse spec sample 20 correctly {Backslash escapes}`() {
         val parsed = processor.processMarkdownDocument("<https://example.com?find=\\*>")
 
         /*
@@ -369,7 +368,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 21 correctly (Backslash escapes)`() {
+    fun `should parse spec sample 21 correctly {Backslash escapes}`() {
         val parsed = processor.processMarkdownDocument("<a href=\"/bar\\/)\">")
 
         /*
@@ -380,7 +379,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 22 correctly (Backslash escapes)`() {
+    fun `should parse spec sample 22 correctly {Backslash escapes}`() {
         val parsed = processor.processMarkdownDocument("[foo](/bar\\* \"ti\\*tle\")")
 
         /*
@@ -391,7 +390,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 23 correctly (Backslash escapes)`() {
+    fun `should parse spec sample 23 correctly {Backslash escapes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -410,7 +409,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 24 correctly (Backslash escapes)`() {
+    fun `should parse spec sample 24 correctly {Backslash escapes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -430,7 +429,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 25 correctly (Entity and numeric character references)`() {
+    fun `should parse spec sample 25 correctly {Entity and numeric character references}`() {
         @Suppress("CheckDtdRefs") // Malformed on purpose
         val parsed =
             processor.processMarkdownDocument(
@@ -452,7 +451,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 26 correctly (Entity and numeric character references)`() {
+    fun `should parse spec sample 26 correctly {Entity and numeric character references}`() {
         val parsed = processor.processMarkdownDocument("&#35; &#1234; &#992; &#0;")
 
         /*
@@ -463,7 +462,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 27 correctly (Entity and numeric character references)`() {
+    fun `should parse spec sample 27 correctly {Entity and numeric character references}`() {
         val parsed = processor.processMarkdownDocument("&#X22; &#XD06; &#xcab;")
 
         /*
@@ -475,7 +474,7 @@ class MarkdownProcessorDocumentParsingTest {
 
     @Suppress("CheckDtdRefs")
     @Test
-    fun `should parse spec sample 28 correctly (Entity and numeric character references)`() {
+    fun `should parse spec sample 28 correctly {Entity and numeric character references}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -500,7 +499,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 29 correctly (Entity and numeric character references)`() {
+    fun `should parse spec sample 29 correctly {Entity and numeric character references}`() {
         val parsed = processor.processMarkdownDocument("&copy")
 
         /*
@@ -512,7 +511,7 @@ class MarkdownProcessorDocumentParsingTest {
 
     @Suppress("CheckDtdRefs") // Malformed on purpose
     @Test
-    fun `should parse spec sample 30 correctly (Entity and numeric character references)`() {
+    fun `should parse spec sample 30 correctly {Entity and numeric character references}`() {
         val parsed = processor.processMarkdownDocument("&MadeUpEntity;")
 
         /*
@@ -523,7 +522,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 31 correctly (Entity and numeric character references)`() {
+    fun `should parse spec sample 31 correctly {Entity and numeric character references}`() {
         val parsed = processor.processMarkdownDocument("<a href=\"&ouml;&ouml;.html\">")
 
         /*
@@ -534,7 +533,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 32 correctly (Entity and numeric character references)`() {
+    fun `should parse spec sample 32 correctly {Entity and numeric character references}`() {
         val parsed = processor.processMarkdownDocument("[foo](/f&ouml;&ouml; \"f&ouml;&ouml;\")")
 
         /*
@@ -545,7 +544,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 33 correctly (Entity and numeric character references)`() {
+    fun `should parse spec sample 33 correctly {Entity and numeric character references}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -565,7 +564,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 34 correctly (Entity and numeric character references)`() {
+    fun `should parse spec sample 34 correctly {Entity and numeric character references}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -585,7 +584,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 35 correctly (Entity and numeric character references)`() {
+    fun `should parse spec sample 35 correctly {Entity and numeric character references}`() {
         val parsed = processor.processMarkdownDocument("`f&ouml;&ouml;`")
 
         /*
@@ -596,7 +595,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 36 correctly (Entity and numeric character references)`() {
+    fun `should parse spec sample 36 correctly {Entity and numeric character references}`() {
         val parsed = processor.processMarkdownDocument("    f&ouml;f&ouml;")
 
         /*
@@ -608,7 +607,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 37 correctly (Entity and numeric character references)`() {
+    fun `should parse spec sample 37 correctly {Entity and numeric character references}`() {
         val parsed = processor.processMarkdownDocument("&#42;foo&#42;\n*foo*")
 
         /*
@@ -620,7 +619,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 38 correctly (Entity and numeric character references)`() {
+    fun `should parse spec sample 38 correctly {Entity and numeric character references}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -640,12 +639,12 @@ class MarkdownProcessorDocumentParsingTest {
          */
         parsed.assertEquals(
             paragraph("\\* foo"),
-            unorderedList(listItem(paragraph("foo")), bulletMarker = "*"),
+            unorderedList(listItem(paragraph("foo")), marker = "*"),
         )
     }
 
     @Test
-    fun `should parse spec sample 39 correctly (Entity and numeric character references)`() {
+    fun `should parse spec sample 39 correctly {Entity and numeric character references}`() {
         val parsed = processor.processMarkdownDocument("foo&#10;&#10;bar")
 
         /*
@@ -658,7 +657,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 40 correctly (Entity and numeric character references)`() {
+    fun `should parse spec sample 40 correctly {Entity and numeric character references}`() {
         val parsed = processor.processMarkdownDocument("&#9;foo")
 
         /*
@@ -669,7 +668,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 41 correctly (Entity and numeric character references)`() {
+    fun `should parse spec sample 41 correctly {Entity and numeric character references}`() {
         val parsed = processor.processMarkdownDocument("[a](url &quot;tit&quot;)")
 
         /*
@@ -680,7 +679,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 42 correctly (Precedence)`() {
+    fun `should parse spec sample 42 correctly {Precedence}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -706,7 +705,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 43 correctly (Thematic breaks)`() {
+    fun `should parse spec sample 43 correctly {Thematic breaks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -724,14 +723,14 @@ class MarkdownProcessorDocumentParsingTest {
          * <hr />
          */
         parsed.assertEquals(
-            ThematicBreak,
-            ThematicBreak,
-            ThematicBreak,
+            thematicBreak(),
+            thematicBreak(),
+            thematicBreak(),
         )
     }
 
     @Test
-    fun `should parse spec sample 44 correctly (Thematic breaks)`() {
+    fun `should parse spec sample 44 correctly {Thematic breaks}`() {
         val parsed = processor.processMarkdownDocument("+++")
 
         /*
@@ -742,7 +741,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 45 correctly (Thematic breaks)`() {
+    fun `should parse spec sample 45 correctly {Thematic breaks}`() {
         val parsed = processor.processMarkdownDocument("===")
 
         /*
@@ -753,7 +752,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 46 correctly (Thematic breaks)`() {
+    fun `should parse spec sample 46 correctly {Thematic breaks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -774,7 +773,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 47 correctly (Thematic breaks)`() {
+    fun `should parse spec sample 47 correctly {Thematic breaks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -792,14 +791,14 @@ class MarkdownProcessorDocumentParsingTest {
          * <hr />
          */
         parsed.assertEquals(
-            ThematicBreak,
-            ThematicBreak,
-            ThematicBreak,
+            thematicBreak(),
+            thematicBreak(),
+            thematicBreak(),
         )
     }
 
     @Test
-    fun `should parse spec sample 48 correctly (Thematic breaks)`() {
+    fun `should parse spec sample 48 correctly {Thematic breaks}`() {
         val parsed = processor.processMarkdownDocument("    ***")
 
         /*
@@ -811,7 +810,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 49 correctly (Thematic breaks)`() {
+    fun `should parse spec sample 49 correctly {Thematic breaks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -830,62 +829,62 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 50 correctly (Thematic breaks)`() {
+    fun `should parse spec sample 50 correctly {Thematic breaks}`() {
         val parsed = processor.processMarkdownDocument("_____________________________________")
 
         /*
          * Expected HTML:
          * <hr />
          */
-        parsed.assertEquals(ThematicBreak)
+        parsed.assertEquals(thematicBreak())
     }
 
     @Test
-    fun `should parse spec sample 51 correctly (Thematic breaks)`() {
+    fun `should parse spec sample 51 correctly {Thematic breaks}`() {
         val parsed = processor.processMarkdownDocument(" - - -")
 
         /*
          * Expected HTML:
          * <hr />
          */
-        parsed.assertEquals(ThematicBreak)
+        parsed.assertEquals(thematicBreak())
     }
 
     @Test
-    fun `should parse spec sample 52 correctly (Thematic breaks)`() {
+    fun `should parse spec sample 52 correctly {Thematic breaks}`() {
         val parsed = processor.processMarkdownDocument(" **  * ** * ** * **")
 
         /*
          * Expected HTML:
          * <hr />
          */
-        parsed.assertEquals(ThematicBreak)
+        parsed.assertEquals(thematicBreak())
     }
 
     @Test
-    fun `should parse spec sample 53 correctly (Thematic breaks)`() {
+    fun `should parse spec sample 53 correctly {Thematic breaks}`() {
         val parsed = processor.processMarkdownDocument("-     -      -      -")
 
         /*
          * Expected HTML:
          * <hr />
          */
-        parsed.assertEquals(ThematicBreak)
+        parsed.assertEquals(thematicBreak())
     }
 
     @Test
-    fun `should parse spec sample 54 correctly (Thematic breaks)`() {
+    fun `should parse spec sample 54 correctly {Thematic breaks}`() {
         val parsed = processor.processMarkdownDocument("- - - -    ")
 
         /*
          * Expected HTML:
          * <hr />
          */
-        parsed.assertEquals(ThematicBreak)
+        parsed.assertEquals(thematicBreak())
     }
 
     @Test
-    fun `should parse spec sample 55 correctly (Thematic breaks)`() {
+    fun `should parse spec sample 55 correctly {Thematic breaks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -912,7 +911,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 56 correctly (Thematic breaks)`() {
+    fun `should parse spec sample 56 correctly {Thematic breaks}`() {
         val parsed = processor.processMarkdownDocument(" *-*")
 
         /*
@@ -923,7 +922,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 57 correctly (Thematic breaks)`() {
+    fun `should parse spec sample 57 correctly {Thematic breaks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -946,13 +945,13 @@ class MarkdownProcessorDocumentParsingTest {
          */
         parsed.assertEquals(
             unorderedList(listItem(paragraph("foo"))),
-            ThematicBreak,
+            thematicBreak(),
             unorderedList(listItem(paragraph("bar"))),
         )
     }
 
     @Test
-    fun `should parse spec sample 58 correctly (Thematic breaks)`() {
+    fun `should parse spec sample 58 correctly {Thematic breaks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -971,13 +970,13 @@ class MarkdownProcessorDocumentParsingTest {
          */
         parsed.assertEquals(
             paragraph("Foo"),
-            ThematicBreak,
+            thematicBreak(),
             paragraph("bar"),
         )
     }
 
     @Test
-    fun `should parse spec sample 59 correctly (Thematic breaks)`() {
+    fun `should parse spec sample 59 correctly {Thematic breaks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1000,7 +999,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 60 correctly (Thematic breaks)`() {
+    fun `should parse spec sample 60 correctly {Thematic breaks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1022,14 +1021,14 @@ class MarkdownProcessorDocumentParsingTest {
          * </ul>
          */
         parsed.assertEquals(
-            unorderedList(listItem(paragraph("Foo")), bulletMarker = "*"),
-            ThematicBreak,
-            unorderedList(listItem(paragraph("Bar")), bulletMarker = "*"),
+            unorderedList(listItem(paragraph("Foo")), marker = "*"),
+            thematicBreak(),
+            unorderedList(listItem(paragraph("Bar")), marker = "*"),
         )
     }
 
     @Test
-    fun `should parse spec sample 61 correctly (Thematic breaks)`() {
+    fun `should parse spec sample 61 correctly {Thematic breaks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1051,13 +1050,13 @@ class MarkdownProcessorDocumentParsingTest {
         parsed.assertEquals(
             unorderedList(
                 listItem(paragraph("Foo")),
-                listItem(ThematicBreak),
+                listItem(thematicBreak()),
             ),
         )
     }
 
     @Test
-    fun `should parse spec sample 62 correctly (ATX headings)`() {
+    fun `should parse spec sample 62 correctly {ATX headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1091,7 +1090,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 63 correctly (ATX headings)`() {
+    fun `should parse spec sample 63 correctly {ATX headings}`() {
         val parsed = processor.processMarkdownDocument("####### foo")
 
         /*
@@ -1102,7 +1101,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 64 correctly (ATX headings)`() {
+    fun `should parse spec sample 64 correctly {ATX headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1125,7 +1124,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 65 correctly (ATX headings)`() {
+    fun `should parse spec sample 65 correctly {ATX headings}`() {
         val parsed = processor.processMarkdownDocument("\\## foo")
 
         /*
@@ -1136,7 +1135,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 66 correctly (ATX headings)`() {
+    fun `should parse spec sample 66 correctly {ATX headings}`() {
         val parsed = processor.processMarkdownDocument("# foo *bar* \\*baz\\*")
 
         /*
@@ -1149,7 +1148,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 67 correctly (ATX headings)`() {
+    fun `should parse spec sample 67 correctly {ATX headings}`() {
         val parsed = processor.processMarkdownDocument("#                  foo                     ")
 
         /*
@@ -1160,7 +1159,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 68 correctly (ATX headings)`() {
+    fun `should parse spec sample 68 correctly {ATX headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1185,7 +1184,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 69 correctly (ATX headings)`() {
+    fun `should parse spec sample 69 correctly {ATX headings}`() {
         val parsed = processor.processMarkdownDocument("    # foo")
 
         /*
@@ -1197,7 +1196,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 70 correctly (ATX headings)`() {
+    fun `should parse spec sample 70 correctly {ATX headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1216,7 +1215,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 71 correctly (ATX headings)`() {
+    fun `should parse spec sample 71 correctly {ATX headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1238,7 +1237,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 72 correctly (ATX headings)`() {
+    fun `should parse spec sample 72 correctly {ATX headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1260,7 +1259,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 73 correctly (ATX headings)`() {
+    fun `should parse spec sample 73 correctly {ATX headings}`() {
         val parsed = processor.processMarkdownDocument("### foo ###     ")
 
         /*
@@ -1271,7 +1270,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 74 correctly (ATX headings)`() {
+    fun `should parse spec sample 74 correctly {ATX headings}`() {
         val parsed = processor.processMarkdownDocument("### foo ### b")
 
         /*
@@ -1282,7 +1281,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 75 correctly (ATX headings)`() {
+    fun `should parse spec sample 75 correctly {ATX headings}`() {
         val parsed = processor.processMarkdownDocument("# foo#")
 
         /*
@@ -1293,7 +1292,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 76 correctly (ATX headings)`() {
+    fun `should parse spec sample 76 correctly {ATX headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1318,7 +1317,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 77 correctly (ATX headings)`() {
+    fun `should parse spec sample 77 correctly {ATX headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1336,14 +1335,14 @@ class MarkdownProcessorDocumentParsingTest {
          * <hr />
          */
         parsed.assertEquals(
-            ThematicBreak,
+            thematicBreak(),
             heading(level = 2, "foo"),
-            ThematicBreak,
+            thematicBreak(),
         )
     }
 
     @Test
-    fun `should parse spec sample 78 correctly (ATX headings)`() {
+    fun `should parse spec sample 78 correctly {ATX headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1368,7 +1367,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 79 correctly (ATX headings)`() {
+    fun `should parse spec sample 79 correctly {ATX headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1393,7 +1392,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 80 correctly (Setext headings)`() {
+    fun `should parse spec sample 80 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1419,7 +1418,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 81 correctly (Setext headings)`() {
+    fun `should parse spec sample 81 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1439,7 +1438,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 82 correctly (Setext headings)`() {
+    fun `should parse spec sample 82 correctly {Setext headings}`() {
         val parsed = processor.processMarkdownDocument("  Foo *bar\nbaz*\t\n====")
 
         /*
@@ -1451,7 +1450,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 83 correctly (Setext headings)`() {
+    fun `should parse spec sample 83 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1476,7 +1475,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 84 correctly (Setext headings)`() {
+    fun `should parse spec sample 84 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1506,7 +1505,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 85 correctly (Setext headings)`() {
+    fun `should parse spec sample 85 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1530,12 +1529,12 @@ class MarkdownProcessorDocumentParsingTest {
          */
         parsed.assertEquals(
             indentedCodeBlock("Foo\n---\n\nFoo"),
-            ThematicBreak,
+            thematicBreak(),
         )
     }
 
     @Test
-    fun `should parse spec sample 86 correctly (Setext headings)`() {
+    fun `should parse spec sample 86 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1553,7 +1552,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 87 correctly (Setext headings)`() {
+    fun `should parse spec sample 87 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1572,7 +1571,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 88 correctly (Setext headings)`() {
+    fun `should parse spec sample 88 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1595,12 +1594,12 @@ class MarkdownProcessorDocumentParsingTest {
         parsed.assertEquals(
             paragraph("Foo = ="),
             paragraph("Foo"),
-            ThematicBreak,
+            thematicBreak(),
         )
     }
 
     @Test
-    fun `should parse spec sample 89 correctly (Setext headings)`() {
+    fun `should parse spec sample 89 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1618,7 +1617,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 90 correctly (Setext headings)`() {
+    fun `should parse spec sample 90 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1636,7 +1635,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 91 correctly (Setext headings)`() {
+    fun `should parse spec sample 91 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1667,7 +1666,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 92 correctly (Setext headings)`() {
+    fun `should parse spec sample 92 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1686,12 +1685,12 @@ class MarkdownProcessorDocumentParsingTest {
          */
         parsed.assertEquals(
             blockQuote(paragraph("Foo")),
-            ThematicBreak,
+            thematicBreak(),
         )
     }
 
     @Test
-    fun `should parse spec sample 93 correctly (Setext headings)`() {
+    fun `should parse spec sample 93 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1714,7 +1713,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 94 correctly (Setext headings)`() {
+    fun `should parse spec sample 94 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1733,12 +1732,12 @@ class MarkdownProcessorDocumentParsingTest {
          */
         parsed.assertEquals(
             unorderedList(listItem(paragraph("Foo"))),
-            ThematicBreak,
+            thematicBreak(),
         )
     }
 
     @Test
-    fun `should parse spec sample 95 correctly (Setext headings)`() {
+    fun `should parse spec sample 95 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1758,7 +1757,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 96 correctly (Setext headings)`() {
+    fun `should parse spec sample 96 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1780,7 +1779,7 @@ class MarkdownProcessorDocumentParsingTest {
          * <p>Baz</p>
          */
         parsed.assertEquals(
-            ThematicBreak,
+            thematicBreak(),
             heading(level = 2, "Foo"),
             heading(level = 2, "Bar"),
             paragraph("Baz"),
@@ -1788,7 +1787,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 97 correctly (Setext headings)`() {
+    fun `should parse spec sample 97 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1806,7 +1805,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 98 correctly (Setext headings)`() {
+    fun `should parse spec sample 98 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1822,13 +1821,13 @@ class MarkdownProcessorDocumentParsingTest {
          * <hr />
          */
         parsed.assertEquals(
-            ThematicBreak,
-            ThematicBreak,
+            thematicBreak(),
+            thematicBreak(),
         )
     }
 
     @Test
-    fun `should parse spec sample 99 correctly (Setext headings)`() {
+    fun `should parse spec sample 99 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1847,12 +1846,12 @@ class MarkdownProcessorDocumentParsingTest {
          */
         parsed.assertEquals(
             unorderedList(listItem(paragraph("foo"))),
-            ThematicBreak,
+            thematicBreak(),
         )
     }
 
     @Test
-    fun `should parse spec sample 100 correctly (Setext headings)`() {
+    fun `should parse spec sample 100 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1870,12 +1869,12 @@ class MarkdownProcessorDocumentParsingTest {
          */
         parsed.assertEquals(
             indentedCodeBlock("foo"),
-            ThematicBreak,
+            thematicBreak(),
         )
     }
 
     @Test
-    fun `should parse spec sample 101 correctly (Setext headings)`() {
+    fun `should parse spec sample 101 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1894,12 +1893,12 @@ class MarkdownProcessorDocumentParsingTest {
          */
         parsed.assertEquals(
             blockQuote(paragraph("foo")),
-            ThematicBreak,
+            thematicBreak(),
         )
     }
 
     @Test
-    fun `should parse spec sample 102 correctly (Setext headings)`() {
+    fun `should parse spec sample 102 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1917,7 +1916,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 103 correctly (Setext headings)`() {
+    fun `should parse spec sample 103 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1944,7 +1943,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 104 correctly (Setext headings)`() {
+    fun `should parse spec sample 104 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1967,13 +1966,13 @@ class MarkdownProcessorDocumentParsingTest {
          */
         parsed.assertEquals(
             paragraph("Foo bar"),
-            ThematicBreak,
+            thematicBreak(),
             paragraph("baz"),
         )
     }
 
     @Test
-    fun `should parse spec sample 105 correctly (Setext headings)`() {
+    fun `should parse spec sample 105 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -1994,13 +1993,13 @@ class MarkdownProcessorDocumentParsingTest {
          */
         parsed.assertEquals(
             paragraph("Foo bar"),
-            ThematicBreak,
+            thematicBreak(),
             paragraph("baz"),
         )
     }
 
     @Test
-    fun `should parse spec sample 106 correctly (Setext headings)`() {
+    fun `should parse spec sample 106 correctly {Setext headings}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2023,7 +2022,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 107 correctly (Indented code blocks)`() {
+    fun `should parse spec sample 107 correctly {Indented code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2043,7 +2042,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 108 correctly (Indented code blocks)`() {
+    fun `should parse spec sample 108 correctly {Indented code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2072,7 +2071,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 109 correctly (Indented code blocks)`() {
+    fun `should parse spec sample 109 correctly {Indented code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2106,7 +2105,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 110 correctly (Indented code blocks)`() {
+    fun `should parse spec sample 110 correctly {Indented code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2130,7 +2129,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 111 correctly (Indented code blocks)`() {
+    fun `should parse spec sample 111 correctly {Indented code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2160,7 +2159,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 112 correctly (Indented code blocks)`() {
+    fun `should parse spec sample 112 correctly {Indented code blocks}`() {
         val parsed = processor.processMarkdownDocument("    chunk1\n      \n      chunk2")
 
         /*
@@ -2174,7 +2173,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 113 correctly (Indented code blocks)`() {
+    fun `should parse spec sample 113 correctly {Indented code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2193,7 +2192,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 114 correctly (Indented code blocks)`() {
+    fun `should parse spec sample 114 correctly {Indented code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2216,7 +2215,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 115 correctly (Indented code blocks)`() {
+    fun `should parse spec sample 115 correctly {Indented code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2245,12 +2244,12 @@ class MarkdownProcessorDocumentParsingTest {
             indentedCodeBlock("foo"),
             heading(level = 2, "Heading"),
             indentedCodeBlock("foo"),
-            ThematicBreak,
+            thematicBreak(),
         )
     }
 
     @Test
-    fun `should parse spec sample 116 correctly (Indented code blocks)`() {
+    fun `should parse spec sample 116 correctly {Indented code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2270,7 +2269,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 117 correctly (Indented code blocks)`() {
+    fun `should parse spec sample 117 correctly {Indented code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2291,7 +2290,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 118 correctly (Indented code blocks)`() {
+    fun `should parse spec sample 118 correctly {Indented code blocks}`() {
         val parsed = processor.processMarkdownDocument("    foo  ")
 
         /*
@@ -2303,7 +2302,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 119 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 119 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2325,7 +2324,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 120 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 120 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2347,7 +2346,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 121 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 121 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2366,7 +2365,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 122 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 122 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2388,7 +2387,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 123 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 123 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2410,7 +2409,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 124 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 124 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2432,7 +2431,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 125 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 125 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2454,7 +2453,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 126 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 126 correctly {Fenced code blocks}`() {
         val parsed = processor.processMarkdownDocument("```")
 
         /*
@@ -2465,7 +2464,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 127 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 127 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2488,7 +2487,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 128 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 128 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2515,7 +2514,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 129 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 129 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2537,7 +2536,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 130 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 130 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2555,7 +2554,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 131 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 131 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2577,7 +2576,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 132 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 132 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2601,7 +2600,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 133 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 133 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2625,7 +2624,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 134 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 134 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2647,7 +2646,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 135 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 135 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2667,7 +2666,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 136 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 136 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2687,7 +2686,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 137 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 137 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2708,7 +2707,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 138 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 138 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2727,7 +2726,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 139 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 139 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2748,7 +2747,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 140 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 140 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2776,7 +2775,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 141 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 141 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2805,7 +2804,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 142 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 142 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2834,7 +2833,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 143 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 143 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2863,7 +2862,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 144 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 144 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2886,7 +2885,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 145 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 145 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2905,7 +2904,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 146 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 146 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2930,7 +2929,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 147 correctly (Fenced code blocks)`() {
+    fun `should parse spec sample 147 correctly {Fenced code blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2950,7 +2949,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 148 correctly (HTML blocks)`() {
+    fun `should parse spec sample 148 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -2982,7 +2981,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 149 correctly (HTML blocks)`() {
+    fun `should parse spec sample 149 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3028,7 +3027,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 150 correctly (HTML blocks)`() {
+    fun `should parse spec sample 150 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3049,7 +3048,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 151 correctly (HTML blocks)`() {
+    fun `should parse spec sample 151 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3068,7 +3067,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 152 correctly (HTML blocks)`() {
+    fun `should parse spec sample 152 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3095,7 +3094,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 153 correctly (HTML blocks)`() {
+    fun `should parse spec sample 153 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3125,7 +3124,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 154 correctly (HTML blocks)`() {
+    fun `should parse spec sample 154 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3155,7 +3154,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 155 correctly (HTML blocks)`() {
+    fun `should parse spec sample 155 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3180,7 +3179,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 156 correctly (HTML blocks)`() {
+    fun `should parse spec sample 156 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3199,7 +3198,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 157 correctly (HTML blocks)`() {
+    fun `should parse spec sample 157 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3218,7 +3217,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 158 correctly (HTML blocks)`() {
+    fun `should parse spec sample 158 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3237,7 +3236,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 159 correctly (HTML blocks)`() {
+    fun `should parse spec sample 159 correctly {HTML blocks}`() {
         val parsed = processor.processMarkdownDocument("<div><a href=\"bar\">*foo*</a></div>")
 
         /*
@@ -3248,7 +3247,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 160 correctly (HTML blocks)`() {
+    fun `should parse spec sample 160 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3278,7 +3277,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 161 correctly (HTML blocks)`() {
+    fun `should parse spec sample 161 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3311,7 +3310,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 162 correctly (HTML blocks)`() {
+    fun `should parse spec sample 162 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3341,7 +3340,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 163 correctly (HTML blocks)`() {
+    fun `should parse spec sample 163 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3371,7 +3370,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 164 correctly (HTML blocks)`() {
+    fun `should parse spec sample 164 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3401,7 +3400,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 165 correctly (HTML blocks)`() {
+    fun `should parse spec sample 165 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3428,7 +3427,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 166 correctly (HTML blocks)`() {
+    fun `should parse spec sample 166 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3458,7 +3457,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 167 correctly (HTML blocks)`() {
+    fun `should parse spec sample 167 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3485,7 +3484,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 168 correctly (HTML blocks)`() {
+    fun `should parse spec sample 168 correctly {HTML blocks}`() {
         val parsed = processor.processMarkdownDocument("<del>*foo*</del>")
 
         /*
@@ -3496,7 +3495,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 169 correctly (HTML blocks)`() {
+    fun `should parse spec sample 169 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3538,7 +3537,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 170 correctly (HTML blocks)`() {
+    fun `should parse spec sample 170 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3577,7 +3576,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 171 correctly (HTML blocks)`() {
+    fun `should parse spec sample 171 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3619,7 +3618,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 172 correctly (HTML blocks)`() {
+    fun `should parse spec sample 172 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3661,7 +3660,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 173 correctly (HTML blocks)`() {
+    fun `should parse spec sample 173 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3694,7 +3693,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 174 correctly (HTML blocks)`() {
+    fun `should parse spec sample 174 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3721,7 +3720,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 175 correctly (HTML blocks)`() {
+    fun `should parse spec sample 175 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3749,7 +3748,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 176 correctly (HTML blocks)`() {
+    fun `should parse spec sample 176 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3771,7 +3770,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 177 correctly (HTML blocks)`() {
+    fun `should parse spec sample 177 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3793,7 +3792,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 178 correctly (HTML blocks)`() {
+    fun `should parse spec sample 178 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3823,7 +3822,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 179 correctly (HTML blocks)`() {
+    fun `should parse spec sample 179 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3859,7 +3858,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 180 correctly (HTML blocks)`() {
+    fun `should parse spec sample 180 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3898,7 +3897,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 181 correctly (HTML blocks)`() {
+    fun `should parse spec sample 181 correctly {HTML blocks}`() {
         val parsed = processor.processMarkdownDocument("<!DOCTYPE html>")
 
         /*
@@ -3909,7 +3908,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 182 correctly (HTML blocks)`() {
+    fun `should parse spec sample 182 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3969,7 +3968,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 183 correctly (HTML blocks)`() {
+    fun `should parse spec sample 183 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -3993,7 +3992,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 184 correctly (HTML blocks)`() {
+    fun `should parse spec sample 184 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4017,7 +4016,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 185 correctly (HTML blocks)`() {
+    fun `should parse spec sample 185 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4050,7 +4049,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 186 correctly (HTML blocks)`() {
+    fun `should parse spec sample 186 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4083,7 +4082,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 187 correctly (HTML blocks)`() {
+    fun `should parse spec sample 187 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4104,7 +4103,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 188 correctly (HTML blocks)`() {
+    fun `should parse spec sample 188 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4131,7 +4130,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 189 correctly (HTML blocks)`() {
+    fun `should parse spec sample 189 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4161,7 +4160,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 190 correctly (HTML blocks)`() {
+    fun `should parse spec sample 190 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4200,7 +4199,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 191 correctly (HTML blocks)`() {
+    fun `should parse spec sample 191 correctly {HTML blocks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4240,7 +4239,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 192 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 192 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4259,7 +4258,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 193 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 193 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4280,7 +4279,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 194 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 194 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4299,7 +4298,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 195 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 195 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4320,7 +4319,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 196 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 196 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4347,7 +4346,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 197 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 197 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4374,7 +4373,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 198 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 198 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4394,7 +4393,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 199 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 199 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4417,7 +4416,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 200 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 200 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4436,7 +4435,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 201 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 201 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4459,7 +4458,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 202 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 202 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4478,7 +4477,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 203 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 203 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4497,7 +4496,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 204 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 204 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4517,7 +4516,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 205 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 205 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4536,7 +4535,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 206 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 206 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4555,7 +4554,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 207 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 207 correctly {Link reference definitions}`() {
         val parsed = processor.processMarkdownDocument("[foo]: /url")
 
         /*
@@ -4566,7 +4565,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 208 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 208 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4586,7 +4585,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 209 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 209 correctly {Link reference definitions}`() {
         val parsed = processor.processMarkdownDocument("[foo]: /url \"title\" ok")
 
         /*
@@ -4597,7 +4596,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 210 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 210 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4615,7 +4614,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 211 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 211 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4639,7 +4638,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 212 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 212 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4665,7 +4664,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 213 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 213 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4690,7 +4689,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 214 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 214 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4715,7 +4714,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 215 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 215 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4739,7 +4738,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 216 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 216 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4759,7 +4758,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 217 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 217 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4787,7 +4786,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 218 correctly (Link reference definitions)`() {
+    fun `should parse spec sample 218 correctly {Link reference definitions}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4811,7 +4810,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 219 correctly (Paragraphs)`() {
+    fun `should parse spec sample 219 correctly {Paragraphs}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4834,7 +4833,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 220 correctly (Paragraphs)`() {
+    fun `should parse spec sample 220 correctly {Paragraphs}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4861,7 +4860,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 221 correctly (Paragraphs)`() {
+    fun `should parse spec sample 221 correctly {Paragraphs}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4885,7 +4884,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 222 correctly (Paragraphs)`() {
+    fun `should parse spec sample 222 correctly {Paragraphs}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4904,7 +4903,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 223 correctly (Paragraphs)`() {
+    fun `should parse spec sample 223 correctly {Paragraphs}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4925,7 +4924,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 224 correctly (Paragraphs)`() {
+    fun `should parse spec sample 224 correctly {Paragraphs}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4944,7 +4943,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 225 correctly (Paragraphs)`() {
+    fun `should parse spec sample 225 correctly {Paragraphs}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4967,7 +4966,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 226 correctly (Paragraphs)`() {
+    fun `should parse spec sample 226 correctly {Paragraphs}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -4986,7 +4985,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 227 correctly (Blank lines)`() {
+    fun `should parse spec sample 227 correctly {Blank lines}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5014,7 +5013,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 228 correctly (Block quotes)`() {
+    fun `should parse spec sample 228 correctly {Block quotes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5042,7 +5041,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 229 correctly (Block quotes)`() {
+    fun `should parse spec sample 229 correctly {Block quotes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5070,7 +5069,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 230 correctly (Block quotes)`() {
+    fun `should parse spec sample 230 correctly {Block quotes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5098,7 +5097,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 231 correctly (Block quotes)`() {
+    fun `should parse spec sample 231 correctly {Block quotes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5120,7 +5119,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 232 correctly (Block quotes)`() {
+    fun `should parse spec sample 232 correctly {Block quotes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5148,7 +5147,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 233 correctly (Block quotes)`() {
+    fun `should parse spec sample 233 correctly {Block quotes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5171,7 +5170,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 234 correctly (Block quotes)`() {
+    fun `should parse spec sample 234 correctly {Block quotes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5190,12 +5189,12 @@ class MarkdownProcessorDocumentParsingTest {
          */
         parsed.assertEquals(
             blockQuote(paragraph("foo")),
-            ThematicBreak,
+            thematicBreak(),
         )
     }
 
     @Test
-    fun `should parse spec sample 235 correctly (Block quotes)`() {
+    fun `should parse spec sample 235 correctly {Block quotes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5223,7 +5222,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 236 correctly (Block quotes)`() {
+    fun `should parse spec sample 236 correctly {Block quotes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5249,7 +5248,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 237 correctly (Block quotes)`() {
+    fun `should parse spec sample 237 correctly {Block quotes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5276,7 +5275,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 238 correctly (Block quotes)`() {
+    fun `should parse spec sample 238 correctly {Block quotes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5297,7 +5296,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 239 correctly (Block quotes)`() {
+    fun `should parse spec sample 239 correctly {Block quotes}`() {
         val parsed = processor.processMarkdownDocument(">")
 
         /*
@@ -5309,7 +5308,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 240 correctly (Block quotes)`() {
+    fun `should parse spec sample 240 correctly {Block quotes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5329,7 +5328,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 241 correctly (Block quotes)`() {
+    fun `should parse spec sample 241 correctly {Block quotes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5350,7 +5349,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 242 correctly (Block quotes)`() {
+    fun `should parse spec sample 242 correctly {Block quotes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5377,7 +5376,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 243 correctly (Block quotes)`() {
+    fun `should parse spec sample 243 correctly {Block quotes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5398,7 +5397,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 244 correctly (Block quotes)`() {
+    fun `should parse spec sample 244 correctly {Block quotes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5425,7 +5424,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 245 correctly (Block quotes)`() {
+    fun `should parse spec sample 245 correctly {Block quotes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5449,7 +5448,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 246 correctly (Block quotes)`() {
+    fun `should parse spec sample 246 correctly {Block quotes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5472,13 +5471,13 @@ class MarkdownProcessorDocumentParsingTest {
          */
         parsed.assertEquals(
             blockQuote(paragraph("aaa")),
-            ThematicBreak,
+            thematicBreak(),
             blockQuote(paragraph("bbb")),
         )
     }
 
     @Test
-    fun `should parse spec sample 247 correctly (Block quotes)`() {
+    fun `should parse spec sample 247 correctly {Block quotes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5499,7 +5498,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 248 correctly (Block quotes)`() {
+    fun `should parse spec sample 248 correctly {Block quotes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5524,7 +5523,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 249 correctly (Block quotes)`() {
+    fun `should parse spec sample 249 correctly {Block quotes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5549,7 +5548,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 250 correctly (Block quotes)`() {
+    fun `should parse spec sample 250 correctly {Block quotes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5580,7 +5579,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 251 correctly (Block quotes)`() {
+    fun `should parse spec sample 251 correctly {Block quotes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5613,7 +5612,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 252 correctly (Block quotes)`() {
+    fun `should parse spec sample 252 correctly {Block quotes}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5641,7 +5640,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 253 correctly (List items)`() {
+    fun `should parse spec sample 253 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5673,7 +5672,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 254 correctly (List items)`() {
+    fun `should parse spec sample 254 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5714,7 +5713,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 255 correctly (List items)`() {
+    fun `should parse spec sample 255 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5739,7 +5738,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 256 correctly (List items)`() {
+    fun `should parse spec sample 256 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5768,7 +5767,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 257 correctly (List items)`() {
+    fun `should parse spec sample 257 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5794,7 +5793,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 258 correctly (List items)`() {
+    fun `should parse spec sample 258 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5823,7 +5822,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 259 correctly (List items)`() {
+    fun `should parse spec sample 259 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5860,7 +5859,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 260 correctly (List items)`() {
+    fun `should parse spec sample 260 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5893,7 +5892,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 261 correctly (List items)`() {
+    fun `should parse spec sample 261 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5916,7 +5915,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 262 correctly (List items)`() {
+    fun `should parse spec sample 262 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5949,7 +5948,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 263 correctly (List items)`() {
+    fun `should parse spec sample 263 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -5994,7 +5993,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 264 correctly (List items)`() {
+    fun `should parse spec sample 264 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6030,7 +6029,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 265 correctly (List items)`() {
+    fun `should parse spec sample 265 correctly {List items}`() {
         val parsed = processor.processMarkdownDocument("123456789. ok")
 
         /*
@@ -6043,7 +6042,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 266 correctly (List items)`() {
+    fun `should parse spec sample 266 correctly {List items}`() {
         val parsed = processor.processMarkdownDocument("1234567890. not ok")
 
         /*
@@ -6054,7 +6053,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 267 correctly (List items)`() {
+    fun `should parse spec sample 267 correctly {List items}`() {
         val parsed = processor.processMarkdownDocument("0. ok")
 
         /*
@@ -6067,7 +6066,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 268 correctly (List items)`() {
+    fun `should parse spec sample 268 correctly {List items}`() {
         val parsed = processor.processMarkdownDocument("003. ok")
 
         /*
@@ -6080,7 +6079,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 269 correctly (List items)`() {
+    fun `should parse spec sample 269 correctly {List items}`() {
         val parsed = processor.processMarkdownDocument("-1. not ok")
 
         /*
@@ -6091,7 +6090,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 270 correctly (List items)`() {
+    fun `should parse spec sample 270 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6121,7 +6120,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 271 correctly (List items)`() {
+    fun `should parse spec sample 271 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6152,7 +6151,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 272 correctly (List items)`() {
+    fun `should parse spec sample 272 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6181,7 +6180,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 273 correctly (List items)`() {
+    fun `should parse spec sample 273 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6219,7 +6218,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 274 correctly (List items)`() {
+    fun `should parse spec sample 274 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6257,7 +6256,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 275 correctly (List items)`() {
+    fun `should parse spec sample 275 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6280,7 +6279,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 276 correctly (List items)`() {
+    fun `should parse spec sample 276 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6305,7 +6304,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 277 correctly (List items)`() {
+    fun `should parse spec sample 277 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6334,7 +6333,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 278 correctly (List items)`() {
+    fun `should parse spec sample 278 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6374,7 +6373,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 279 correctly (List items)`() {
+    fun `should parse spec sample 279 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6394,7 +6393,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 280 correctly (List items)`() {
+    fun `should parse spec sample 280 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6419,7 +6418,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 281 correctly (List items)`() {
+    fun `should parse spec sample 281 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6448,7 +6447,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 282 correctly (List items)`() {
+    fun `should parse spec sample 282 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6477,7 +6476,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 283 correctly (List items)`() {
+    fun `should parse spec sample 283 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6506,7 +6505,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 284 correctly (List items)`() {
+    fun `should parse spec sample 284 correctly {List items}`() {
         val parsed = processor.processMarkdownDocument("*")
 
         /*
@@ -6515,11 +6514,11 @@ class MarkdownProcessorDocumentParsingTest {
          * <li></li>
          * </ul>
          */
-        parsed.assertEquals(unorderedList(listItem(), bulletMarker = "*"))
+        parsed.assertEquals(unorderedList(listItem(), marker = "*"))
     }
 
     @Test
-    fun `should parse spec sample 285 correctly (List items)`() {
+    fun `should parse spec sample 285 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6546,7 +6545,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 286 correctly (List items)`() {
+    fun `should parse spec sample 286 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6587,7 +6586,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 287 correctly (List items)`() {
+    fun `should parse spec sample 287 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6628,7 +6627,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 288 correctly (List items)`() {
+    fun `should parse spec sample 288 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6669,7 +6668,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 289 correctly (List items)`() {
+    fun `should parse spec sample 289 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6709,7 +6708,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 290 correctly (List items)`() {
+    fun `should parse spec sample 290 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6750,7 +6749,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 291 correctly (List items)`() {
+    fun `should parse spec sample 291 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6775,7 +6774,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 292 correctly (List items)`() {
+    fun `should parse spec sample 292 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6806,7 +6805,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 293 correctly (List items)`() {
+    fun `should parse spec sample 293 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6837,7 +6836,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 294 correctly (List items)`() {
+    fun `should parse spec sample 294 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6888,7 +6887,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 295 correctly (List items)`() {
+    fun `should parse spec sample 295 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6920,7 +6919,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 296 correctly (List items)`() {
+    fun `should parse spec sample 296 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6953,7 +6952,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 297 correctly (List items)`() {
+    fun `should parse spec sample 297 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -6983,7 +6982,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 298 correctly (List items)`() {
+    fun `should parse spec sample 298 correctly {List items}`() {
         val parsed = processor.processMarkdownDocument("- - foo")
 
         /*
@@ -7006,7 +7005,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 299 correctly (List items)`() {
+    fun `should parse spec sample 299 correctly {List items}`() {
         val parsed = processor.processMarkdownDocument("1. - 2. foo")
 
         /*
@@ -7040,7 +7039,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 300 correctly (List items)`() {
+    fun `should parse spec sample 300 correctly {List items}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7072,7 +7071,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 301 correctly (Lists)`() {
+    fun `should parse spec sample 301 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7100,13 +7099,13 @@ class MarkdownProcessorDocumentParsingTest {
             ),
             unorderedList(
                 listItem(paragraph("baz")),
-                bulletMarker = "+",
+                marker = "+",
             ),
         )
     }
 
     @Test
-    fun `should parse spec sample 302 correctly (Lists)`() {
+    fun `should parse spec sample 302 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7141,7 +7140,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 303 correctly (Lists)`() {
+    fun `should parse spec sample 303 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7170,7 +7169,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 304 correctly (Lists)`() {
+    fun `should parse spec sample 304 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7191,7 +7190,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 305 correctly (Lists)`() {
+    fun `should parse spec sample 305 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7215,7 +7214,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 306 correctly (Lists)`() {
+    fun `should parse spec sample 306 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7254,7 +7253,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 307 correctly (Lists)`() {
+    fun `should parse spec sample 307 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7307,7 +7306,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 308 correctly (Lists)`() {
+    fun `should parse spec sample 308 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7348,7 +7347,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 309 correctly (Lists)`() {
+    fun `should parse spec sample 309 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7392,7 +7391,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 310 correctly (Lists)`() {
+    fun `should parse spec sample 310 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7433,7 +7432,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 311 correctly (Lists)`() {
+    fun `should parse spec sample 311 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7471,7 +7470,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 312 correctly (Lists)`() {
+    fun `should parse spec sample 312 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7505,7 +7504,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 313 correctly (Lists)`() {
+    fun `should parse spec sample 313 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7542,7 +7541,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 314 correctly (Lists)`() {
+    fun `should parse spec sample 314 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7579,7 +7578,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 315 correctly (Lists)`() {
+    fun `should parse spec sample 315 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7609,13 +7608,13 @@ class MarkdownProcessorDocumentParsingTest {
                 listItem(),
                 listItem(paragraph("c")),
                 isTight = false,
-                bulletMarker = "*",
+                marker = "*",
             ),
         )
     }
 
     @Test
-    fun `should parse spec sample 316 correctly (Lists)`() {
+    fun `should parse spec sample 316 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7654,7 +7653,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 317 correctly (Lists)`() {
+    fun `should parse spec sample 317 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7692,7 +7691,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 318 correctly (Lists)`() {
+    fun `should parse spec sample 318 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7730,7 +7729,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 319 correctly (Lists)`() {
+    fun `should parse spec sample 319 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7775,7 +7774,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 320 correctly (Lists)`() {
+    fun `should parse spec sample 320 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7802,13 +7801,13 @@ class MarkdownProcessorDocumentParsingTest {
             unorderedList(
                 listItem(paragraph("a"), blockQuote(paragraph("b"))),
                 listItem(paragraph("c")),
-                bulletMarker = "*",
+                marker = "*",
             ),
         )
     }
 
     @Test
-    fun `should parse spec sample 321 correctly (Lists)`() {
+    fun `should parse spec sample 321 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7848,7 +7847,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 322 correctly (Lists)`() {
+    fun `should parse spec sample 322 correctly {Lists}`() {
         val parsed = processor.processMarkdownDocument("- a")
 
         /*
@@ -7861,7 +7860,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 323 correctly (Lists)`() {
+    fun `should parse spec sample 323 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7892,7 +7891,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 324 correctly (Lists)`() {
+    fun `should parse spec sample 324 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7927,7 +7926,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 325 correctly (Lists)`() {
+    fun `should parse spec sample 325 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -7957,18 +7956,18 @@ class MarkdownProcessorDocumentParsingTest {
                     paragraph("foo"),
                     unorderedList(
                         listItem(paragraph("bar")),
-                        bulletMarker = "*",
+                        marker = "*",
                     ),
                     paragraph("baz"),
                 ),
-                bulletMarker = "*",
+                marker = "*",
                 isTight = false,
             ),
         )
     }
 
     @Test
-    fun `should parse spec sample 326 correctly (Lists)`() {
+    fun `should parse spec sample 326 correctly {Lists}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -8024,7 +8023,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 327 correctly (Inlines)`() {
+    fun `should parse spec sample 327 correctly {Inlines}`() {
         val parsed = processor.processMarkdownDocument("`hi`lo`")
 
         /*
@@ -8035,7 +8034,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 328 correctly (Code spans)`() {
+    fun `should parse spec sample 328 correctly {Code spans}`() {
         val parsed = processor.processMarkdownDocument("`foo`")
 
         /*
@@ -8046,7 +8045,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 329 correctly (Code spans)`() {
+    fun `should parse spec sample 329 correctly {Code spans}`() {
         val parsed = processor.processMarkdownDocument("`` foo ` bar ``")
 
         /*
@@ -8057,7 +8056,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 330 correctly (Code spans)`() {
+    fun `should parse spec sample 330 correctly {Code spans}`() {
         val parsed = processor.processMarkdownDocument("` `` `")
 
         /*
@@ -8068,7 +8067,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 331 correctly (Code spans)`() {
+    fun `should parse spec sample 331 correctly {Code spans}`() {
         val parsed = processor.processMarkdownDocument("`  ``  `")
 
         /*
@@ -8079,7 +8078,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 332 correctly (Code spans)`() {
+    fun `should parse spec sample 332 correctly {Code spans}`() {
         val parsed = processor.processMarkdownDocument("` a`")
 
         /*
@@ -8090,7 +8089,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 333 correctly (Code spans)`() {
+    fun `should parse spec sample 333 correctly {Code spans}`() {
         val parsed = processor.processMarkdownDocument("` b `")
 
         /*
@@ -8101,7 +8100,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 334 correctly (Code spans)`() {
+    fun `should parse spec sample 334 correctly {Code spans}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -8120,7 +8119,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 335 correctly (Code spans)`() {
+    fun `should parse spec sample 335 correctly {Code spans}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -8141,7 +8140,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 336 correctly (Code spans)`() {
+    fun `should parse spec sample 336 correctly {Code spans}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -8160,7 +8159,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 337 correctly (Code spans)`() {
+    fun `should parse spec sample 337 correctly {Code spans}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -8178,7 +8177,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 338 correctly (Code spans)`() {
+    fun `should parse spec sample 338 correctly {Code spans}`() {
         val parsed = processor.processMarkdownDocument("`foo\\`bar`")
 
         /*
@@ -8189,7 +8188,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 339 correctly (Code spans)`() {
+    fun `should parse spec sample 339 correctly {Code spans}`() {
         val parsed = processor.processMarkdownDocument("``foo`bar``")
 
         /*
@@ -8200,7 +8199,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 340 correctly (Code spans)`() {
+    fun `should parse spec sample 340 correctly {Code spans}`() {
         val parsed = processor.processMarkdownDocument("` foo `` bar `")
 
         /*
@@ -8211,7 +8210,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 341 correctly (Code spans)`() {
+    fun `should parse spec sample 341 correctly {Code spans}`() {
         val parsed = processor.processMarkdownDocument("*foo`*`")
 
         /*
@@ -8222,7 +8221,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 342 correctly (Code spans)`() {
+    fun `should parse spec sample 342 correctly {Code spans}`() {
         val parsed = processor.processMarkdownDocument("[not a `link](/foo`)")
 
         /*
@@ -8233,7 +8232,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 343 correctly (Code spans)`() {
+    fun `should parse spec sample 343 correctly {Code spans}`() {
         val parsed = processor.processMarkdownDocument("`<a href=\"`\">`")
 
         /*
@@ -8244,7 +8243,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 344 correctly (Code spans)`() {
+    fun `should parse spec sample 344 correctly {Code spans}`() {
         val parsed = processor.processMarkdownDocument("<a href=\"`\">`")
 
         /*
@@ -8255,7 +8254,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 345 correctly (Code spans)`() {
+    fun `should parse spec sample 345 correctly {Code spans}`() {
         val parsed = processor.processMarkdownDocument("`<https://foo.bar.`baz>`")
 
         /*
@@ -8266,7 +8265,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 346 correctly (Code spans)`() {
+    fun `should parse spec sample 346 correctly {Code spans}`() {
         val parsed = processor.processMarkdownDocument("<https://foo.bar.`baz>`")
 
         /*
@@ -8277,7 +8276,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 347 correctly (Code spans)`() {
+    fun `should parse spec sample 347 correctly {Code spans}`() {
         val parsed = processor.processMarkdownDocument("```foo``")
 
         /*
@@ -8288,7 +8287,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 348 correctly (Code spans)`() {
+    fun `should parse spec sample 348 correctly {Code spans}`() {
         val parsed = processor.processMarkdownDocument("`foo")
 
         /*
@@ -8299,7 +8298,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 349 correctly (Code spans)`() {
+    fun `should parse spec sample 349 correctly {Code spans}`() {
         val parsed = processor.processMarkdownDocument("`foo``bar``")
 
         /*
@@ -8310,7 +8309,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 350 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 350 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*foo bar*")
 
         /*
@@ -8321,7 +8320,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 351 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 351 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("a * foo bar*")
 
         /*
@@ -8332,7 +8331,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 352 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 352 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("a*\"foo\"*")
 
         /*
@@ -8343,7 +8342,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 353 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 353 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("* a *")
 
         /*
@@ -8354,7 +8353,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 354 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 354 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument(
             """
             |*$*alpha.
@@ -8375,7 +8374,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 355 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 355 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("foo*bar*")
 
         /*
@@ -8386,7 +8385,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 356 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 356 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("5*6*78")
 
         /*
@@ -8397,7 +8396,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 357 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 357 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("_foo bar_")
 
         /*
@@ -8408,7 +8407,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 358 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 358 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("_ foo bar_")
 
         /*
@@ -8419,7 +8418,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 359 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 359 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("a_\"foo\"_")
 
         /*
@@ -8430,7 +8429,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 360 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 360 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("foo_bar_")
 
         /*
@@ -8441,7 +8440,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 361 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 361 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("5_6_78")
 
         /*
@@ -8452,7 +8451,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 362 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 362 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("пристаням_стремятся_")
 
         /*
@@ -8463,7 +8462,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 363 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 363 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("aa_\"bb\"_cc")
 
         /*
@@ -8474,7 +8473,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 364 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 364 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("foo-_(bar)_")
 
         /*
@@ -8485,7 +8484,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 365 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 365 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("_foo*")
 
         /*
@@ -8496,7 +8495,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 366 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 366 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*foo bar *")
 
         /*
@@ -8507,7 +8506,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 367 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 367 correctly {Emphasis and strong emphasis}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -8526,7 +8525,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 368 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 368 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*(*foo)")
 
         /*
@@ -8537,7 +8536,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 369 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 369 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*(*foo*)*")
 
         /*
@@ -8548,7 +8547,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 370 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 370 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*foo*bar")
 
         /*
@@ -8559,7 +8558,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 371 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 371 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("_foo bar _")
 
         /*
@@ -8570,7 +8569,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 372 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 372 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("_(_foo)")
 
         /*
@@ -8581,7 +8580,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 373 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 373 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("_(_foo_)_")
 
         /*
@@ -8592,7 +8591,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 374 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 374 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("_foo_bar")
 
         /*
@@ -8603,7 +8602,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 375 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 375 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("_пристаням_стремятся")
 
         /*
@@ -8614,7 +8613,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 376 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 376 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("_foo_bar_baz_")
 
         /*
@@ -8625,7 +8624,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 377 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 377 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("_(bar)_.")
 
         /*
@@ -8636,7 +8635,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 378 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 378 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("**foo bar**")
 
         /*
@@ -8647,7 +8646,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 379 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 379 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("** foo bar**")
 
         /*
@@ -8658,7 +8657,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 380 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 380 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("a**\"foo\"**")
 
         /*
@@ -8669,7 +8668,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 381 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 381 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("foo**bar**")
 
         /*
@@ -8680,7 +8679,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 382 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 382 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("__foo bar__")
 
         /*
@@ -8691,7 +8690,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 383 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 383 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("__ foo bar__")
 
         /*
@@ -8702,7 +8701,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 384 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 384 correctly {Emphasis and strong emphasis}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -8721,7 +8720,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 385 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 385 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("a__\"foo\"__")
 
         /*
@@ -8732,7 +8731,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 386 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 386 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("foo__bar__")
 
         /*
@@ -8743,7 +8742,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 387 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 387 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("5__6__78")
 
         /*
@@ -8754,7 +8753,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 388 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 388 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("пристаням__стремятся__")
 
         /*
@@ -8765,7 +8764,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 389 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 389 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("__foo, __bar__, baz__")
 
         /*
@@ -8776,7 +8775,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 390 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 390 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("foo-__(bar)__")
 
         /*
@@ -8787,7 +8786,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 391 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 391 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("**foo bar **")
 
         /*
@@ -8798,7 +8797,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 392 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 392 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("**(**foo)")
 
         /*
@@ -8809,7 +8808,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 393 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 393 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*(**foo**)*")
 
         /*
@@ -8820,7 +8819,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 394 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 394 correctly {Emphasis and strong emphasis}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -8843,7 +8842,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 395 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 395 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("**foo \"*bar*\" foo**")
 
         /*
@@ -8854,7 +8853,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 396 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 396 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("**foo**bar")
 
         /*
@@ -8865,7 +8864,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 397 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 397 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("__foo bar __")
 
         /*
@@ -8876,7 +8875,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 398 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 398 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("__(__foo)")
 
         /*
@@ -8887,7 +8886,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 399 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 399 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("_(__foo__)_")
 
         /*
@@ -8898,7 +8897,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 400 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 400 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("__foo__bar")
 
         /*
@@ -8909,7 +8908,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 401 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 401 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("__пристаням__стремятся")
 
         /*
@@ -8920,7 +8919,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 402 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 402 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("__foo__bar__baz__")
 
         /*
@@ -8931,7 +8930,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 403 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 403 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("__(bar)__.")
 
         /*
@@ -8942,7 +8941,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 404 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 404 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*foo [bar](/url)*")
 
         /*
@@ -8953,7 +8952,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 405 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 405 correctly {Emphasis and strong emphasis}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -8972,7 +8971,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 406 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 406 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("_foo __bar__ baz_")
 
         /*
@@ -8983,7 +8982,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 407 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 407 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("_foo _bar_ baz_")
 
         /*
@@ -8994,7 +8993,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 408 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 408 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("__foo_ bar_")
 
         /*
@@ -9005,7 +9004,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 409 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 409 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*foo *bar**")
 
         /*
@@ -9016,7 +9015,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 410 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 410 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*foo **bar** baz*")
 
         /*
@@ -9027,7 +9026,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 411 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 411 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*foo**bar**baz*")
 
         /*
@@ -9038,7 +9037,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 412 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 412 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*foo**bar*")
 
         /*
@@ -9049,7 +9048,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 413 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 413 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("***foo** bar*")
 
         /*
@@ -9060,7 +9059,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 414 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 414 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*foo **bar***")
 
         /*
@@ -9071,7 +9070,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 415 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 415 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*foo**bar***")
 
         /*
@@ -9082,7 +9081,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 416 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 416 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("foo***bar***baz")
 
         /*
@@ -9093,7 +9092,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 417 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 417 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("foo******bar*********baz")
 
         /*
@@ -9104,7 +9103,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 418 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 418 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*foo **bar *baz* bim** bop*")
 
         /*
@@ -9115,7 +9114,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 419 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 419 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*foo [*bar*](/url)*")
 
         /*
@@ -9126,7 +9125,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 420 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 420 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("** is not an empty emphasis")
 
         /*
@@ -9137,7 +9136,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 421 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 421 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("**** is not an empty strong emphasis")
 
         /*
@@ -9148,7 +9147,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 422 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 422 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("**foo [bar](/url)**")
 
         /*
@@ -9159,7 +9158,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 423 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 423 correctly {Emphasis and strong emphasis}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -9178,7 +9177,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 424 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 424 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("__foo _bar_ baz__")
 
         /*
@@ -9189,7 +9188,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 425 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 425 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("__foo __bar__ baz__")
 
         /*
@@ -9200,7 +9199,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 426 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 426 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("____foo__ bar__")
 
         /*
@@ -9211,7 +9210,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 427 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 427 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("**foo **bar****")
 
         /*
@@ -9222,7 +9221,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 428 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 428 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("**foo *bar* baz**")
 
         /*
@@ -9233,7 +9232,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 429 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 429 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("**foo*bar*baz**")
 
         /*
@@ -9244,7 +9243,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 430 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 430 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("***foo* bar**")
 
         /*
@@ -9255,7 +9254,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 431 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 431 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("**foo *bar***")
 
         /*
@@ -9266,7 +9265,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 432 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 432 correctly {Emphasis and strong emphasis}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -9285,7 +9284,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 433 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 433 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("**foo [*bar*](/url)**")
 
         /*
@@ -9296,7 +9295,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 434 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 434 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("__ is not an empty emphasis")
 
         /*
@@ -9307,7 +9306,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 435 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 435 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("____ is not an empty strong emphasis")
 
         /*
@@ -9318,7 +9317,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 436 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 436 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("foo ***")
 
         /*
@@ -9329,7 +9328,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 437 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 437 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("foo *\\**")
 
         /*
@@ -9340,7 +9339,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 438 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 438 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("foo *_*")
 
         /*
@@ -9351,7 +9350,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 439 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 439 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("foo *****")
 
         /*
@@ -9362,7 +9361,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 440 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 440 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("foo **\\***")
 
         /*
@@ -9373,7 +9372,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 441 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 441 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("foo **_**")
 
         /*
@@ -9384,7 +9383,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 442 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 442 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("**foo*")
 
         /*
@@ -9395,7 +9394,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 443 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 443 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*foo**")
 
         /*
@@ -9406,7 +9405,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 444 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 444 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("***foo**")
 
         /*
@@ -9417,7 +9416,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 445 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 445 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("****foo*")
 
         /*
@@ -9428,7 +9427,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 446 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 446 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("**foo***")
 
         /*
@@ -9439,7 +9438,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 447 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 447 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*foo****")
 
         /*
@@ -9450,7 +9449,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 448 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 448 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("foo ___")
 
         /*
@@ -9461,7 +9460,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 449 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 449 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("foo _\\__")
 
         /*
@@ -9472,7 +9471,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 450 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 450 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("foo _*_")
 
         /*
@@ -9483,7 +9482,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 451 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 451 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("foo _____")
 
         /*
@@ -9494,7 +9493,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 452 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 452 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("foo __\\___")
 
         /*
@@ -9505,7 +9504,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 453 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 453 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("foo __*__")
 
         /*
@@ -9516,7 +9515,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 454 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 454 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("__foo_")
 
         /*
@@ -9527,7 +9526,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 455 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 455 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("_foo__")
 
         /*
@@ -9538,7 +9537,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 456 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 456 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("___foo__")
 
         /*
@@ -9549,7 +9548,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 457 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 457 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("____foo_")
 
         /*
@@ -9560,7 +9559,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 458 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 458 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("__foo___")
 
         /*
@@ -9571,7 +9570,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 459 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 459 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("_foo____")
 
         /*
@@ -9582,7 +9581,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 460 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 460 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("**foo**")
 
         /*
@@ -9593,7 +9592,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 461 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 461 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*_foo_*")
 
         /*
@@ -9604,7 +9603,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 462 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 462 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("__foo__")
 
         /*
@@ -9615,7 +9614,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 463 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 463 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("_*foo*_")
 
         /*
@@ -9626,7 +9625,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 462+1b correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 462+1b correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("_*foo _bar_*_")
 
         /*
@@ -9637,7 +9636,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 462+1c correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 462+1c correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("__foo _bar___")
 
         /*
@@ -9648,7 +9647,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 462+1d correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 462+1d correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("_*foo _bar_ a*_")
 
         /*
@@ -9659,7 +9658,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 462+1e correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 462+1e correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("__foo _bar_ a__")
 
         /*
@@ -9670,7 +9669,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 462+1f correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 462+1f correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("_*foo *bar* a*_")
 
         /*
@@ -9681,7 +9680,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 464 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 464 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("****foo****")
 
         /*
@@ -9692,7 +9691,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 465 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 465 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("____foo____")
 
         /*
@@ -9703,7 +9702,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 466 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 466 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("******foo******")
 
         /*
@@ -9714,7 +9713,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 467 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 467 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("***foo***")
 
         /*
@@ -9725,7 +9724,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 468 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 468 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("_____foo_____")
 
         /*
@@ -9736,7 +9735,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 469 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 469 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*foo _bar* baz_")
 
         /*
@@ -9747,7 +9746,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 470 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 470 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*foo __bar *baz bim__ bam*")
 
         /*
@@ -9758,7 +9757,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 471 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 471 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("**foo **bar baz**")
 
         /*
@@ -9769,7 +9768,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 472 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 472 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*foo *bar baz*")
 
         /*
@@ -9780,7 +9779,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 473 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 473 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*[bar*](/url)")
 
         /*
@@ -9791,7 +9790,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 474 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 474 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("_foo [bar_](/url)")
 
         /*
@@ -9802,7 +9801,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 475 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 475 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*<img src=\"foo\" title=\"*\"/>")
 
         /*
@@ -9813,7 +9812,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 476 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 476 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("**<a href=\"**\">")
 
         /*
@@ -9824,7 +9823,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 477 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 477 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("__<a href=\"__\">")
 
         /*
@@ -9835,7 +9834,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 478 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 478 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("*a `*`*")
 
         /*
@@ -9846,7 +9845,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 479 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 479 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("_a `_`_")
 
         /*
@@ -9857,7 +9856,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 480 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 480 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("**a<https://foo.bar/?q=**>")
 
         /*
@@ -9868,7 +9867,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 481 correctly (Emphasis and strong emphasis)`() {
+    fun `should parse spec sample 481 correctly {Emphasis and strong emphasis}`() {
         val parsed = processor.processMarkdownDocument("__a<https://foo.bar/?q=__>")
 
         /*
@@ -9879,7 +9878,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 482 correctly (Links)`() {
+    fun `should parse spec sample 482 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link](/uri \"title\")")
 
         /*
@@ -9890,7 +9889,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 483 correctly (Links)`() {
+    fun `should parse spec sample 483 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link](/uri)")
 
         /*
@@ -9901,7 +9900,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 484 correctly (Links)`() {
+    fun `should parse spec sample 484 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[](./target.md)")
 
         /*
@@ -9912,7 +9911,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 485 correctly (Links)`() {
+    fun `should parse spec sample 485 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link]()")
 
         /*
@@ -9923,7 +9922,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 486 correctly (Links)`() {
+    fun `should parse spec sample 486 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link](<>)")
 
         /*
@@ -9934,7 +9933,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 487 correctly (Links)`() {
+    fun `should parse spec sample 487 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[]()")
 
         /*
@@ -9945,7 +9944,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 488 correctly (Links)`() {
+    fun `should parse spec sample 488 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link](/my uri)")
 
         /*
@@ -9956,7 +9955,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 489 correctly (Links)`() {
+    fun `should parse spec sample 489 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link](</my uri>)")
 
         /*
@@ -9967,7 +9966,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 490 correctly (Links)`() {
+    fun `should parse spec sample 490 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -9986,7 +9985,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 491 correctly (Links)`() {
+    fun `should parse spec sample 491 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10005,7 +10004,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 492 correctly (Links)`() {
+    fun `should parse spec sample 492 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[a](<b)c>)")
 
         /*
@@ -10016,7 +10015,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 493 correctly (Links)`() {
+    fun `should parse spec sample 493 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link](<foo\\>)")
 
         /*
@@ -10027,7 +10026,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 494 correctly (Links)`() {
+    fun `should parse spec sample 494 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10052,7 +10051,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 495 correctly (Links)`() {
+    fun `should parse spec sample 495 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link](\\(foo\\))")
 
         /*
@@ -10063,7 +10062,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 496 correctly (Links)`() {
+    fun `should parse spec sample 496 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link](foo(and(bar)))")
 
         /*
@@ -10074,7 +10073,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 497 correctly (Links)`() {
+    fun `should parse spec sample 497 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link](foo(and(bar))")
 
         /*
@@ -10085,7 +10084,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 498 correctly (Links)`() {
+    fun `should parse spec sample 498 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link](foo\\(and\\(bar\\))")
 
         /*
@@ -10096,7 +10095,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 499 correctly (Links)`() {
+    fun `should parse spec sample 499 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link](<foo(and(bar)>)")
 
         /*
@@ -10107,7 +10106,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 500 correctly (Links)`() {
+    fun `should parse spec sample 500 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link](foo\\)\\:)")
 
         /*
@@ -10118,7 +10117,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 501 correctly (Links)`() {
+    fun `should parse spec sample 501 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10145,7 +10144,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 502 correctly (Links)`() {
+    fun `should parse spec sample 502 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link](foo\\bar)")
 
         /*
@@ -10156,7 +10155,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 503 correctly (Links)`() {
+    fun `should parse spec sample 503 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link](foo%20b&auml;)")
 
         /*
@@ -10167,7 +10166,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 504 correctly (Links)`() {
+    fun `should parse spec sample 504 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link](\"title\")")
 
         /*
@@ -10178,7 +10177,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 505 correctly (Links)`() {
+    fun `should parse spec sample 505 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10201,7 +10200,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 506 correctly (Links)`() {
+    fun `should parse spec sample 506 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link](/url \"title \\\"&quot;\")")
 
         /*
@@ -10212,7 +10211,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 507 correctly (Links)`() {
+    fun `should parse spec sample 507 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link](/url \"title\")")
 
         /*
@@ -10223,7 +10222,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 508 correctly (Links)`() {
+    fun `should parse spec sample 508 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link](/url \"title \"and\" title\")")
 
         /*
@@ -10234,7 +10233,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 509 correctly (Links)`() {
+    fun `should parse spec sample 509 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link](/url 'title \"and\" title')")
 
         /*
@@ -10245,7 +10244,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 510 correctly (Links)`() {
+    fun `should parse spec sample 510 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10263,7 +10262,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 511 correctly (Links)`() {
+    fun `should parse spec sample 511 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link] (/uri)")
 
         /*
@@ -10274,7 +10273,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 512 correctly (Links)`() {
+    fun `should parse spec sample 512 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link [foo [bar]]](/uri)")
 
         /*
@@ -10285,7 +10284,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 513 correctly (Links)`() {
+    fun `should parse spec sample 513 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link] bar](/uri)")
 
         /*
@@ -10296,7 +10295,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 514 correctly (Links)`() {
+    fun `should parse spec sample 514 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link [bar](/uri)")
 
         /*
@@ -10307,7 +10306,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 515 correctly (Links)`() {
+    fun `should parse spec sample 515 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link \\[bar](/uri)")
 
         /*
@@ -10318,7 +10317,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 516 correctly (Links)`() {
+    fun `should parse spec sample 516 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[link *foo **bar** `#`*](/uri)")
 
         /*
@@ -10329,7 +10328,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 517 correctly (Links)`() {
+    fun `should parse spec sample 517 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[![moon](moon.jpg)](/uri)")
 
         /*
@@ -10340,7 +10339,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 518 correctly (Links)`() {
+    fun `should parse spec sample 518 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[foo [bar](/uri)](/uri)")
 
         /*
@@ -10351,7 +10350,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 519 correctly (Links)`() {
+    fun `should parse spec sample 519 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[foo *[bar [baz](/uri)](/uri)*](/uri)")
 
         /*
@@ -10363,7 +10362,7 @@ class MarkdownProcessorDocumentParsingTest {
 
     @Ignore
     @Test
-    fun `should parse spec sample 520 correctly (Links)`() {
+    fun `should parse spec sample 520 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("![[[foo](uri1)](uri2)](uri3)")
 
         /*
@@ -10374,7 +10373,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 521 correctly (Links)`() {
+    fun `should parse spec sample 521 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("*[foo*](/uri)")
 
         /*
@@ -10385,7 +10384,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 522 correctly (Links)`() {
+    fun `should parse spec sample 522 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[foo *bar](baz*)")
 
         /*
@@ -10396,7 +10395,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 523 correctly (Links)`() {
+    fun `should parse spec sample 523 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("*foo [bar* baz]")
 
         /*
@@ -10407,7 +10406,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 524 correctly (Links)`() {
+    fun `should parse spec sample 524 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[foo <bar attr=\"](baz)\">")
 
         /*
@@ -10418,7 +10417,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 525 correctly (Links)`() {
+    fun `should parse spec sample 525 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[foo`](/uri)`")
 
         /*
@@ -10429,7 +10428,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 526 correctly (Links)`() {
+    fun `should parse spec sample 526 correctly {Links}`() {
         val parsed = processor.processMarkdownDocument("[foo<https://example.com/?search=](uri)>")
 
         /*
@@ -10444,7 +10443,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 527 correctly (Links)`() {
+    fun `should parse spec sample 527 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10463,7 +10462,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 528 correctly (Links)`() {
+    fun `should parse spec sample 528 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10482,7 +10481,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 529 correctly (Links)`() {
+    fun `should parse spec sample 529 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10501,7 +10500,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 530 correctly (Links)`() {
+    fun `should parse spec sample 530 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10520,7 +10519,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 531 correctly (Links)`() {
+    fun `should parse spec sample 531 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10539,7 +10538,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 532 correctly (Links)`() {
+    fun `should parse spec sample 532 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10558,7 +10557,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 533 correctly (Links)`() {
+    fun `should parse spec sample 533 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10577,7 +10576,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 534 correctly (Links)`() {
+    fun `should parse spec sample 534 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10596,7 +10595,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 535 correctly (Links)`() {
+    fun `should parse spec sample 535 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10615,7 +10614,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 536 correctly (Links)`() {
+    fun `should parse spec sample 536 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10634,7 +10633,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 537 correctly (Links)`() {
+    fun `should parse spec sample 537 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10653,7 +10652,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 538 correctly (Links)`() {
+    fun `should parse spec sample 538 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10676,7 +10675,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 539 correctly (Links)`() {
+    fun `should parse spec sample 539 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10695,7 +10694,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 540 correctly (Links)`() {
+    fun `should parse spec sample 540 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10714,7 +10713,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 541 correctly (Links)`() {
+    fun `should parse spec sample 541 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10734,7 +10733,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 542 correctly (Links)`() {
+    fun `should parse spec sample 542 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10753,7 +10752,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 543 correctly (Links)`() {
+    fun `should parse spec sample 543 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10774,7 +10773,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 544 correctly (Links)`() {
+    fun `should parse spec sample 544 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10795,7 +10794,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 545 correctly (Links)`() {
+    fun `should parse spec sample 545 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10814,7 +10813,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 546 correctly (Links)`() {
+    fun `should parse spec sample 546 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10837,7 +10836,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 547 correctly (Links)`() {
+    fun `should parse spec sample 547 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10860,7 +10859,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 548 correctly (Links)`() {
+    fun `should parse spec sample 548 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10883,7 +10882,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 549 correctly (Links)`() {
+    fun `should parse spec sample 549 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10902,7 +10901,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 550 correctly (Links)`() {
+    fun `should parse spec sample 550 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10921,7 +10920,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 551 correctly (Links)`() {
+    fun `should parse spec sample 551 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10944,7 +10943,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 552 correctly (Links)`() {
+    fun `should parse spec sample 552 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10971,7 +10970,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 553 correctly (Links)`() {
+    fun `should parse spec sample 553 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -10990,7 +10989,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 554 correctly (Links)`() {
+    fun `should parse spec sample 554 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11009,7 +11008,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 555 correctly (Links)`() {
+    fun `should parse spec sample 555 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11028,7 +11027,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 556 correctly (Links)`() {
+    fun `should parse spec sample 556 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11049,7 +11048,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 557 correctly (Links)`() {
+    fun `should parse spec sample 557 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11068,7 +11067,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 558 correctly (Links)`() {
+    fun `should parse spec sample 558 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11087,7 +11086,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 559 correctly (Links)`() {
+    fun `should parse spec sample 559 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11106,7 +11105,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 560 correctly (Links)`() {
+    fun `should parse spec sample 560 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11125,7 +11124,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 561 correctly (Links)`() {
+    fun `should parse spec sample 561 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11144,7 +11143,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 562 correctly (Links)`() {
+    fun `should parse spec sample 562 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11163,7 +11162,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 563 correctly (Links)`() {
+    fun `should parse spec sample 563 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11182,7 +11181,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 564 correctly (Links)`() {
+    fun `should parse spec sample 564 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11201,7 +11200,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 565 correctly (Links)`() {
+    fun `should parse spec sample 565 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11221,7 +11220,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 566 correctly (Links)`() {
+    fun `should parse spec sample 566 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11240,7 +11239,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 567 correctly (Links)`() {
+    fun `should parse spec sample 567 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11259,7 +11258,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 568 correctly (Links)`() {
+    fun `should parse spec sample 568 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11278,7 +11277,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 569 correctly (Links)`() {
+    fun `should parse spec sample 569 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11297,7 +11296,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 570 correctly (Links)`() {
+    fun `should parse spec sample 570 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11317,7 +11316,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 571 correctly (Links)`() {
+    fun `should parse spec sample 571 correctly {Links}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11337,7 +11336,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 572 correctly (Images)`() {
+    fun `should parse spec sample 572 correctly {Images}`() {
         val parsed = processor.processMarkdownDocument("![foo](/url \"title\")")
 
         /*
@@ -11348,7 +11347,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 573 correctly (Images)`() {
+    fun `should parse spec sample 573 correctly {Images}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11367,7 +11366,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 574 correctly (Images)`() {
+    fun `should parse spec sample 574 correctly {Images}`() {
         val parsed = processor.processMarkdownDocument("![foo ![bar](/url)](/url2)")
 
         /*
@@ -11378,7 +11377,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 575 correctly (Images)`() {
+    fun `should parse spec sample 575 correctly {Images}`() {
         val parsed = processor.processMarkdownDocument("![foo [bar](/url)](/url2)")
 
         /*
@@ -11389,7 +11388,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 576 correctly (Images)`() {
+    fun `should parse spec sample 576 correctly {Images}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11408,7 +11407,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 577 correctly (Images)`() {
+    fun `should parse spec sample 577 correctly {Images}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11427,7 +11426,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 578 correctly (Images)`() {
+    fun `should parse spec sample 578 correctly {Images}`() {
         val parsed = processor.processMarkdownDocument("![foo](train.jpg)")
 
         /*
@@ -11438,7 +11437,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 579 correctly (Images)`() {
+    fun `should parse spec sample 579 correctly {Images}`() {
         val parsed = processor.processMarkdownDocument("My ![foo bar](/path/to/train.jpg  \"title\"   )")
 
         /*
@@ -11449,7 +11448,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 580 correctly (Images)`() {
+    fun `should parse spec sample 580 correctly {Images}`() {
         val parsed = processor.processMarkdownDocument("![foo](<url>)")
 
         /*
@@ -11460,7 +11459,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 581 correctly (Images)`() {
+    fun `should parse spec sample 581 correctly {Images}`() {
         val parsed = processor.processMarkdownDocument("![](/url)")
 
         /*
@@ -11471,7 +11470,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 582 correctly (Images)`() {
+    fun `should parse spec sample 582 correctly {Images}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11490,7 +11489,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 583 correctly (Images)`() {
+    fun `should parse spec sample 583 correctly {Images}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11509,7 +11508,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 584 correctly (Images)`() {
+    fun `should parse spec sample 584 correctly {Images}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11528,7 +11527,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 585 correctly (Images)`() {
+    fun `should parse spec sample 585 correctly {Images}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11547,7 +11546,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 586 correctly (Images)`() {
+    fun `should parse spec sample 586 correctly {Images}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11566,7 +11565,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 587 correctly (Images)`() {
+    fun `should parse spec sample 587 correctly {Images}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11587,7 +11586,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 588 correctly (Images)`() {
+    fun `should parse spec sample 588 correctly {Images}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11606,7 +11605,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 589 correctly (Images)`() {
+    fun `should parse spec sample 589 correctly {Images}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11625,7 +11624,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 590 correctly (Images)`() {
+    fun `should parse spec sample 590 correctly {Images}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11648,7 +11647,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 591 correctly (Images)`() {
+    fun `should parse spec sample 591 correctly {Images}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11667,7 +11666,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 592 correctly (Images)`() {
+    fun `should parse spec sample 592 correctly {Images}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11686,7 +11685,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 593 correctly (Images)`() {
+    fun `should parse spec sample 593 correctly {Images}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11705,7 +11704,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 594 correctly (Autolinks)`() {
+    fun `should parse spec sample 594 correctly {Autolinks}`() {
         val parsed = processor.processMarkdownDocument("<http://foo.bar.baz>")
 
         /*
@@ -11716,7 +11715,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 595 correctly (Autolinks)`() {
+    fun `should parse spec sample 595 correctly {Autolinks}`() {
         val parsed = processor.processMarkdownDocument("<https://foo.bar.baz/test?q=hello&id=22&boolean>")
 
         /*
@@ -11731,7 +11730,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 596 correctly (Autolinks)`() {
+    fun `should parse spec sample 596 correctly {Autolinks}`() {
         val parsed = processor.processMarkdownDocument("<irc://foo.bar:2233/baz>")
 
         /*
@@ -11742,7 +11741,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 597 correctly (Autolinks)`() {
+    fun `should parse spec sample 597 correctly {Autolinks}`() {
         val parsed = processor.processMarkdownDocument("<MAILTO:FOO@BAR.BAZ>")
 
         /*
@@ -11753,7 +11752,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 598 correctly (Autolinks)`() {
+    fun `should parse spec sample 598 correctly {Autolinks}`() {
         val parsed = processor.processMarkdownDocument("<a+b+c:d>")
 
         /*
@@ -11764,7 +11763,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 599 correctly (Autolinks)`() {
+    fun `should parse spec sample 599 correctly {Autolinks}`() {
         val parsed = processor.processMarkdownDocument("<made-up-scheme://foo,bar>")
 
         /*
@@ -11775,7 +11774,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 600 correctly (Autolinks)`() {
+    fun `should parse spec sample 600 correctly {Autolinks}`() {
         val parsed = processor.processMarkdownDocument("<https://../>")
 
         /*
@@ -11786,7 +11785,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 601 correctly (Autolinks)`() {
+    fun `should parse spec sample 601 correctly {Autolinks}`() {
         val parsed = processor.processMarkdownDocument("<localhost:5001/foo>")
 
         /*
@@ -11797,7 +11796,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 602 correctly (Autolinks)`() {
+    fun `should parse spec sample 602 correctly {Autolinks}`() {
         val parsed = processor.processMarkdownDocument("<https://foo.bar/baz bim>")
 
         /*
@@ -11809,7 +11808,7 @@ class MarkdownProcessorDocumentParsingTest {
 
     @Ignore
     @Test
-    fun `should parse spec sample 603 correctly (Autolinks)`() {
+    fun `should parse spec sample 603 correctly {Autolinks}`() {
         val parsed = processor.processMarkdownDocument("<https://example.com/\\[\\>")
 
         /*
@@ -11820,7 +11819,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 604 correctly (Autolinks)`() {
+    fun `should parse spec sample 604 correctly {Autolinks}`() {
         val parsed = processor.processMarkdownDocument("<foo@bar.example.com>")
 
         /*
@@ -11831,7 +11830,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 605 correctly (Autolinks)`() {
+    fun `should parse spec sample 605 correctly {Autolinks}`() {
         val parsed = processor.processMarkdownDocument("<foo+special@Bar.baz-bar0.com>")
 
         /*
@@ -11846,7 +11845,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 606 correctly (Autolinks)`() {
+    fun `should parse spec sample 606 correctly {Autolinks}`() {
         val parsed = processor.processMarkdownDocument("<foo\\+@bar.example.com>")
 
         /*
@@ -11857,7 +11856,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 607 correctly (Autolinks)`() {
+    fun `should parse spec sample 607 correctly {Autolinks}`() {
         val parsed = processor.processMarkdownDocument("<>")
 
         /*
@@ -11868,7 +11867,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 608 correctly (Autolinks)`() {
+    fun `should parse spec sample 608 correctly {Autolinks}`() {
         val parsed = processor.processMarkdownDocument("< https://foo.bar >")
 
         /*
@@ -11879,7 +11878,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 609 correctly (Autolinks)`() {
+    fun `should parse spec sample 609 correctly {Autolinks}`() {
         val parsed = processor.processMarkdownDocument("<m:abc>")
 
         /*
@@ -11890,7 +11889,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 610 correctly (Autolinks)`() {
+    fun `should parse spec sample 610 correctly {Autolinks}`() {
         val parsed = processor.processMarkdownDocument("<foo.bar.baz>")
 
         /*
@@ -11901,7 +11900,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 611 correctly (Autolinks)`() {
+    fun `should parse spec sample 611 correctly {Autolinks}`() {
         val parsed = processor.processMarkdownDocument("https://example.com")
 
         /*
@@ -11912,7 +11911,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 612 correctly (Autolinks)`() {
+    fun `should parse spec sample 612 correctly {Autolinks}`() {
         val parsed = processor.processMarkdownDocument("foo@bar.example.com")
 
         /*
@@ -11923,7 +11922,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 613 correctly (Raw HTML)`() {
+    fun `should parse spec sample 613 correctly {Raw HTML}`() {
         val parsed = processor.processMarkdownDocument("<a><bab><c2c>")
 
         /*
@@ -11934,7 +11933,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 614 correctly (Raw HTML)`() {
+    fun `should parse spec sample 614 correctly {Raw HTML}`() {
         val parsed = processor.processMarkdownDocument("<a/><b2/>")
 
         /*
@@ -11945,7 +11944,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 615 correctly (Raw HTML)`() {
+    fun `should parse spec sample 615 correctly {Raw HTML}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11964,7 +11963,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 616 correctly (Raw HTML)`() {
+    fun `should parse spec sample 616 correctly {Raw HTML}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -11987,7 +11986,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 617 correctly (Raw HTML)`() {
+    fun `should parse spec sample 617 correctly {Raw HTML}`() {
         val parsed = processor.processMarkdownDocument("Foo <responsive-image src=\"foo.jpg\" />")
 
         /*
@@ -11998,7 +11997,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 618 correctly (Raw HTML)`() {
+    fun `should parse spec sample 618 correctly {Raw HTML}`() {
         val parsed = processor.processMarkdownDocument("<33> <__>")
 
         /*
@@ -12009,7 +12008,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 619 correctly (Raw HTML)`() {
+    fun `should parse spec sample 619 correctly {Raw HTML}`() {
         val parsed = processor.processMarkdownDocument("<a h*#ref=\"hi\">")
 
         /*
@@ -12020,7 +12019,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 620 correctly (Raw HTML)`() {
+    fun `should parse spec sample 620 correctly {Raw HTML}`() {
         val parsed = processor.processMarkdownDocument("<a href=\"hi'> <a href=hi'>")
 
         /*
@@ -12031,7 +12030,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 621 correctly (Raw HTML)`() {
+    fun `should parse spec sample 621 correctly {Raw HTML}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -12058,7 +12057,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 622 correctly (Raw HTML)`() {
+    fun `should parse spec sample 622 correctly {Raw HTML}`() {
         val parsed = processor.processMarkdownDocument("<a href='bar'title=title>")
 
         /*
@@ -12069,7 +12068,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 623 correctly (Raw HTML)`() {
+    fun `should parse spec sample 623 correctly {Raw HTML}`() {
         val parsed = processor.processMarkdownDocument("</a></foo >")
 
         /*
@@ -12080,7 +12079,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 624 correctly (Raw HTML)`() {
+    fun `should parse spec sample 624 correctly {Raw HTML}`() {
         val parsed = processor.processMarkdownDocument("</a href=\"foo\">")
 
         /*
@@ -12091,7 +12090,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 625 correctly (Raw HTML)`() {
+    fun `should parse spec sample 625 correctly {Raw HTML}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -12110,7 +12109,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 626 correctly (Raw HTML)`() {
+    fun `should parse spec sample 626 correctly {Raw HTML}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -12133,7 +12132,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 627 correctly (Raw HTML)`() {
+    fun `should parse spec sample 627 correctly {Raw HTML}`() {
         val parsed = processor.processMarkdownDocument("foo <?php echo \$a; ?>")
 
         /*
@@ -12144,7 +12143,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 628 correctly (Raw HTML)`() {
+    fun `should parse spec sample 628 correctly {Raw HTML}`() {
         val parsed = processor.processMarkdownDocument("foo <!ELEMENT br EMPTY>")
 
         /*
@@ -12155,7 +12154,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 629 correctly (Raw HTML)`() {
+    fun `should parse spec sample 629 correctly {Raw HTML}`() {
         val parsed = processor.processMarkdownDocument("foo <![CDATA[>&<]]>")
 
         /*
@@ -12166,7 +12165,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 630 correctly (Raw HTML)`() {
+    fun `should parse spec sample 630 correctly {Raw HTML}`() {
         val parsed = processor.processMarkdownDocument("foo <a href=\"&ouml;\">")
 
         /*
@@ -12177,7 +12176,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 631 correctly (Raw HTML)`() {
+    fun `should parse spec sample 631 correctly {Raw HTML}`() {
         val parsed = processor.processMarkdownDocument("foo <a href=\"\\*\">")
 
         /*
@@ -12188,7 +12187,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 632 correctly (Raw HTML)`() {
+    fun `should parse spec sample 632 correctly {Raw HTML}`() {
         val parsed = processor.processMarkdownDocument("<a href=\"\\\"\">")
 
         /*
@@ -12199,7 +12198,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 633 correctly (Hard line breaks)`() {
+    fun `should parse spec sample 633 correctly {Hard line breaks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -12218,7 +12217,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 634 correctly (Hard line breaks)`() {
+    fun `should parse spec sample 634 correctly {Hard line breaks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -12237,7 +12236,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 635 correctly (Hard line breaks)`() {
+    fun `should parse spec sample 635 correctly {Hard line breaks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -12256,7 +12255,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 636 correctly (Hard line breaks)`() {
+    fun `should parse spec sample 636 correctly {Hard line breaks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -12275,7 +12274,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 637 correctly (Hard line breaks)`() {
+    fun `should parse spec sample 637 correctly {Hard line breaks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -12294,7 +12293,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 638 correctly (Hard line breaks)`() {
+    fun `should parse spec sample 638 correctly {Hard line breaks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -12313,7 +12312,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 639 correctly (Hard line breaks)`() {
+    fun `should parse spec sample 639 correctly {Hard line breaks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -12332,7 +12331,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 640 correctly (Hard line breaks)`() {
+    fun `should parse spec sample 640 correctly {Hard line breaks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -12350,7 +12349,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 641 correctly (Hard line breaks)`() {
+    fun `should parse spec sample 641 correctly {Hard line breaks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -12368,7 +12367,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 642 correctly (Hard line breaks)`() {
+    fun `should parse spec sample 642 correctly {Hard line breaks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -12387,7 +12386,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 643 correctly (Hard line breaks)`() {
+    fun `should parse spec sample 643 correctly {Hard line breaks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -12406,7 +12405,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 644 correctly (Hard line breaks)`() {
+    fun `should parse spec sample 644 correctly {Hard line breaks}`() {
         val parsed = processor.processMarkdownDocument("foo\\")
 
         /*
@@ -12417,7 +12416,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 645 correctly (Hard line breaks)`() {
+    fun `should parse spec sample 645 correctly {Hard line breaks}`() {
         val parsed = processor.processMarkdownDocument("foo  ")
 
         /*
@@ -12428,7 +12427,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 646 correctly (Hard line breaks)`() {
+    fun `should parse spec sample 646 correctly {Hard line breaks}`() {
         val parsed = processor.processMarkdownDocument("### foo\\")
 
         /*
@@ -12439,7 +12438,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 647 correctly (Hard line breaks)`() {
+    fun `should parse spec sample 647 correctly {Hard line breaks}`() {
         val parsed = processor.processMarkdownDocument("### foo  ")
 
         /*
@@ -12450,7 +12449,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 648 correctly (Soft line breaks)`() {
+    fun `should parse spec sample 648 correctly {Soft line breaks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -12469,7 +12468,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 649 correctly (Soft line breaks)`() {
+    fun `should parse spec sample 649 correctly {Soft line breaks}`() {
         val parsed =
             processor.processMarkdownDocument(
                 """
@@ -12488,7 +12487,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 650 correctly (Textual content)`() {
+    fun `should parse spec sample 650 correctly {Textual content}`() {
         val parsed = processor.processMarkdownDocument("hello $.;'there")
 
         /*
@@ -12499,7 +12498,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 651 correctly (Textual content)`() {
+    fun `should parse spec sample 651 correctly {Textual content}`() {
         val parsed = processor.processMarkdownDocument("Foo χρῆν")
 
         /*
@@ -12510,7 +12509,7 @@ class MarkdownProcessorDocumentParsingTest {
     }
 
     @Test
-    fun `should parse spec sample 652 correctly (Textual content)`() {
+    fun `should parse spec sample 652 correctly {Textual content}`() {
         val parsed = processor.processMarkdownDocument("Multiple     spaces")
 
         /*


### PR DESCRIPTION
- use one node type for Heading
- rename 'content' to 'children' if it points to other blocks

Also clean up tests to not use parenthesis,
becasue it breaks navigation in IDEA