### PR TITLE
Improve CircularProgressIndicator code

### DIFF
--- a/ui/api/ui.api
+++ b/ui/api/ui.api
@@ -221,8 +221,8 @@ public final class org/jetbrains/jewel/ui/component/ChipState$Companion {
 }
 
 public final class org/jetbrains/jewel/ui/component/CircularProgressIndicatorKt {
-	public static final fun CircularProgressIndicator (Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/ui/component/styling/CircularProgressStyle;Landroidx/compose/runtime/Composer;II)V
-	public static final fun CircularProgressIndicatorBig (Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/ui/component/styling/CircularProgressStyle;Landroidx/compose/runtime/Composer;II)V
+	public static final fun CircularProgressIndicator (Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/ui/component/styling/CircularProgressStyle;Lkotlinx/coroutines/CoroutineDispatcher;Landroidx/compose/runtime/Composer;II)V
+	public static final fun CircularProgressIndicatorBig (Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/ui/component/styling/CircularProgressStyle;Lkotlinx/coroutines/CoroutineDispatcher;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class org/jetbrains/jewel/ui/component/ComposableSingletons$MenuKt {


### PR DESCRIPTION
We only use the launched effect to load the new frames, and instead use an infinitely repeating animation for the actual frame selection.

This is done so that UI tests don't hang on the infinite work done in the launched effect.

We also now allow providing a dispatcher on which we should load the frames, which defaults to Default, but can be overridden in tests with a TestDispatcher.