### PR TITLE
Set default color of Divider composable

### DIFF
--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Divider.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Divider.kt
@@ -22,7 +22,7 @@ import org.jetbrains.jewel.ui.theme.dividerStyle
 public fun Divider(
     orientation: Orientation,
     modifier: Modifier = Modifier,
-    color: Color = Color.Unspecified,
+    color: Color = JewelTheme.globalColors.borders.normal,
     thickness: Dp = Dp.Unspecified,
     startIndent: Dp = Dp.Unspecified,
     style: DividerStyle = JewelTheme.dividerStyle,


### PR DESCRIPTION
The current color and fallback style create a transparent appearance for the Divider under Classic UI's Darkula theme. This change fixes such issue.

Manually verified that the color is correct for both new and Classic UI in all available themes.