### PR TITLE
Fix dividers not showing up in old UI themes

### DIFF
--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridge.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridge.kt
@@ -431,7 +431,7 @@ private fun readChipStyle(): ChipStyle {
 
 private fun readDividerStyle() =
     DividerStyle(
-        color = retrieveColorOrUnspecified("Borders.color"),
+        color = JBColor.border().toComposeColorOrUnspecified(),
         metrics = DividerMetrics.defaults(),
     )
 


### PR DESCRIPTION
The color key we were using was correct, but it is missing a fallback for when it's undefined. Such is the case with old UI themes (e.g., Darcula). So, the proper fix is to use JBColor.border(), which has a hardcoded fallback color.

Fixes #355, supersedes #356 