### PR TITLE
Update onFocusChanged in SelectableLazyColumn

### DIFF
--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/SelectableLazyColumn.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/SelectableLazyColumn.kt
@@ -77,7 +77,15 @@ public fun SelectableLazyColumn(
     val focusManager = LocalFocusManager.current
     val focusRequester = remember { FocusRequester() }
     LazyColumn(
-        modifier = modifier.onFocusChanged { isFocused = it.hasFocus }
+        modifier = modifier
+            .onFocusChanged {
+                isFocused = it.hasFocus
+                with(state) {
+                    if (isFocused && lastActiveItemIndex == null && selectedKeys.isEmpty()) {
+                        keyActions.actions.onSelectFirstItem(keys, this)
+                    }
+                }
+            }
             .focusRequester(focusRequester)
             .focusable(interactionSource = interactionSource)
             .onPreviewKeyEvent { event ->


### PR DESCRIPTION
The onFocusChanged function in SelectableLazyColumn has been updated to trigger onSelectFirstItem if the component receives focus and no items are currently active or selected. This ensures an item gets automatically selected in the absence of any selected or active items, improving user experience and interaction flow.