### PR TITLE
Add text colours to GlobalColors

### DIFF
--- a/foundation/api/foundation.api
+++ b/foundation/api/foundation.api
@@ -26,12 +26,12 @@ public abstract interface annotation class org/jetbrains/jewel/foundation/Genera
 public final class org/jetbrains/jewel/foundation/GlobalColors {
 	public static final field $stable I
 	public static final field Companion Lorg/jetbrains/jewel/foundation/GlobalColors$Companion;
-	public synthetic fun <init> (Lorg/jetbrains/jewel/foundation/BorderColors;Lorg/jetbrains/jewel/foundation/OutlineColors;JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lorg/jetbrains/jewel/foundation/BorderColors;Lorg/jetbrains/jewel/foundation/OutlineColors;Lorg/jetbrains/jewel/foundation/TextColors;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBorders ()Lorg/jetbrains/jewel/foundation/BorderColors;
-	public final fun getInfoContent-0d7_KjU ()J
 	public final fun getOutlines ()Lorg/jetbrains/jewel/foundation/OutlineColors;
-	public final fun getPaneBackground-0d7_KjU ()J
+	public final fun getPanelBackground-0d7_KjU ()J
+	public final fun getText ()Lorg/jetbrains/jewel/foundation/TextColors;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -126,6 +126,23 @@ public final class org/jetbrains/jewel/foundation/StrokeKt {
 	public static synthetic fun Stroke-Ke5fDM4$default (FLandroidx/compose/ui/graphics/Brush;Lorg/jetbrains/jewel/foundation/Stroke$Alignment;FILjava/lang/Object;)Lorg/jetbrains/jewel/foundation/Stroke;
 	public static final fun Stroke-nMwvq1g (FJLorg/jetbrains/jewel/foundation/Stroke$Alignment;F)Lorg/jetbrains/jewel/foundation/Stroke;
 	public static synthetic fun Stroke-nMwvq1g$default (FJLorg/jetbrains/jewel/foundation/Stroke$Alignment;FILjava/lang/Object;)Lorg/jetbrains/jewel/foundation/Stroke;
+}
+
+public final class org/jetbrains/jewel/foundation/TextColors {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/foundation/TextColors$Companion;
+	public synthetic fun <init> (JJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDisabled-0d7_KjU ()J
+	public final fun getError-0d7_KjU ()J
+	public final fun getInfo-0d7_KjU ()J
+	public final fun getNormal-0d7_KjU ()J
+	public final fun getSelected-0d7_KjU ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/foundation/TextColors$Companion {
 }
 
 public class org/jetbrains/jewel/foundation/lazy/DefaultMacOsSelectableColumnKeybindings : org/jetbrains/jewel/foundation/lazy/DefaultSelectableColumnKeybindings {

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/GlobalColors.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/GlobalColors.kt
@@ -10,8 +10,21 @@ import androidx.compose.ui.graphics.Color
 public class GlobalColors(
     public val borders: BorderColors,
     public val outlines: OutlineColors,
-    public val infoContent: Color,
-    public val paneBackground: Color,
+    public val text: TextColors,
+    public val panelBackground: Color,
+) {
+
+    public companion object
+}
+
+@Immutable
+@GenerateDataFunctions
+public class TextColors(
+    public val normal: Color,
+    public val selected: Color,
+    public val disabled: Color,
+    public val info: Color,
+    public val error: Color,
 ) {
 
     public companion object

--- a/ide-laf-bridge/api/ide-laf-bridge.api
+++ b/ide-laf-bridge/api/ide-laf-bridge.api
@@ -87,6 +87,7 @@ public final class org/jetbrains/jewel/bridge/theme/BridgeGlobalColorsKt {
 	public static final fun readFromLaF (Lorg/jetbrains/jewel/foundation/BorderColors$Companion;)Lorg/jetbrains/jewel/foundation/BorderColors;
 	public static final fun readFromLaF (Lorg/jetbrains/jewel/foundation/GlobalColors$Companion;)Lorg/jetbrains/jewel/foundation/GlobalColors;
 	public static final fun readFromLaF (Lorg/jetbrains/jewel/foundation/OutlineColors$Companion;)Lorg/jetbrains/jewel/foundation/OutlineColors;
+	public static final fun readFromLaF (Lorg/jetbrains/jewel/foundation/TextColors$Companion;)Lorg/jetbrains/jewel/foundation/TextColors;
 }
 
 public final class org/jetbrains/jewel/bridge/theme/BridgeGlobalMetricsKt {

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/BridgeGlobalColors.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/BridgeGlobalColors.kt
@@ -3,17 +3,19 @@ package org.jetbrains.jewel.bridge.theme
 import com.intellij.ide.ui.laf.darcula.DarculaUIUtil
 import com.intellij.ui.JBColor
 import org.jetbrains.jewel.bridge.retrieveColorOrUnspecified
+import org.jetbrains.jewel.bridge.toComposeColor
 import org.jetbrains.jewel.bridge.toComposeColorOrUnspecified
 import org.jetbrains.jewel.foundation.BorderColors
 import org.jetbrains.jewel.foundation.GlobalColors
 import org.jetbrains.jewel.foundation.OutlineColors
+import org.jetbrains.jewel.foundation.TextColors
 
 public fun GlobalColors.Companion.readFromLaF(): GlobalColors =
     GlobalColors(
         borders = BorderColors.readFromLaF(),
         outlines = OutlineColors.readFromLaF(),
-        infoContent = retrieveColorOrUnspecified("*.infoForeground"),
-        paneBackground = retrieveColorOrUnspecified("Panel.background"),
+        text = TextColors.readFromLaF(),
+        panelBackground = retrieveColorOrUnspecified("Panel.background"),
     )
 
 public fun BorderColors.Companion.readFromLaF(): BorderColors =
@@ -21,6 +23,15 @@ public fun BorderColors.Companion.readFromLaF(): BorderColors =
         normal = JBColor.border().toComposeColorOrUnspecified(),
         focused = DarculaUIUtil.getOutlineColor(true, true).toComposeColorOrUnspecified(),
         disabled = DarculaUIUtil.getOutlineColor(false, false).toComposeColorOrUnspecified(),
+    )
+
+public fun TextColors.Companion.readFromLaF(): TextColors =
+    TextColors(
+        normal = JBColor.foreground().toComposeColor(),
+        selected = retrieveColorOrUnspecified("Label.selectedForeground"),
+        disabled = retrieveColorOrUnspecified("Label.disabledForeground"),
+        info = retrieveColorOrUnspecified("Label.infoForeground"),
+        error = retrieveColorOrUnspecified("Label.errorForeground"),
     )
 
 public fun OutlineColors.Companion.readFromLaF(): OutlineColors =

--- a/int-ui/int-ui-standalone/api/int-ui-standalone.api
+++ b/int-ui/int-ui-standalone/api/int-ui-standalone.api
@@ -319,10 +319,12 @@ public final class org/jetbrains/jewel/intui/standalone/styling/IntUiUndecorated
 public final class org/jetbrains/jewel/intui/standalone/theme/IntUiGlobalColorsKt {
 	public static final fun dark-GyCwops (Lorg/jetbrains/jewel/foundation/BorderColors$Companion;JJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/foundation/BorderColors;
 	public static final fun dark-Hformbs (Lorg/jetbrains/jewel/foundation/OutlineColors$Companion;JJJJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/foundation/OutlineColors;
-	public static final fun dark-jA1GFJw (Lorg/jetbrains/jewel/foundation/GlobalColors$Companion;Lorg/jetbrains/jewel/foundation/BorderColors;Lorg/jetbrains/jewel/foundation/OutlineColors;JJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/foundation/GlobalColors;
+	public static final fun dark-Hformbs (Lorg/jetbrains/jewel/foundation/TextColors$Companion;JJJJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/foundation/TextColors;
+	public static final fun dark-yrwZFoE (Lorg/jetbrains/jewel/foundation/GlobalColors$Companion;Lorg/jetbrains/jewel/foundation/BorderColors;Lorg/jetbrains/jewel/foundation/OutlineColors;Lorg/jetbrains/jewel/foundation/TextColors;JLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/foundation/GlobalColors;
 	public static final fun light-GyCwops (Lorg/jetbrains/jewel/foundation/BorderColors$Companion;JJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/foundation/BorderColors;
 	public static final fun light-Hformbs (Lorg/jetbrains/jewel/foundation/OutlineColors$Companion;JJJJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/foundation/OutlineColors;
-	public static final fun light-jA1GFJw (Lorg/jetbrains/jewel/foundation/GlobalColors$Companion;Lorg/jetbrains/jewel/foundation/BorderColors;Lorg/jetbrains/jewel/foundation/OutlineColors;JJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/foundation/GlobalColors;
+	public static final fun light-Hformbs (Lorg/jetbrains/jewel/foundation/TextColors$Companion;JJJJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/foundation/TextColors;
+	public static final fun light-yrwZFoE (Lorg/jetbrains/jewel/foundation/GlobalColors$Companion;Lorg/jetbrains/jewel/foundation/BorderColors;Lorg/jetbrains/jewel/foundation/OutlineColors;Lorg/jetbrains/jewel/foundation/TextColors;JLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/foundation/GlobalColors;
 }
 
 public final class org/jetbrains/jewel/intui/standalone/theme/IntUiGlobalMetricsKt {

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/theme/IntUiGlobalColors.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/theme/IntUiGlobalColors.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.Color
 import org.jetbrains.jewel.foundation.BorderColors
 import org.jetbrains.jewel.foundation.GlobalColors
 import org.jetbrains.jewel.foundation.OutlineColors
+import org.jetbrains.jewel.foundation.TextColors
 import org.jetbrains.jewel.intui.core.theme.IntUiDarkTheme
 import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 
@@ -12,28 +13,28 @@ import org.jetbrains.jewel.intui.core.theme.IntUiLightTheme
 public fun GlobalColors.Companion.light(
     borders: BorderColors = BorderColors.light(),
     outlines: OutlineColors = OutlineColors.light(),
-    infoContent: Color = IntUiLightTheme.colors.grey(7),
+    text: TextColors = TextColors.light(),
     paneBackground: Color = IntUiLightTheme.colors.grey(13),
 ): GlobalColors =
     GlobalColors(
         borders = borders,
         outlines = outlines,
-        infoContent = infoContent,
-        paneBackground = paneBackground,
+        text = text,
+        panelBackground = paneBackground,
     )
 
 @Composable
 public fun GlobalColors.Companion.dark(
     borders: BorderColors = BorderColors.dark(),
     outlines: OutlineColors = OutlineColors.dark(),
-    infoContent: Color = IntUiDarkTheme.colors.grey(7),
+    text: TextColors = TextColors.dark(),
     paneBackground: Color = IntUiDarkTheme.colors.grey(2),
 ): GlobalColors =
     GlobalColors(
         borders = borders,
         outlines = outlines,
-        infoContent = infoContent,
-        paneBackground = paneBackground,
+        text = text,
+        panelBackground = paneBackground,
     )
 
 @Composable
@@ -51,6 +52,26 @@ public fun BorderColors.Companion.dark(
     disabled: Color = IntUiDarkTheme.colors.grey(4),
 ): BorderColors =
     BorderColors(normal, focused, disabled)
+
+@Composable
+public fun TextColors.Companion.light(
+    normal: Color = IntUiLightTheme.colors.grey(1),
+    selected: Color = IntUiLightTheme.colors.grey(1),
+    disabled: Color = IntUiLightTheme.colors.grey(8),
+    info: Color = IntUiLightTheme.colors.grey(7),
+    error: Color = IntUiLightTheme.colors.red(4),
+): TextColors =
+    TextColors(normal, selected, disabled, info, error)
+
+@Composable
+public fun TextColors.Companion.dark(
+    normal: Color = IntUiDarkTheme.colors.grey(12),
+    selected: Color = IntUiDarkTheme.colors.grey(12),
+    disabled: Color = IntUiDarkTheme.colors.grey(6),
+    info: Color = IntUiDarkTheme.colors.grey(7),
+    error: Color = IntUiDarkTheme.colors.red(7),
+): TextColors =
+    TextColors(normal, selected, disabled, info, error)
 
 @Composable
 public fun OutlineColors.Companion.light(

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/theme/IntUiTheme.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/theme/IntUiTheme.kt
@@ -180,7 +180,7 @@ public fun JewelTheme.Companion.lightThemeDefinition(
     palette: ThemeColorPalette = IntUiLightTheme.colors,
     iconData: ThemeIconData = IntUiLightTheme.iconData,
     defaultTextStyle: TextStyle = JewelTheme.createDefaultTextStyle(),
-    contentColor: Color = IntUiLightTheme.colors.grey(1),
+    contentColor: Color = colors.text.normal,
 ): ThemeDefinition =
     ThemeDefinition(
         name = "IntUI Light",
@@ -200,7 +200,7 @@ public fun JewelTheme.Companion.darkThemeDefinition(
     palette: ThemeColorPalette = IntUiDarkTheme.colors,
     iconData: ThemeIconData = IntUiDarkTheme.iconData,
     defaultTextStyle: TextStyle = JewelTheme.createDefaultTextStyle(),
-    contentColor: Color = IntUiDarkTheme.colors.grey(12),
+    contentColor: Color = colors.text.normal,
 ): ThemeDefinition =
     ThemeDefinition(
         name = "IntUI Dark",

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/ComponentsView.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/ComponentsView.kt
@@ -42,7 +42,7 @@ import kotlin.time.Duration.Companion.milliseconds
 @Composable
 @View(title = "Components", position = 1, icon = "icons/structure.svg")
 fun ComponentsView() {
-    Row(Modifier.trackActivation().fillMaxSize().background(JewelTheme.globalColors.paneBackground)) {
+    Row(Modifier.trackActivation().fillMaxSize().background(JewelTheme.globalColors.panelBackground)) {
         ComponentsToolBar()
         Divider(Orientation.Vertical)
         ComponentView(ComponentsViewModel.currentView)

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/MarkdownView.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/MarkdownView.kt
@@ -22,7 +22,7 @@ import org.jetbrains.jewel.ui.component.Divider
 @View(title = "Markdown", position = 2, icon = "icons/markdown.svg")
 @Composable
 fun MarkdownDemo() {
-    Row(Modifier.trackActivation().fillMaxSize().background(JewelTheme.globalColors.paneBackground)) {
+    Row(Modifier.trackActivation().fillMaxSize().background(JewelTheme.globalColors.panelBackground)) {
         var currentMarkdown by remember { mutableStateOf(JewelReadme) }
         MarkdownEditor(currentMarkdown, { currentMarkdown = it }, Modifier.fillMaxHeight().weight(1f))
 

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/WelcomeView.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/WelcomeView.kt
@@ -37,7 +37,7 @@ fun WelcomeView() {
     Column(
         modifier = Modifier.trackActivation()
             .fillMaxSize()
-            .background(JewelTheme.globalColors.paneBackground)
+            .background(JewelTheme.globalColors.panelBackground)
             .padding(24.dp),
         verticalArrangement = Arrangement.spacedBy(24.dp),
     ) {

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/markdown/MarkdownEditor.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/markdown/MarkdownEditor.kt
@@ -41,7 +41,7 @@ internal fun MarkdownEditor(
     Column(modifier) {
         ControlsRow(
             onMarkdownChange,
-            Modifier.fillMaxWidth().background(JewelTheme.globalColors.paneBackground).padding(8.dp),
+            Modifier.fillMaxWidth().background(JewelTheme.globalColors.panelBackground).padding(8.dp),
         )
         Divider(orientation = Orientation.Horizontal)
         Editor(currentMarkdown, onMarkdownChange, Modifier.fillMaxWidth().weight(1f))


### PR DESCRIPTION
It's practical to have the "base" text colours in GlobalColors:

 * Normal
 * Selected
 * Disabled
 * Info
 * Error

They apply to labels and most components, but not every component (e.g., default buttons have "inverted" text colors).

Note that the text colour is used as content colour, but not directly in the styling. Besides, when initialising the stylings, we can't really read these values as they haven't been init yet.

This is mostly a convenience for users that want to set a content colour (e.g., to visually show some text as disabled/error).

Note: GlobalColors.paneBackground was renamed to panelBackground for consistency with the Swing color key naming.