### PR TITLE
Allow rendering Markdown content as disabled

### DIFF
--- a/markdown/core/api/core.api
+++ b/markdown/core/api/core.api
@@ -408,13 +408,13 @@ public abstract interface class org/jetbrains/jewel/markdown/extensions/Markdown
 
 public abstract interface class org/jetbrains/jewel/markdown/extensions/MarkdownBlockRendererExtension {
 	public abstract fun canRender (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CustomBlock;)Z
-	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CustomBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Lorg/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CustomBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Lorg/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 }
 
 public final class org/jetbrains/jewel/markdown/extensions/MarkdownKt {
-	public static final fun LazyMarkdown (Ljava/util/List;Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/foundation/lazy/LazyListState;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Landroidx/compose/runtime/Composer;II)V
-	public static final fun Markdown (Ljava/lang/String;Landroidx/compose/ui/Modifier;ZLkotlinx/coroutines/CoroutineDispatcher;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;Lorg/jetbrains/jewel/markdown/processing/MarkdownProcessor;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Landroidx/compose/runtime/Composer;II)V
-	public static final fun Markdown (Ljava/util/List;Landroidx/compose/ui/Modifier;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Landroidx/compose/runtime/Composer;II)V
+	public static final fun LazyMarkdown (Ljava/util/List;Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/foundation/lazy/LazyListState;ZZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Landroidx/compose/runtime/Composer;II)V
+	public static final fun Markdown (Ljava/lang/String;Landroidx/compose/ui/Modifier;ZZLkotlinx/coroutines/CoroutineDispatcher;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;Lorg/jetbrains/jewel/markdown/processing/MarkdownProcessor;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Landroidx/compose/runtime/Composer;II)V
+	public static final fun Markdown (Ljava/util/List;Landroidx/compose/ui/Modifier;ZZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Landroidx/compose/runtime/Composer;II)V
 	public static final fun getLocalMarkdownBlockRenderer ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 	public static final fun getLocalMarkdownProcessor ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 	public static final fun getLocalMarkdownStyling ()Landroidx/compose/runtime/ProvidableCompositionLocal;
@@ -448,7 +448,7 @@ public class org/jetbrains/jewel/markdown/rendering/DefaultInlineMarkdownRendere
 	public static final field Companion Lorg/jetbrains/jewel/markdown/rendering/DefaultInlineMarkdownRenderer$Companion;
 	public fun <init> (Ljava/util/List;)V
 	public fun <init> ([Lorg/jetbrains/jewel/markdown/extensions/MarkdownProcessorExtension;)V
-	public fun renderAsAnnotatedString (Ljava/lang/Iterable;Lorg/jetbrains/jewel/markdown/rendering/InlinesStyling;)Landroidx/compose/ui/text/AnnotatedString;
+	public fun renderAsAnnotatedString (Ljava/lang/Iterable;Lorg/jetbrains/jewel/markdown/rendering/InlinesStyling;Z)Landroidx/compose/ui/text/AnnotatedString;
 }
 
 public final class org/jetbrains/jewel/markdown/rendering/DefaultInlineMarkdownRenderer$Companion {
@@ -457,26 +457,26 @@ public final class org/jetbrains/jewel/markdown/rendering/DefaultInlineMarkdownR
 public class org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer : org/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer {
 	public static final field $stable I
 	public fun <init> (Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;Ljava/util/List;Lorg/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer;)V
-	public fun render (Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$BlockQuote;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$BlockQuote;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Ljava/util/List;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$BlockQuote;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$BlockQuote;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$FencedCodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code$Fenced;Landroidx/compose/runtime/Composer;I)V
 	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$IndentedCodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code$Indented;Landroidx/compose/runtime/Composer;I)V
 	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code;Landroidx/compose/runtime/Composer;I)V
 	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$HtmlBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$HtmlBlock;Landroidx/compose/runtime/Composer;I)V
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$OrderedList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Ordered;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$UnorderedList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Unordered;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListItem;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public fun render-BLSRvKs (Lorg/commonmark/node/Paragraph;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Paragraph;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public fun render-kPCWZlk (Lorg/commonmark/node/Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading$HN;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public fun render-kPCWZlk (Lorg/commonmark/node/Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$OrderedList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Ordered;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$UnorderedList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Unordered;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListItem;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public fun render-EPtGD7Q (Lorg/commonmark/node/Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading$HN;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public fun render-EPtGD7Q (Lorg/commonmark/node/Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public fun render-VUzZlgQ (Lorg/commonmark/node/Paragraph;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Paragraph;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public fun renderThematicBreak (Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$ThematicBreak;Landroidx/compose/runtime/Composer;I)V
 }
 
 public abstract interface class org/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer {
 	public static final field Companion Lorg/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer$Companion;
-	public abstract fun renderAsAnnotatedString (Ljava/lang/Iterable;Lorg/jetbrains/jewel/markdown/rendering/InlinesStyling;)Landroidx/compose/ui/text/AnnotatedString;
+	public abstract fun renderAsAnnotatedString (Ljava/lang/Iterable;Lorg/jetbrains/jewel/markdown/rendering/InlinesStyling;Z)Landroidx/compose/ui/text/AnnotatedString;
 }
 
 public final class org/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer$Companion {
@@ -505,20 +505,20 @@ public final class org/jetbrains/jewel/markdown/rendering/InlinesStyling$Compani
 
 public abstract interface class org/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer {
 	public static final field Companion Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer$Companion;
-	public abstract fun render (Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$BlockQuote;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$BlockQuote;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Ljava/util/List;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$BlockQuote;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$BlockQuote;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$FencedCodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code$Fenced;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$IndentedCodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code$Indented;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$HtmlBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$HtmlBlock;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$OrderedList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Ordered;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$UnorderedList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Unordered;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListItem;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render-BLSRvKs (Lorg/commonmark/node/Paragraph;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Paragraph;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render-kPCWZlk (Lorg/commonmark/node/Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading$HN;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render-kPCWZlk (Lorg/commonmark/node/Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$OrderedList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Ordered;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$UnorderedList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Unordered;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListItem;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render-EPtGD7Q (Lorg/commonmark/node/Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading$HN;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render-EPtGD7Q (Lorg/commonmark/node/Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render-VUzZlgQ (Lorg/commonmark/node/Paragraph;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Paragraph;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun renderThematicBreak (Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$ThematicBreak;Landroidx/compose/runtime/Composer;I)V
 }
 

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/Markdown.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/Markdown.kt
@@ -55,7 +55,8 @@ public val JewelTheme.Companion.markdownBlockRenderer: MarkdownBlockRenderer
 public fun Markdown(
     @Language("Markdown") markdown: String,
     modifier: Modifier = Modifier,
-    isSelectable: Boolean = false,
+    selectable: Boolean = false,
+    enabled: Boolean = true,
     renderingDispatcher: CoroutineDispatcher = Dispatchers.Default,
     onUrlClick: (String) -> Unit = {},
     onTextClick: () -> Unit = {},
@@ -72,7 +73,8 @@ public fun Markdown(
     Markdown(
         markdownBlocks = markdownBlocks,
         modifier = modifier,
-        isSelectable = isSelectable,
+        selectable = selectable,
+        enabled = enabled,
         onUrlClick = onUrlClick,
         onTextClick = onTextClick,
         markdownStyling = markdownStyling,
@@ -85,17 +87,18 @@ public fun Markdown(
 public fun Markdown(
     markdownBlocks: List<MarkdownBlock>,
     modifier: Modifier = Modifier,
-    isSelectable: Boolean = false,
+    enabled: Boolean = true,
+    selectable: Boolean = false,
     onUrlClick: (String) -> Unit = {},
     onTextClick: () -> Unit = {},
     markdownStyling: MarkdownStyling = JewelTheme.markdownStyling,
     blockRenderer: MarkdownBlockRenderer = JewelTheme.markdownBlockRenderer,
 ) {
-    if (isSelectable) {
+    if (selectable) {
         SelectionContainer(modifier) {
             Column(verticalArrangement = Arrangement.spacedBy(markdownStyling.blockVerticalSpacing)) {
                 for (block in markdownBlocks) {
-                    blockRenderer.render(block, onUrlClick, onTextClick)
+                    blockRenderer.render(block, enabled, onUrlClick, onTextClick)
                 }
             }
         }
@@ -105,7 +108,7 @@ public fun Markdown(
             verticalArrangement = Arrangement.spacedBy(markdownStyling.blockVerticalSpacing),
         ) {
             for (block in markdownBlocks) {
-                blockRenderer.render(block, onUrlClick, onTextClick)
+                blockRenderer.render(block, enabled, onUrlClick, onTextClick)
             }
         }
     }
@@ -118,13 +121,14 @@ public fun LazyMarkdown(
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(0.dp),
     state: LazyListState = rememberLazyListState(),
-    isSelectable: Boolean = false,
+    enabled: Boolean = true,
+    selectable: Boolean = false,
     onUrlClick: (String) -> Unit = {},
     onTextClick: () -> Unit = {},
     markdownStyling: MarkdownStyling = JewelTheme.markdownStyling,
     blockRenderer: MarkdownBlockRenderer = JewelTheme.markdownBlockRenderer,
 ) {
-    if (isSelectable) {
+    if (selectable) {
         SelectionContainer(modifier) {
             LazyColumn(
                 state = state,
@@ -132,7 +136,7 @@ public fun LazyMarkdown(
                 verticalArrangement = Arrangement.spacedBy(markdownStyling.blockVerticalSpacing),
             ) {
                 items(markdownBlocks) { block ->
-                    blockRenderer.render(block, onUrlClick, onTextClick)
+                    blockRenderer.render(block, enabled, onUrlClick, onTextClick)
                 }
             }
         }
@@ -144,7 +148,7 @@ public fun LazyMarkdown(
             verticalArrangement = Arrangement.spacedBy(markdownStyling.blockVerticalSpacing),
         ) {
             items(markdownBlocks) { block ->
-                blockRenderer.render(block, onUrlClick, onTextClick)
+                blockRenderer.render(block, enabled, onUrlClick, onTextClick)
             }
         }
     }

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/MarkdownBlockRendererExtension.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/MarkdownBlockRendererExtension.kt
@@ -24,6 +24,7 @@ public interface MarkdownBlockRendererExtension {
         block: CustomBlock,
         blockRenderer: MarkdownBlockRenderer,
         inlineRenderer: InlineMarkdownRenderer,
+        enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
     )

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer.kt
@@ -12,7 +12,11 @@ public interface InlineMarkdownRenderer {
      * Render the [inlineMarkdown] as an [AnnotatedString], using the [styling]
      * provided.
      */
-    public fun renderAsAnnotatedString(inlineMarkdown: Iterable<InlineMarkdown>, styling: InlinesStyling): AnnotatedString
+    public fun renderAsAnnotatedString(
+        inlineMarkdown: Iterable<InlineMarkdown>,
+        styling: InlinesStyling,
+        enabled: Boolean,
+    ): AnnotatedString
 
     public companion object {
 

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer.kt
@@ -20,6 +20,7 @@ public interface MarkdownBlockRenderer {
     @Composable
     public fun render(
         blocks: List<MarkdownBlock>,
+        enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
     )
@@ -27,6 +28,7 @@ public interface MarkdownBlockRenderer {
     @Composable
     public fun render(
         block: MarkdownBlock,
+        enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
     )
@@ -35,6 +37,7 @@ public interface MarkdownBlockRenderer {
     public fun render(
         block: Paragraph,
         styling: MarkdownStyling.Paragraph,
+        enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
     )
@@ -43,6 +46,7 @@ public interface MarkdownBlockRenderer {
     public fun render(
         block: MarkdownBlock.Heading,
         styling: MarkdownStyling.Heading,
+        enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
     )
@@ -51,6 +55,7 @@ public interface MarkdownBlockRenderer {
     public fun render(
         block: MarkdownBlock.Heading,
         styling: MarkdownStyling.Heading.HN,
+        enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
     )
@@ -59,6 +64,7 @@ public interface MarkdownBlockRenderer {
     public fun render(
         block: BlockQuote,
         styling: MarkdownStyling.BlockQuote,
+        enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
     )
@@ -67,6 +73,7 @@ public interface MarkdownBlockRenderer {
     public fun render(
         block: ListBlock,
         styling: MarkdownStyling.List,
+        enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
     )
@@ -75,6 +82,7 @@ public interface MarkdownBlockRenderer {
     public fun render(
         block: OrderedList,
         styling: MarkdownStyling.List.Ordered,
+        enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
     )
@@ -83,6 +91,7 @@ public interface MarkdownBlockRenderer {
     public fun render(
         block: UnorderedList,
         styling: MarkdownStyling.List.Unordered,
+        enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
     )
@@ -90,6 +99,7 @@ public interface MarkdownBlockRenderer {
     @Composable
     public fun render(
         block: ListItem,
+        enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
     )

--- a/markdown/extension/gfm-alerts/api/gfm-alerts.api
+++ b/markdown/extension/gfm-alerts/api/gfm-alerts.api
@@ -116,7 +116,7 @@ public final class org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubA
 	public static final field $stable I
 	public fun <init> (Lorg/jetbrains/jewel/markdown/extensions/github/alerts/AlertStyling;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;)V
 	public fun canRender (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CustomBlock;)Z
-	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CustomBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Lorg/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CustomBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Lorg/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 }
 
 public final class org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertProcessorExtension : org/jetbrains/jewel/markdown/extensions/MarkdownProcessorExtension {

--- a/markdown/extension/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertBlockRenderer.kt
+++ b/markdown/extension/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertBlockRenderer.kt
@@ -45,6 +45,7 @@ public class GitHubAlertBlockRenderer(
         block: CustomBlock,
         blockRenderer: MarkdownBlockRenderer,
         inlineRenderer: InlineMarkdownRenderer,
+        enabled: Boolean,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
     ) {
@@ -54,11 +55,11 @@ public class GitHubAlertBlockRenderer(
         val alert = block as? Alert
 
         when (alert) {
-            is Caution -> Alert(alert, styling.caution, blockRenderer, onUrlClick, onTextClick)
-            is Important -> Alert(alert, styling.important, blockRenderer, onUrlClick, onTextClick)
-            is Note -> Alert(alert, styling.note, blockRenderer, onUrlClick, onTextClick)
-            is Tip -> Alert(alert, styling.tip, blockRenderer, onUrlClick, onTextClick)
-            is Warning -> Alert(alert, styling.warning, blockRenderer, onUrlClick, onTextClick)
+            is Caution -> Alert(alert, styling.caution, enabled, blockRenderer, onUrlClick, onTextClick)
+            is Important -> Alert(alert, styling.important, enabled, blockRenderer, onUrlClick, onTextClick)
+            is Note -> Alert(alert, styling.note, enabled, blockRenderer, onUrlClick, onTextClick)
+            is Tip -> Alert(alert, styling.tip, enabled, blockRenderer, onUrlClick, onTextClick)
+            is Warning -> Alert(alert, styling.warning, enabled, blockRenderer, onUrlClick, onTextClick)
             else -> error("Unsupported block of type ${block.javaClass.name} cannot be rendered")
         }
     }
@@ -67,6 +68,7 @@ public class GitHubAlertBlockRenderer(
     private fun Alert(
         block: Alert,
         styling: BaseAlertStyling,
+        enabled: Boolean,
         blockRenderer: MarkdownBlockRenderer,
         onUrlClick: (String) -> Unit,
         onTextClick: () -> Unit,
@@ -126,7 +128,7 @@ public class GitHubAlertBlockRenderer(
             CompositionLocalProvider(
                 LocalContentColor provides styling.textColor.takeOrElse { LocalContentColor.current },
             ) {
-                blockRenderer.render(block.content, onUrlClick, onTextClick)
+                blockRenderer.render(block.content, enabled, onUrlClick, onTextClick)
             }
         }
     }

--- a/markdown/ide-laf-bridge-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/bridge/styling/BridgeMarkdownStyling.kt
+++ b/markdown/ide-laf-bridge-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/bridge/styling/BridgeMarkdownStyling.kt
@@ -422,7 +422,7 @@ private val defaultTextSize
     get() = (JBFont.labelFontSize() + 1).sp
 
 private val defaultTextStyle
-    get() = retrieveDefaultTextStyle()
+    get() = retrieveDefaultTextStyle().copy(color = Color.Unspecified)
 
 private val dividerColor
     get() = retrieveColorOrUnspecified("Group.separatorColor")

--- a/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
+++ b/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -26,6 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.intellij.icons.AllIcons
+import com.intellij.ide.BrowserUtil
 import com.intellij.ui.JBColor
 import com.intellij.util.ui.JBUI
 import icons.JewelIcons
@@ -36,6 +38,7 @@ import org.jetbrains.jewel.foundation.modifier.onActivated
 import org.jetbrains.jewel.foundation.modifier.trackActivation
 import org.jetbrains.jewel.foundation.modifier.trackComponentActivation
 import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.foundation.theme.LocalContentColor
 import org.jetbrains.jewel.intui.markdown.bridge.ProvideMarkdownStyling
 import org.jetbrains.jewel.markdown.extensions.Markdown
 import org.jetbrains.jewel.ui.Orientation
@@ -237,23 +240,7 @@ private fun RowScope.ColumnTwo() {
         Modifier.trackActivation().weight(1f),
         verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
-        ProvideMarkdownStyling {
-            Markdown(
-                """
-                |Hi! This is an example of **Markdown** rendering. We support the [CommonMark specs](https://commonmark.org/)
-                |out of the box, but you can also have _extensions_.
-                |
-                |For example:
-                | * Images
-                | * Tables
-                | * And more — I am running out of random things to say 😆
-                """.trimMargin(),
-                Modifier.fillMaxWidth()
-                    .background(JBUI.CurrentTheme.Banner.INFO_BACKGROUND.toComposeColor(), RoundedCornerShape(8.dp))
-                    .border(1.dp, JBUI.CurrentTheme.Banner.INFO_BORDER_COLOR.toComposeColor(), RoundedCornerShape(8.dp))
-                    .padding(8.dp),
-            )
-        }
+        MarkdownExample()
 
         Divider(Orientation.Horizontal)
 
@@ -293,6 +280,39 @@ private fun RowScope.ColumnTwo() {
             Box(Modifier.fillMaxWidth()) {
                 Text(element.data, Modifier.padding(2.dp))
             }
+        }
+    }
+}
+
+@Composable
+private fun MarkdownExample() {
+    var enabled by remember { mutableStateOf(true) }
+    CheckboxRow("Enabled", enabled, { enabled = it })
+
+    val contentColor = if (enabled) JewelTheme.globalColors.text.normal else JewelTheme.globalColors.text.disabled
+    CompositionLocalProvider(LocalContentColor provides contentColor) {
+        ProvideMarkdownStyling {
+            Markdown(
+                """
+                |Hi! This is an example of **Markdown** rendering. We support the [CommonMark specs](https://commonmark.org/)
+                |out of the box, but you can also have _extensions_.
+                |
+                |For example:
+                | * Images
+                | * Tables
+                | * And more — I am running out of random things to say 😆
+                """.trimMargin(),
+                Modifier.fillMaxWidth()
+                    .background(JBUI.CurrentTheme.Banner.INFO_BACKGROUND.toComposeColor(), RoundedCornerShape(8.dp))
+                    .border(
+                        1.dp,
+                        JBUI.CurrentTheme.Banner.INFO_BORDER_COLOR.toComposeColor(),
+                        RoundedCornerShape(8.dp),
+                    )
+                    .padding(8.dp),
+                enabled = enabled,
+                onUrlClick = { url -> BrowserUtil.open(url) },
+            )
         }
     }
 }

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/markdown/MarkdownPreview.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/markdown/MarkdownPreview.kt
@@ -90,7 +90,7 @@ internal fun MarkdownPreview(
                 modifier = modifier.background(background),
                 contentPadding = PaddingValues(16.dp),
                 state = lazyListState,
-                isSelectable = true,
+                selectable = true,
                 onUrlClick = { url -> Desktop.getDesktop().browse(URI.create(url)) },
             )
 


### PR DESCRIPTION
Disabled content will not use any inline colours, instead using only the current content colour. Url hovering and clicking is also disabled, and so is text clicking.