### PR TITLE
Don’t use `toInt(unit: kotlin.time.DurationUnit)` function

### DIFF
--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Scrollbars.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Scrollbars.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.unit.dp
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.styling.ScrollbarStyle
 import org.jetbrains.jewel.ui.theme.scrollbarStyle
-import kotlin.time.DurationUnit
 import androidx.compose.foundation.ScrollbarStyle as ComposeScrollbarStyle
 
 @Composable
@@ -29,13 +28,13 @@ public fun VerticalScrollbar(
     style: ScrollbarStyle = JewelTheme.scrollbarStyle,
 ) {
     val shape by remember { mutableStateOf(RoundedCornerShape(style.metrics.thumbCornerSize)) }
-    val hoverDurationMillis by remember { mutableStateOf(style.hoverDuration.inWholeMilliseconds) }
+    val hoverDurationMillis by remember { mutableStateOf(style.hoverDuration.inWholeMilliseconds.toInt()) }
 
     val composeScrollbarStyle = ComposeScrollbarStyle(
         minimalHeight = style.metrics.minThumbLength,
         thickness = style.metrics.thumbThickness,
         shape = shape,
-        hoverDurationMillis = hoverDurationMillis.toInt(),
+        hoverDurationMillis = hoverDurationMillis,
         unhoverColor = style.colors.thumbBackground,
         hoverColor = style.colors.thumbBackgroundHovered,
     )
@@ -60,9 +59,7 @@ public fun HorizontalScrollbar(
     style: ScrollbarStyle = JewelTheme.scrollbarStyle,
 ) {
     val shape by remember { mutableStateOf(RoundedCornerShape(style.metrics.thumbCornerSize)) }
-    val hoverDurationMillis by remember {
-        mutableStateOf(style.hoverDuration.toInt(DurationUnit.MILLISECONDS))
-    }
+    val hoverDurationMillis by remember { mutableStateOf(style.hoverDuration.inWholeMilliseconds.toInt()) }
 
     val composeScrollbarStyle = ComposeScrollbarStyle(
         minimalHeight = style.metrics.minThumbLength,


### PR DESCRIPTION
Hi!

I noticed that `HorizontalScrollbar` uses `toInt(unit:)` function which requires `kotlin.time` package. Such requirements leads to the runtime linkage error.

```
loader constraint violation: when resolving method 
'int kotlin.time.Duration.toInt-impl(long, kotlin.time.DurationUnit)' 
the class loader com.intellij.ide.plugins.cl.PluginClassLoader of the current class,
org/jetbrains/jewel/ui/component/ScrollbarsKt, 
and the class loader com.intellij.util.lang.PathClassLoader for the method's defining class,
kotlin/time/Duration, have different Class objects for the type 
kotlin/time/DurationUnit used in the signature 
(org.jetbrains.jewel.ui.component.ScrollbarsKt is in unnamed module of
loader com.intellij.ide.plugins.cl.PluginClassLoader, parent loader 'bootstrap'; 
kotlin.time.Duration is in unnamed module of loader com.intellij.util.lang.PathClassLoader)
```

Other scroll bar components don't rely on it and their usage doesn't produce such error.

Some side questions:
* Why do `shape` and `hoverDurationMillis` store `MutableState` instead of plain values?
* Why isn't there `key` for `remeber` calls that are used for `shape` and `hoverDurationMillis`?