### PR TITLE
Add simple FocusOutline API

### DIFF
--- a/ui/api/ui.api
+++ b/ui/api/ui.api
@@ -92,6 +92,7 @@ public final class org/jetbrains/jewel/ui/Outline$Companion {
 
 public final class org/jetbrains/jewel/ui/OutlineKt {
 	public static final fun focusOutline-FJfuzF0 (Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/foundation/state/FocusableComponentState;Landroidx/compose/ui/graphics/Shape;Lorg/jetbrains/jewel/foundation/Stroke$Alignment;FLandroidx/compose/runtime/Composer;II)Landroidx/compose/ui/Modifier;
+	public static final fun focusOutline-FJfuzF0 (Landroidx/compose/ui/Modifier;ZLandroidx/compose/ui/graphics/Shape;Lorg/jetbrains/jewel/foundation/Stroke$Alignment;FLandroidx/compose/runtime/Composer;II)Landroidx/compose/ui/Modifier;
 	public static final fun outline-HYR8e34 (Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/foundation/state/FocusableComponentState;Lorg/jetbrains/jewel/ui/Outline;Landroidx/compose/ui/graphics/Shape;Lorg/jetbrains/jewel/foundation/Stroke$Alignment;FLandroidx/compose/runtime/Composer;II)Landroidx/compose/ui/Modifier;
 }
 

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/Outline.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/Outline.kt
@@ -35,10 +35,18 @@ public fun Modifier.focusOutline(
     outlineShape: Shape,
     alignment: Stroke.Alignment = Stroke.Alignment.Outside,
     outlineWidth: Dp = JewelTheme.globalMetrics.outlineWidth,
+): Modifier = focusOutline(state.isFocused, outlineShape, alignment, outlineWidth)
+
+@Composable
+public fun Modifier.focusOutline(
+    showOutline: Boolean,
+    outlineShape: Shape,
+    alignment: Stroke.Alignment = Stroke.Alignment.Outside,
+    outlineWidth: Dp = JewelTheme.globalMetrics.outlineWidth,
 ): Modifier {
     val outlineColors = JewelTheme.globalColors.outlines
 
-    return thenIf(state.isFocused) {
+    return thenIf(showOutline) {
         val outlineColor = outlineColors.focused
         border(alignment, outlineWidth, outlineColor, outlineShape)
     }


### PR DESCRIPTION
Add an overload for `Modifier.focusOutline` that takes a simple `Boolean` instead of a `FocusableComponentState`, allowing users to use the modifier even for components that don't have a `FocusableComponentState`.