### PR TITLE
Migrate to the new LinkAnnotation API

### DIFF
--- a/markdown/core/api/core.api
+++ b/markdown/core/api/core.api
@@ -457,7 +457,7 @@ public class org/jetbrains/jewel/markdown/rendering/DefaultInlineMarkdownRendere
 	public static final field Companion Lorg/jetbrains/jewel/markdown/rendering/DefaultInlineMarkdownRenderer$Companion;
 	public fun <init> (Ljava/util/List;)V
 	public fun <init> ([Lorg/jetbrains/jewel/markdown/extensions/MarkdownProcessorExtension;)V
-	public fun renderAsAnnotatedString (Ljava/lang/Iterable;Lorg/jetbrains/jewel/markdown/rendering/InlinesStyling;Z)Landroidx/compose/ui/text/AnnotatedString;
+	public fun renderAsAnnotatedString (Ljava/lang/Iterable;Lorg/jetbrains/jewel/markdown/rendering/InlinesStyling;ZLkotlin/jvm/functions/Function1;)Landroidx/compose/ui/text/AnnotatedString;
 }
 
 public final class org/jetbrains/jewel/markdown/rendering/DefaultInlineMarkdownRenderer$Companion {
@@ -486,12 +486,16 @@ public class org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer
 
 public abstract interface class org/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer {
 	public static final field Companion Lorg/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer$Companion;
-	public abstract fun renderAsAnnotatedString (Ljava/lang/Iterable;Lorg/jetbrains/jewel/markdown/rendering/InlinesStyling;Z)Landroidx/compose/ui/text/AnnotatedString;
+	public abstract fun renderAsAnnotatedString (Ljava/lang/Iterable;Lorg/jetbrains/jewel/markdown/rendering/InlinesStyling;ZLkotlin/jvm/functions/Function1;)Landroidx/compose/ui/text/AnnotatedString;
 }
 
 public final class org/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer$Companion {
 	public final fun default (Ljava/util/List;)Lorg/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer;
 	public static synthetic fun default$default (Lorg/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer$Companion;Ljava/util/List;ILjava/lang/Object;)Lorg/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer;
+}
+
+public final class org/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer$DefaultImpls {
+	public static synthetic fun renderAsAnnotatedString$default (Lorg/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer;Ljava/lang/Iterable;Lorg/jetbrains/jewel/markdown/rendering/InlinesStyling;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Landroidx/compose/ui/text/AnnotatedString;
 }
 
 public final class org/jetbrains/jewel/markdown/rendering/InlinesStyling {

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultInlineMarkdownRenderer.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultInlineMarkdownRenderer.kt
@@ -5,8 +5,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.AnnotatedString.Builder
 import androidx.compose.ui.text.ExperimentalTextApi
+import androidx.compose.ui.text.LinkAnnotation.Url
 import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.UrlAnnotation
 import androidx.compose.ui.text.buildAnnotatedString
 import org.commonmark.renderer.text.TextContentRenderer
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
@@ -14,11 +14,14 @@ import org.jetbrains.jewel.markdown.InlineMarkdown
 import org.jetbrains.jewel.markdown.extensions.MarkdownProcessorExtension
 
 @ExperimentalJewelApi
-public open class DefaultInlineMarkdownRenderer(rendererExtensions: List<MarkdownProcessorExtension>) : InlineMarkdownRenderer {
+public open class DefaultInlineMarkdownRenderer(
+    rendererExtensions: List<MarkdownProcessorExtension>,
+) : InlineMarkdownRenderer {
     public constructor(vararg extensions: MarkdownProcessorExtension) : this(extensions.toList())
 
     private val plainTextRenderer =
-        TextContentRenderer.builder()
+        TextContentRenderer
+            .builder()
             .extensions(rendererExtensions.map { it.textRendererExtension })
             .build()
 
@@ -60,7 +63,7 @@ public open class DefaultInlineMarkdownRenderer(rendererExtensions: List<Markdow
 
                 is InlineMarkdown.Link -> {
                     withStyles(styling.link.withEnabled(enabled), child) {
-                        pushUrlAnnotation(UrlAnnotation(it.nativeNode.destination))
+                        pushLink(Url(it.nativeNode.destination))
                         appendInlineMarkdownFrom(it.children, styling, enabled)
                     }
                 }

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
@@ -487,16 +487,17 @@ public open class DefaultMarkdownBlockRenderer(
             style = mergedStyle,
             modifier = modifier.pointerHoverIcon(actualPointerIcon, true),
             onHover = { offset -> hoverPointerIcon = determinePointerIcon(offset, text) },
-        ) { offset ->
-            if (!enabled) return@ClickableText
+            onClick = { offset ->
+                if (!enabled) return@ClickableText
 
-            val span = text.getUrlAnnotations(offset, offset).firstOrNull()
-            if (span != null) {
-                onUrlClick(span.item.url)
-            } else {
-                onUnhandledClick()
-            }
-        }
+                val span = text.getUrlAnnotations(offset, offset).firstOrNull()
+                if (span != null) {
+                    onUrlClick(span.item.url)
+                } else {
+                    onUnhandledClick()
+                }
+            },
+        )
     }
 
     private fun determinePointerIcon(
@@ -506,10 +507,9 @@ public open class DefaultMarkdownBlockRenderer(
         if (offset == null) return PointerIcon.Hand
 
         val hasLinkAnnotations = text.getLinkAnnotations(offset, offset).isNotEmpty()
-        return if (hasLinkAnnotations) {
-            PointerIcon.Hand
-        } else {
-            PointerIcon.Default
+        return when {
+            hasLinkAnnotations -> PointerIcon.Hand
+            else -> PointerIcon.Default
         }
     }
 

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
@@ -109,7 +109,8 @@ public open class DefaultMarkdownBlockRenderer(
             is Paragraph -> render(block, rootStyling.paragraph, enabled, onUrlClick, onTextClick)
             ThematicBreak -> renderThematicBreak(rootStyling.thematicBreak)
             is CustomBlock -> {
-                rendererExtensions.find { it.blockRenderer.canRender(block) }
+                rendererExtensions
+                    .find { it.blockRenderer.canRender(block) }
                     ?.blockRenderer
                     ?.render(block, blockRenderer = this, inlineRenderer, enabled, onUrlClick, onTextClick)
             }
@@ -128,7 +129,9 @@ public open class DefaultMarkdownBlockRenderer(
         SimpleClickableText(
             text = renderedContent,
             textStyle = styling.inlinesStyling.textStyle,
-            color = styling.inlinesStyling.textStyle.color.takeOrElse { LocalContentColor.current },
+            color =
+                styling.inlinesStyling.textStyle.color
+                    .takeOrElse { LocalContentColor.current },
             enabled = enabled,
             onUnhandledClick = onTextClick,
             onUrlClick = onUrlClick,
@@ -214,21 +217,21 @@ public open class DefaultMarkdownBlockRenderer(
         onTextClick: () -> Unit,
     ) {
         Column(
-            Modifier.drawBehind {
-                val isLtr = layoutDirection == Ltr
-                val lineWidthPx = styling.lineWidth.toPx()
-                val x = if (isLtr) lineWidthPx / 2 else size.width - lineWidthPx / 2
+            Modifier
+                .drawBehind {
+                    val isLtr = layoutDirection == Ltr
+                    val lineWidthPx = styling.lineWidth.toPx()
+                    val x = if (isLtr) lineWidthPx / 2 else size.width - lineWidthPx / 2
 
-                drawLine(
-                    styling.lineColor,
-                    Offset(x, 0f),
-                    Offset(x, size.height),
-                    lineWidthPx,
-                    styling.strokeCap,
-                    styling.pathEffect,
-                )
-            }
-                .padding(styling.padding),
+                    drawLine(
+                        styling.lineColor,
+                        Offset(x, 0f),
+                        Offset(x, size.height),
+                        lineWidthPx,
+                        styling.strokeCap,
+                        styling.pathEffect,
+                    )
+                }.padding(styling.padding),
             verticalArrangement = Arrangement.spacedBy(rootStyling.blockVerticalSpacing),
         ) {
             CompositionLocalProvider(LocalContentColor provides styling.textColor) {
@@ -278,7 +281,8 @@ public open class DefaultMarkdownBlockRenderer(
                         style = styling.numberStyle,
                         color = styling.numberStyle.color.takeOrElse { LocalContentColor.current },
                         modifier =
-                            Modifier.widthIn(min = styling.numberMinWidth)
+                            Modifier
+                                .widthIn(min = styling.numberMinWidth)
                                 .pointerHoverIcon(PointerIcon.Default, overrideDescendants = true),
                         textAlign = styling.numberTextAlign,
                     )
@@ -357,7 +361,8 @@ public open class DefaultMarkdownBlockRenderer(
     ) {
         HorizontallyScrollingContainer(
             isScrollable = styling.scrollsHorizontally,
-            Modifier.background(styling.background, styling.shape)
+            Modifier
+                .background(styling.background, styling.shape)
                 .border(styling.borderWidth, styling.borderColor, styling.shape)
                 .then(if (styling.fillWidth) Modifier.fillMaxWidth() else Modifier),
         ) {
@@ -366,7 +371,8 @@ public open class DefaultMarkdownBlockRenderer(
                 style = styling.editorTextStyle,
                 color = styling.editorTextStyle.color.takeOrElse { LocalContentColor.current },
                 modifier =
-                    Modifier.padding(styling.padding)
+                    Modifier
+                        .padding(styling.padding)
                         .pointerHoverIcon(PointerIcon.Default, overrideDescendants = true),
             )
         }
@@ -379,7 +385,8 @@ public open class DefaultMarkdownBlockRenderer(
     ) {
         HorizontallyScrollingContainer(
             isScrollable = styling.scrollsHorizontally,
-            Modifier.background(styling.background, styling.shape)
+            Modifier
+                .background(styling.background, styling.shape)
                 .border(styling.borderWidth, styling.borderColor, styling.shape)
                 .then(if (styling.fillWidth) Modifier.fillMaxWidth() else Modifier),
         ) {
@@ -419,7 +426,7 @@ public open class DefaultMarkdownBlockRenderer(
         infoText: String,
         alignment: Alignment.Horizontal,
         textStyle: TextStyle,
-        modifier: Modifier,
+        modifier: Modifier = Modifier,
     ) {
         Column(modifier, horizontalAlignment = alignment) {
             DisableSelection {
@@ -479,14 +486,7 @@ public open class DefaultMarkdownBlockRenderer(
             text = text,
             style = mergedStyle,
             modifier = modifier.pointerHoverIcon(actualPointerIcon, true),
-            onHover = { offset ->
-                hoverPointerIcon =
-                    if (offset == null || text.getUrlAnnotations(offset, offset).isEmpty()) {
-                        PointerIcon.Default
-                    } else {
-                        PointerIcon.Hand
-                    }
-            },
+            onHover = { offset -> hoverPointerIcon = determinePointerIcon(offset, text) },
         ) { offset ->
             if (!enabled) return@ClickableText
 
@@ -496,6 +496,20 @@ public open class DefaultMarkdownBlockRenderer(
             } else {
                 onUnhandledClick()
             }
+        }
+    }
+
+    private fun determinePointerIcon(
+        offset: Int?,
+        text: AnnotatedString,
+    ): PointerIcon {
+        if (offset == null) return PointerIcon.Hand
+
+        val hasLinkAnnotations = text.getLinkAnnotations(offset, offset).isNotEmpty()
+        return if (hasLinkAnnotations) {
+            PointerIcon.Hand
+        } else {
+            PointerIcon.Default
         }
     }
 
@@ -511,7 +525,8 @@ public open class DefaultMarkdownBlockRenderer(
             content = {
                 val scrollState = rememberScrollState()
                 Box(
-                    Modifier.layoutId("mainContent")
+                    Modifier
+                        .layoutId("mainContent")
                         .then(if (isScrollable) Modifier.horizontalScroll(scrollState) else Modifier),
                 ) {
                     content()
@@ -529,7 +544,8 @@ public open class DefaultMarkdownBlockRenderer(
 
                     HorizontalScrollbar(
                         rememberScrollbarAdapter(scrollState),
-                        Modifier.layoutId("containerHScrollbar")
+                        Modifier
+                            .layoutId("containerHScrollbar")
                             .padding(start = 2.dp, end = 2.dp, bottom = 2.dp)
                             .alpha(alpha),
                     )

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer.kt
@@ -15,6 +15,7 @@ public interface InlineMarkdownRenderer {
         inlineMarkdown: Iterable<InlineMarkdown>,
         styling: InlinesStyling,
         enabled: Boolean,
+        onUrlClicked: ((String) -> Unit)? = null,
     ): AnnotatedString
 
     public companion object {

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/markdown/MarkdownPreview.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/markdown/MarkdownPreview.kt
@@ -92,6 +92,7 @@ internal fun MarkdownPreview(
                 state = lazyListState,
                 selectable = true,
                 onUrlClick = { url -> Desktop.getDesktop().browse(URI.create(url)) },
+                onTextClick = { },
             )
 
             VerticalScrollbar(


### PR DESCRIPTION
# Overview

* Introduced LinkAnnotation.Clickable to drive the behavior of links
* Replaced SimpleClickableText with the good ol' Text
* Successfully wired onUrlClick and onTextClick lambdas and the enabled flag.

## Tests

Manually tested on Windows 11 using the Markdown example as a standalone application and the IDE plugin showcase.

Closes #418