### PR TITLE
Use IJ distributions for compilation of sample

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -24,7 +24,6 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.poko.gradlePlugin)
 
-
     // Enables using type-safe accessors to reference plugins from the [plugins] block defined in
     // version catalogs.
     // Context: https://github.com/gradle/gradle/issues/15383#issuecomment-779893192

--- a/buildSrc/src/main/kotlin/jewel.gradle.kts
+++ b/buildSrc/src/main/kotlin/jewel.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("jewel-linting")
     kotlin("jvm")
@@ -16,18 +18,20 @@ version = when {
     else -> "1.0.0-SNAPSHOT"
 }
 
+val jdkLevel = project.property("jdk.level") as String
 java {
     toolchain {
-        vendor = JvmVendorSpec.JETBRAINS
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(jdkLevel)
     }
+
 }
 
 kotlin {
     jvmToolchain {
-        vendor = JvmVendorSpec.JETBRAINS
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(jdkLevel)
     }
+
+    compilerOptions.jvmTarget.set(JvmTarget.fromTarget(jdkLevel))
 
     target {
         compilations.all { kotlinOptions { freeCompilerArgs += "-Xcontext-receivers" } }

--- a/buildSrc/src/main/kotlin/org/jetbrains/jewel/buildlogic/ideversion/ApiIdeaReleasesItem.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/jewel/buildlogic/ideversion/ApiIdeaReleasesItem.kt
@@ -14,5 +14,6 @@ internal data class ApiIdeaReleasesItem(
         @SerialName("build") val build: String,
         @SerialName("type") val type: String,
         @SerialName("version") val version: String,
+        @SerialName("majorVersion") val majorVersion: String,
     )
 }

--- a/buildSrc/src/main/kotlin/org/jetbrains/jewel/buildlogic/ideversion/IJPVersionsFetcher.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/jewel/buildlogic/ideversion/IJPVersionsFetcher.kt
@@ -1,0 +1,101 @@
+package org.jetbrains.jewel.buildlogic.ideversion
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+import org.gradle.api.logging.Logger
+import java.io.IOException
+import java.net.URI
+
+internal object IJPVersionsFetcher {
+
+    fun fetchIJPVersions(releasesUrl: String, logger: Logger): List<ApiIdeaReleasesItem.Release>? {
+        val json = Json {
+            ignoreUnknownKeys = true
+            isLenient = true
+        }
+
+        val icReleases =
+            try {
+                URI.create(releasesUrl).toURL()
+                    .openStream()
+                    .use { json.decodeFromStream<List<ApiIdeaReleasesItem>>(it) }
+                    .first()
+            } catch (e: IOException) {
+                logger.warn(
+                    "Couldn't fetch IJ Platform releases, can't check for updates.\n" +
+                        "Cause: ${e::class.qualifiedName} — ${e.message}"
+                )
+                return null
+            } catch (e: RuntimeException) {
+                logger.error("Unexpected error while fetching IJ Platform releases, can't check for updates.", e)
+                return null
+            }
+
+        check(icReleases.code == "IIC") { "Was expecting code IIC but was ${icReleases.code}" }
+        check(icReleases.releases.isNotEmpty()) { "Was expecting to have releases but the list is empty" }
+
+        return icReleases.releases
+    }
+
+    fun fetchBuildsForCurrentMajorVersion(
+        releasesUrl: String,
+        majorPlatformVersion: String,
+        logger: Logger,
+    ): List<ApiIdeaReleasesItem.Release>? {
+        val releases = fetchIJPVersions(releasesUrl, logger)
+            ?: return null
+
+        return releases.asSequence()
+            .filter { it.majorVersion == majorPlatformVersion }
+            .sortedWith(ReleaseComparator)
+            .toList()
+    }
+
+    fun fetchLatestBuildForCurrentMajorVersion(
+        releasesUrl: String,
+        majorPlatformVersion: String,
+        logger: Logger,
+    ) =
+        fetchBuildsForCurrentMajorVersion(releasesUrl, majorPlatformVersion, logger)
+            ?.last()
+
+    fun compare(first: ApiIdeaReleasesItem.Release, second: ApiIdeaReleasesItem.Release): Int =
+        VersionComparator.compare(first.build, second.build)
+
+    private object ReleaseComparator : Comparator<ApiIdeaReleasesItem.Release> {
+
+        override fun compare(o1: ApiIdeaReleasesItem.Release?, o2: ApiIdeaReleasesItem.Release?): Int {
+            if (o1 == o2) return 0
+            if (o1 == null) return -1
+            if (o2 == null) return 1
+
+            return VersionComparator.compare(o1.build, o2.build)
+        }
+    }
+
+    private object VersionComparator : Comparator<String> {
+
+        override fun compare(o1: String?, o2: String?): Int {
+            if (o1 == o2) return 0
+            if (o1 == null) return -1
+            if (o2 == null) return 1
+
+            require(o1.isNotEmpty() && o1.all { it.isDigit() || it == '.' }) { "The first version is invalid: '$o1'" }
+            require(o2.isNotEmpty() && o2.all { it.isDigit() || it == '.' }) { "The first version is invalid: '$o2'" }
+
+            val firstGroups = o1.split('.')
+            val secondGroups = o2.split('.')
+
+            require(firstGroups.size == 3) { "The first version is invalid: '$o1'" }
+            require(secondGroups.size == 3) { "The second version is invalid: '$o2'" }
+
+            val firstComparison = firstGroups[0].toInt().compareTo(secondGroups[0].toInt())
+            if (firstComparison != 0) return firstComparison
+
+            val secondComparison = firstGroups[1].toInt().compareTo(secondGroups[1].toInt())
+            if (secondComparison != 0) return secondComparison
+
+            return firstGroups[2].toInt().compareTo(secondGroups[2].toInt())
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,5 +8,6 @@ kotlin.incremental.useClasspathSnapshot=false
 
 org.jetbrains.intellij.platform.buildFeature.useBinaryReleases=false
 
+jdk.level=21
 ijp.target=242
 jewel.release.version=0.19.7

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,8 @@ commonmark = "0.22.0"
 composeDesktop = "1.7.0-dev1703"
 detekt = "1.23.6"
 dokka = "1.9.20"
-idea = "242.19533.56-EAP-SNAPSHOT"
+idea = "242.19890.14"
+intelliJPlatformBuild = "242.19890.14-EAP-SNAPSHOT"
 ideaPlugin = "2.0.0-beta8"
 jna = "5.14.0"
 kotlin = "1.9.24"
@@ -26,8 +27,8 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 
 jna-core = { module = "net.java.dev.jna:jna", version.ref = "jna" }
 
-intellijPlatform-util-ui = { module = "com.jetbrains.intellij.platform:util-ui", version.ref = "idea" }
-intellijPlatform-icons = { module = "com.jetbrains.intellij.platform:icons", version.ref = "idea" }
+intellijPlatform-util-ui = { module = "com.jetbrains.intellij.platform:util-ui", version.ref = "intelliJPlatformBuild" }
+intellijPlatform-icons = { module = "com.jetbrains.intellij.platform:icons", version.ref = "intelliJPlatformBuild" }
 
 # Plugin libraries for build-logic's convention plugins to use to resolve the types/tasks coming from these plugins
 detekt-gradlePlugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }

--- a/samples/ide-plugin/build.gradle.kts
+++ b/samples/ide-plugin/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.ideaPlugin)
     `android-studio-releases-generator`
 }
+
 // Because we need to define IJP dependencies, the dependencyResolutionManagement
 // from settings.gradle.kts is overridden and we have to redeclare everything here.
 repositories {

--- a/samples/standalone/build.gradle.kts
+++ b/samples/standalone/build.gradle.kts
@@ -44,6 +44,7 @@ compose.desktop {
     }
 }
 
+val jdkLevel = project.property("jdk.level") as String
 tasks {
     withType<JavaExec> {
         // afterEvaluate is needed because the Compose Gradle Plugin
@@ -51,8 +52,7 @@ tasks {
         afterEvaluate {
             javaLauncher =
                 project.javaToolchains.launcherFor {
-                    languageVersion = JavaLanguageVersion.of(21)
-                    vendor = JvmVendorSpec.JETBRAINS
+                    languageVersion = JavaLanguageVersion.of(jdkLevel)
                 }
             setExecutable(javaLauncher.map { it.executablePath.asFile.absolutePath }.get())
         }

--- a/ui/api/ui.api
+++ b/ui/api/ui.api
@@ -2459,10 +2459,46 @@ public final class org/jetbrains/jewel/ui/icons/AllIconsKeys$Duplicates {
 	public final fun getSendToTheRightGrayed ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 }
 
+public final class org/jetbrains/jewel/ui/icons/AllIconsKeys$Expui {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/ui/icons/AllIconsKeys$Expui;
+}
+
+public final class org/jetbrains/jewel/ui/icons/AllIconsKeys$Expui$FileTypes {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/ui/icons/AllIconsKeys$Expui$FileTypes;
+	public final fun getJavaScript ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+	public final fun getProperties ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+	public final fun getText ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+}
+
+public final class org/jetbrains/jewel/ui/icons/AllIconsKeys$Expui$General {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/ui/icons/AllIconsKeys$Expui$General;
+	public final fun getAdd ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+	public final fun getChevronDown ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+	public final fun getChevronUp ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+	public final fun getGreenCheckmark ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+}
+
+public final class org/jetbrains/jewel/ui/icons/AllIconsKeys$Expui$Nodes {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/ui/icons/AllIconsKeys$Expui$Nodes;
+	public final fun getDataTables ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+	public final fun getFolder ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+}
+
+public final class org/jetbrains/jewel/ui/icons/AllIconsKeys$Expui$RunConfigurations {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/ui/icons/AllIconsKeys$Expui$RunConfigurations;
+	public final fun getApplication ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+}
+
 public final class org/jetbrains/jewel/ui/icons/AllIconsKeys$FileTypes {
 	public static final field $stable I
 	public static final field INSTANCE Lorg/jetbrains/jewel/ui/icons/AllIconsKeys$FileTypes;
 	public final fun getAS ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+	public final fun getActionScript ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getAddAny ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getAngularJS ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getAny_type ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
@@ -2544,11 +2580,16 @@ public final class org/jetbrains/jewel/ui/icons/AllIconsKeys$General {
 	public final fun getChevronLeft ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getChevronRight ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getChevronUp ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+	public final fun getClose ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+	public final fun getCloseSmall ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+	public final fun getCloseSmallHovered ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getCollapseComponent ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getCollapseComponentHover ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getContextHelp ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+	public final fun getCopy ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getCopyHovered ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getDebugDisabled ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+	public final fun getDelete ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getDivider ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getDrag ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getDropPlace ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
@@ -2561,6 +2602,7 @@ public final class org/jetbrains/jewel/ui/icons/AllIconsKeys$General {
 	public final fun getExclMark ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getExpandComponent ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getExpandComponentHover ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+	public final fun getExport ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getExternalTools ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getFilter ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getFitContent ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
@@ -2570,6 +2612,7 @@ public final class org/jetbrains/jewel/ui/icons/AllIconsKeys$General {
 	public final fun getGreenCheckmark ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getGroups ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getHideToolWindow ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+	public final fun getHistory ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getImplementingMethod ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getInformation ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getInformationDialog ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
@@ -2618,21 +2661,25 @@ public final class org/jetbrains/jewel/ui/icons/AllIconsKeys$General {
 	public final fun getOpenInToolWindow ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getOverridenMethod ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getOverridingMethod ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+	public final fun getPin ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getPinHovered ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getPinSelected ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getPinSelectedHovered ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getPin_tab ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+	public final fun getPreviewHorizontally ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getPrint ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getProjectConfigurable ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getProjectStructure ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getProjectTab ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getQuestionDialog ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getReaderMode ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+	public final fun getRefresh ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getRemove ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getReset ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getRunWithCoverage ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getSeparatorH ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getSettings ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+	public final fun getShow ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getShowInfos ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getShowWarning ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getShow_to_implement ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
@@ -2649,10 +2696,12 @@ public final class org/jetbrains/jewel/ui/icons/AllIconsKeys$General {
 	public final fun getTreeSelected ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getTrialBadge ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getUser ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+	public final fun getVcs ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getWarning ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getWarningDecorator ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getWarningDialog ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getWeb ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+	public final fun getWindowsMenu_20x20 ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getZoomIn ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getZoomOut ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 }
@@ -3032,6 +3081,7 @@ public final class org/jetbrains/jewel/ui/icons/AllIconsKeys$Nodes {
 	public final fun getKeymapOther ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getKeymapTools ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getLambda ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+	public final fun getLibrary ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getLocked ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getLogFolder ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getMethod ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
@@ -3265,6 +3315,9 @@ public final class org/jetbrains/jewel/ui/icons/AllIconsKeys$Run {
 	public final fun getForceRunToCursor ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getForceStepInto ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 	public final fun getForceStepOver ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+	public final fun getRestart ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+	public final fun getShowIgnored ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
+	public final fun getStop ()Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey;
 }
 
 public final class org/jetbrains/jewel/ui/icons/AllIconsKeys$Run$Widget {


### PR DESCRIPTION
The change is important because it means we always use the correct JBR with each IDE version, improving fidelity when running the sample.

Also improves the IJP version detection/validation to be able to handle the fact that IJ versions (used by the IJ Gradle plugin) are in either the '2024.1.4' (stable) or '242.19890.14' (non-stable) format, and platform build numbers (used by the icon generator) are in either the '241.18034.62' (stable) or '242.19890.14-EAP-SNAPSHOT' (non-stable) format.