### PR TITLE
Fix MD code font in dark standalone theme

### DIFF
--- a/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/styling/IntUiMarkdownStyling.kt
+++ b/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/styling/IntUiMarkdownStyling.kt
@@ -83,7 +83,7 @@ public fun MarkdownStyling.Companion.dark(
     paragraph: Paragraph = Paragraph.dark(inlinesStyling),
     heading: Heading = Heading.dark(baseTextStyle),
     blockQuote: BlockQuote = BlockQuote.dark(textColor = baseTextStyle.color),
-    code: Code = Code.dark(baseTextStyle),
+    code: Code = Code.dark(editorTextStyle),
     list: List = List.dark(baseTextStyle),
     image: Image = Image.default(),
     thematicBreak: ThematicBreak = ThematicBreak.dark(),


### PR DESCRIPTION
We were using the default by mistake