### PR TITLE
Fix snapshot publishing version

### DIFF
--- a/buildSrc/src/main/kotlin/jewel-publish.gradle.kts
+++ b/buildSrc/src/main/kotlin/jewel-publish.gradle.kts
@@ -46,7 +46,7 @@ publishing {
             from(components["kotlin"])
             artifact(javadocJar)
             artifact(sourcesJar)
-            version = project.properties["jewel.release.version"] as String
+            version = project.version as String
             artifactId = "jewel-${project.name}-$ijpTarget"
             pom { configureJewelPom() }
         }


### PR DESCRIPTION
We were overwriting published versions by mistake when a snapshot build was created. Two-fold bug: using the wrong version in the repo publishing, and a wrong setting in Space packages allowing for overwriting packages.