### PR TITLE
Minor updates to the build files

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,12 +9,6 @@ val properties = Properties()
 project.file("../gradle.properties").inputStream().use { properties.load(it) }
 
 val jdkLevel = properties.getProperty("jdk.level") as String
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(jdkLevel)
-    }
-}
-
 kotlin {
     jvmToolchain {
         languageVersion = JavaLanguageVersion.of(jdkLevel)

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,9 +1,25 @@
+import java.util.Properties
+
 plugins {
     `kotlin-dsl`
     alias(libs.plugins.kotlinx.serialization)
 }
 
+val properties = Properties()
+project.file("../gradle.properties").inputStream().use { properties.load(it) }
+
+val jdkLevel = properties.getProperty("jdk.level") as String
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(jdkLevel)
+    }
+}
+
 kotlin {
+    jvmToolchain {
+        languageVersion = JavaLanguageVersion.of(jdkLevel)
+    }
+
     sourceSets {
         all {
             languageSettings {

--- a/buildSrc/src/main/kotlin/jewel.gradle.kts
+++ b/buildSrc/src/main/kotlin/jewel.gradle.kts
@@ -19,12 +19,6 @@ version = when {
 }
 
 val jdkLevel = project.property("jdk.level") as String
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(jdkLevel)
-    }
-}
-
 kotlin {
     jvmToolchain {
         languageVersion = JavaLanguageVersion.of(jdkLevel)

--- a/buildSrc/src/main/kotlin/jewel.gradle.kts
+++ b/buildSrc/src/main/kotlin/jewel.gradle.kts
@@ -23,7 +23,6 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(jdkLevel)
     }
-
 }
 
 kotlin {
@@ -86,15 +85,4 @@ configurations.named("sarif") {
         artifact(tasks.detektMain.flatMap { it.sarifReportFile }) { builtBy(tasks.detektMain) }
         artifact(sarifReport) { builtBy(tasks.lintKotlinMain) }
     }
-}
-
-fun Task.removeAssembleDependency() {
-    setDependsOn(
-        dependsOn.filter {
-            when {
-                it is Task && it.name == "assemble" -> false
-                else -> true
-            }
-        }
-    )
 }

--- a/samples/standalone/build.gradle.kts
+++ b/samples/standalone/build.gradle.kts
@@ -21,14 +21,17 @@ dependencies {
     implementation(libs.intellijPlatform.icons)
 }
 
+val jdkLevel = project.property("jdk.level") as String
 java {
     toolchain {
+        languageVersion = JavaLanguageVersion.of(jdkLevel)
         vendor = JvmVendorSpec.JETBRAINS
     }
 }
 
 kotlin {
     jvmToolchain {
+        languageVersion = JavaLanguageVersion.of(jdkLevel)
         vendor = JvmVendorSpec.JETBRAINS
     }
 }
@@ -56,7 +59,6 @@ compose.desktop {
     }
 }
 
-val jdkLevel = project.property("jdk.level") as String
 tasks {
     withType<JavaExec> {
         // afterEvaluate is needed because the Compose Gradle Plugin

--- a/samples/standalone/build.gradle.kts
+++ b/samples/standalone/build.gradle.kts
@@ -22,13 +22,6 @@ dependencies {
 }
 
 val jdkLevel = project.property("jdk.level") as String
-java {
-    toolchain {
-        languageVersion = JavaLanguageVersion.of(jdkLevel)
-        vendor = JvmVendorSpec.JETBRAINS
-    }
-}
-
 kotlin {
     jvmToolchain {
         languageVersion = JavaLanguageVersion.of(jdkLevel)


### PR DESCRIPTION
While I try to figure out what is happening with the IntelliJ Platform Gradle Plugin 2.0[^1], I cleaned up the build scripts a bit. This should ensure that:
1. We use the same major JDK version for buildSrc too
2. We enforce the language version in the standalone sample too (it should come from the Jewel plugin, but it doesn't — possibly because we set a toolchain in the module, too)
3. There are a couple less minor formatting issues than before
4. We have one less unused function


[^1]: For whatever reason, using _any_ JDK 21 as Gradle JVM results in a classloading error at runtime when trying to use any class from the bridge module (but not its transitive dependencies). Even though the code is run with a JDK 21, both in bridge and standalone, Gradle needs to run with a JDK 22 for things to not blow up at runtime.