### PR TITLE
Fix colour keys in bridge

### DIFF
--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/BridgeSliderStyling.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/BridgeSliderStyling.kt
@@ -10,21 +10,21 @@ import org.jetbrains.jewel.ui.component.styling.SliderColors
 import org.jetbrains.jewel.ui.component.styling.SliderMetrics
 
 public fun SliderColors.Companion.light(
-    track: Color = retrieveColorOrUnspecified("ColorPalette.Grey10").takeOrElse { Color(0xFFD3D5DB) },
+    track: Color = retrieveColorOrUnspecified("ColorPalette.Gray10").takeOrElse { Color(0xFFD3D5DB) },
     trackFilled: Color = retrieveColorOrUnspecified("ColorPalette.Blue6").takeOrElse { Color(0xFF588CF3) },
-    trackDisabled: Color = retrieveColorOrUnspecified("ColorPalette.Grey12").takeOrElse { Color(0xFFEBECF0) },
-    trackFilledDisabled: Color = retrieveColorOrUnspecified("ColorPalette.Grey11").takeOrElse { Color(0xFFDFE1E5) },
+    trackDisabled: Color = retrieveColorOrUnspecified("ColorPalette.Gray12").takeOrElse { Color(0xFFEBECF0) },
+    trackFilledDisabled: Color = retrieveColorOrUnspecified("ColorPalette.Gray11").takeOrElse { Color(0xFFDFE1E5) },
     stepMarker: Color = track,
-    thumbFill: Color = retrieveColorOrUnspecified("ColorPalette.Grey14").takeOrElse { Color(0xFFFFFFFF) },
+    thumbFill: Color = retrieveColorOrUnspecified("ColorPalette.Gray14").takeOrElse { Color(0xFFFFFFFF) },
     thumbFillDisabled: Color = thumbFill,
     thumbFillFocused: Color = thumbFill,
     thumbFillPressed: Color = thumbFill,
     thumbFillHovered: Color = thumbFill,
-    thumbBorder: Color = retrieveColorOrUnspecified("ColorPalette.Grey8").takeOrElse { Color(0xFFA8ADBD) },
+    thumbBorder: Color = retrieveColorOrUnspecified("ColorPalette.Gray8").takeOrElse { Color(0xFFA8ADBD) },
     thumbBorderFocused: Color = retrieveColorOrUnspecified("ColorPalette.Blue4").takeOrElse { Color(0xFF3574F0) },
-    thumbBorderDisabled: Color = retrieveColorOrUnspecified("ColorPalette.Grey11").takeOrElse { Color(0xFFDFE1E5) },
-    thumbBorderPressed: Color = retrieveColorOrUnspecified("ColorPalette.Grey7").takeOrElse { Color(0xFF818594) },
-    thumbBorderHovered: Color = retrieveColorOrUnspecified("ColorPalette.Grey9").takeOrElse { Color(0xFFC9CCD6) },
+    thumbBorderDisabled: Color = retrieveColorOrUnspecified("ColorPalette.Gray11").takeOrElse { Color(0xFFDFE1E5) },
+    thumbBorderPressed: Color = retrieveColorOrUnspecified("ColorPalette.Gray7").takeOrElse { Color(0xFF818594) },
+    thumbBorderHovered: Color = retrieveColorOrUnspecified("ColorPalette.Gray9").takeOrElse { Color(0xFFC9CCD6) },
 ): SliderColors =
     SliderColors(
         track,
@@ -45,21 +45,21 @@ public fun SliderColors.Companion.light(
     )
 
 public fun SliderColors.Companion.dark(
-    track: Color = retrieveColorOrUnspecified("ColorPalette.Grey4").takeOrElse { Color(0xFF43454A) },
+    track: Color = retrieveColorOrUnspecified("ColorPalette.Gray4").takeOrElse { Color(0xFF43454A) },
     trackFilled: Color = retrieveColorOrUnspecified("ColorPalette.Blue7").takeOrElse { Color(0xFF467FF2) },
-    trackDisabled: Color = retrieveColorOrUnspecified("ColorPalette.Grey3").takeOrElse { Color(0xFF393B40) },
-    trackFilledDisabled: Color = retrieveColorOrUnspecified("ColorPalette.Grey4").takeOrElse { Color(0xFF43454A) },
+    trackDisabled: Color = retrieveColorOrUnspecified("ColorPalette.Gray3").takeOrElse { Color(0xFF393B40) },
+    trackFilledDisabled: Color = retrieveColorOrUnspecified("ColorPalette.Gray4").takeOrElse { Color(0xFF43454A) },
     stepMarker: Color = track,
-    thumbFill: Color = retrieveColorOrUnspecified("ColorPalette.Grey2").takeOrElse { Color(0xFF2B2D30) },
-    thumbFillDisabled: Color = retrieveColorOrUnspecified("ColorPalette.Grey3").takeOrElse { Color(0xFF393B40) },
+    thumbFill: Color = retrieveColorOrUnspecified("ColorPalette.Gray2").takeOrElse { Color(0xFF2B2D30) },
+    thumbFillDisabled: Color = retrieveColorOrUnspecified("ColorPalette.Gray3").takeOrElse { Color(0xFF393B40) },
     thumbFillFocused: Color = thumbFill,
     thumbFillPressed: Color = thumbFill,
     thumbFillHovered: Color = thumbFill,
-    thumbBorder: Color = retrieveColorOrUnspecified("ColorPalette.Grey7").takeOrElse { Color(0xFF6F737A) },
+    thumbBorder: Color = retrieveColorOrUnspecified("ColorPalette.Gray7").takeOrElse { Color(0xFF6F737A) },
     thumbBorderFocused: Color = retrieveColorOrUnspecified("ColorPalette.Blue6").takeOrElse { Color(0xFF3574F0) },
-    thumbBorderDisabled: Color = retrieveColorOrUnspecified("ColorPalette.Grey5").takeOrElse { Color(0xFF4E5157) },
-    thumbBorderPressed: Color = retrieveColorOrUnspecified("ColorPalette.Grey8").takeOrElse { Color(0xFF868A91) },
-    thumbBorderHovered: Color = retrieveColorOrUnspecified("ColorPalette.Grey9").takeOrElse { Color(0xFF9DA0A8) },
+    thumbBorderDisabled: Color = retrieveColorOrUnspecified("ColorPalette.Gray5").takeOrElse { Color(0xFF4E5157) },
+    thumbBorderPressed: Color = retrieveColorOrUnspecified("ColorPalette.Gray8").takeOrElse { Color(0xFF868A91) },
+    thumbBorderHovered: Color = retrieveColorOrUnspecified("ColorPalette.Gray9").takeOrElse { Color(0xFF9DA0A8) },
 ): SliderColors =
     SliderColors(
         track,

--- a/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/releasessample/ReleaseChannel.kt
+++ b/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/releasessample/ReleaseChannel.kt
@@ -60,16 +60,16 @@ enum class ReleaseChannel(
         background =
             JBColor(
                 // regular =
-                JBColor.namedColor("ColorPalette.Grey12", 0xEBECF0),
+                JBColor.namedColor("ColorPalette.Gray12", 0xEBECF0),
                 // dark  =
-                JBColor.namedColor("ColorPalette.Grey5", 0x4E5157),
+                JBColor.namedColor("ColorPalette.Gray5", 0x4E5157),
             ),
         foreground =
             JBColor(
                 // regular =
-                JBColor.namedColor("ColorPalette.Grey6", 0x6C707E),
+                JBColor.namedColor("ColorPalette.Gray6", 0x6C707E),
                 // dark  =
-                JBColor.namedColor("ColorPalette.Grey10", 0xB4B8BF),
+                JBColor.namedColor("ColorPalette.Gray10", 0xB4B8BF),
             ),
     ),
 }


### PR DESCRIPTION
We had some en-GB key name spelling (Grey) which wasn't found at runtime since the actual palette uses en-US spelling (Gray). This PR fixes it. No issues were present in the standalone version. These cosmetic issues were until now masked by us providing defaults that the code falls back on when it can't load the keys; we had a warning in the logs but I suppose nobody paid attention to them since it all worked anyway 😅 