### PR TITLE
Add Icon action button

### DIFF
--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/component/Buttons.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/component/Buttons.kt
@@ -19,6 +19,8 @@ import org.jetbrains.jewel.ui.component.OutlinedButton
 import org.jetbrains.jewel.ui.component.PlatformIcon
 import org.jetbrains.jewel.ui.component.SelectableIconButton
 import org.jetbrains.jewel.ui.component.Text
+import org.jetbrains.jewel.ui.component.Typography
+import org.jetbrains.jewel.ui.component.styling.IconActionButton
 import org.jetbrains.jewel.ui.component.styling.LocalIconButtonStyle
 import org.jetbrains.jewel.ui.icons.AllIconsKeys
 import org.jetbrains.jewel.ui.painter.hints.Selected
@@ -32,6 +34,7 @@ fun Buttons() {
     ) {
         NormalButtons()
         IconButtons()
+        IconActionButtons()
     }
 }
 
@@ -67,6 +70,8 @@ private fun IconButtons() {
         horizontalArrangement = Arrangement.spacedBy(16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
+        Text("IconButton", style = Typography.h4TextStyle())
+
         Text("Focusable:")
 
         IconButton(onClick = {}) {
@@ -90,5 +95,26 @@ private fun IconButtons() {
                 hints = arrayOf(Selected(selected), Stroke(tint)),
             )
         }
+    }
+}
+
+@Composable
+private fun IconActionButtons() {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text("IconActionButton", style = Typography.h4TextStyle())
+
+        Text("With tooltip:")
+
+        IconActionButton(key = AllIconsKeys.Actions.Copy, contentDescription = "IconButton", onClick = {}) {
+            Text("I am a tooltip")
+        }
+
+        Text("Without tooltip:")
+
+        IconActionButton(key = AllIconsKeys.Actions.Copy, contentDescription = "IconButton", onClick = {})
     }
 }

--- a/ui/api/ui.api
+++ b/ui/api/ui.api
@@ -1219,6 +1219,13 @@ public final class org/jetbrains/jewel/ui/component/styling/HorizontalProgressBa
 	public static final fun getLocalHorizontalProgressBarStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 }
 
+public final class org/jetbrains/jewel/ui/component/styling/IconActionButtonKt {
+	public static final fun IconActionButton (Landroidx/compose/ui/graphics/painter/Painter;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;ZZLorg/jetbrains/jewel/ui/component/styling/IconButtonStyle;Landroidx/compose/foundation/interaction/MutableInteractionSource;Landroidx/compose/runtime/Composer;II)V
+	public static final fun IconActionButton (Landroidx/compose/ui/graphics/painter/Painter;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;ZZLorg/jetbrains/jewel/ui/component/styling/IconButtonStyle;Lorg/jetbrains/jewel/ui/component/styling/TooltipStyle;Landroidx/compose/foundation/TooltipPlacement;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
+	public static final fun IconActionButton (Lorg/jetbrains/jewel/ui/icon/IconKey;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;ZZLorg/jetbrains/jewel/ui/component/styling/IconButtonStyle;Landroidx/compose/foundation/interaction/MutableInteractionSource;Ljava/lang/Class;Landroidx/compose/runtime/Composer;II)V
+	public static final fun IconActionButton (Lorg/jetbrains/jewel/ui/icon/IconKey;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;ZZLorg/jetbrains/jewel/ui/component/styling/IconButtonStyle;Lorg/jetbrains/jewel/ui/component/styling/TooltipStyle;Landroidx/compose/foundation/TooltipPlacement;Landroidx/compose/foundation/interaction/MutableInteractionSource;Ljava/lang/Class;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
+}
+
 public final class org/jetbrains/jewel/ui/component/styling/IconButtonColors {
 	public static final field $stable I
 	public static final field Companion Lorg/jetbrains/jewel/ui/component/styling/IconButtonColors$Companion;

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/styling/IconActionButton.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/styling/IconActionButton.kt
@@ -1,0 +1,180 @@
+/*
+ * Copyright (C) 2024 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jetbrains.jewel.ui.component.styling
+
+import androidx.compose.foundation.TooltipPlacement
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.FixedCursorPoint
+import org.jetbrains.jewel.ui.component.Icon
+import org.jetbrains.jewel.ui.component.IconButton
+import org.jetbrains.jewel.ui.component.Tooltip
+import org.jetbrains.jewel.ui.icon.IconKey
+import org.jetbrains.jewel.ui.theme.iconButtonStyle
+import org.jetbrains.jewel.ui.theme.tooltipStyle
+
+@Composable
+public fun IconActionButton(
+    key: IconKey,
+    contentDescription: String?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    focusable: Boolean = true,
+    style: IconButtonStyle = JewelTheme.iconButtonStyle,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    iconClass: Class<*> = key::class.java,
+) {
+    CoreIconButton(
+        key,
+        contentDescription,
+        iconClass,
+        enabled,
+        focusable,
+        style,
+        interactionSource,
+        modifier,
+        onClick,
+    )
+}
+
+@Composable
+public fun IconActionButton(
+    key: IconKey,
+    contentDescription: String?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    focusable: Boolean = true,
+    style: IconButtonStyle = JewelTheme.iconButtonStyle,
+    tooltipStyle: TooltipStyle = JewelTheme.tooltipStyle,
+    tooltipPlacement: TooltipPlacement = FixedCursorPoint(offset = DpOffset(0.dp, 16.dp)),
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    iconClass: Class<*> = key::class.java,
+    tooltip: @Composable () -> Unit,
+) {
+    Tooltip(
+        tooltip,
+        style = tooltipStyle,
+        tooltipPlacement = tooltipPlacement,
+        modifier = modifier,
+    ) {
+        CoreIconButton(
+            key = key,
+            contentDescription = contentDescription,
+            iconClass = iconClass,
+            enabled = enabled,
+            focusable = focusable,
+            style = style,
+            interactionSource = interactionSource,
+            onClick = onClick,
+        )
+    }
+}
+
+@Composable
+private fun CoreIconButton(
+    key: IconKey,
+    contentDescription: String?,
+    iconClass: Class<*>,
+    enabled: Boolean,
+    focusable: Boolean,
+    style: IconButtonStyle,
+    interactionSource: MutableInteractionSource,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    IconButton(onClick, modifier, enabled, focusable, style, interactionSource) {
+        Icon(key, contentDescription, iconClass = iconClass)
+    }
+}
+
+@Composable
+public fun IconActionButton(
+    painter: Painter,
+    contentDescription: String?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    focusable: Boolean = true,
+    style: IconButtonStyle = JewelTheme.iconButtonStyle,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+) {
+    CoreIconButton(
+        painter,
+        contentDescription,
+        enabled,
+        focusable,
+        style,
+        interactionSource,
+        modifier,
+        onClick,
+    )
+}
+
+@Composable
+public fun IconActionButton(
+    painter: Painter,
+    contentDescription: String?,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    focusable: Boolean = true,
+    style: IconButtonStyle = JewelTheme.iconButtonStyle,
+    tooltipStyle: TooltipStyle = JewelTheme.tooltipStyle,
+    tooltipPlacement: TooltipPlacement = FixedCursorPoint(offset = DpOffset(0.dp, 16.dp)),
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    tooltip: @Composable () -> Unit,
+) {
+    Tooltip(
+        tooltip,
+        style = tooltipStyle,
+        tooltipPlacement = tooltipPlacement,
+        modifier = modifier,
+    ) {
+        CoreIconButton(
+            painter = painter,
+            contentDescription = contentDescription,
+            enabled = enabled,
+            focusable = focusable,
+            style = style,
+            interactionSource = interactionSource,
+            onClick = onClick,
+        )
+    }
+}
+
+@Composable
+private fun CoreIconButton(
+    painter: Painter,
+    contentDescription: String?,
+    enabled: Boolean,
+    focusable: Boolean,
+    style: IconButtonStyle,
+    interactionSource: MutableInteractionSource,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    IconButton(onClick, modifier, enabled, focusable, style, interactionSource) {
+        Icon(painter, contentDescription)
+    }
+}


### PR DESCRIPTION
It's a thin wrapper around IconButton that is slightly easier to use and can also render a tooltip.

Added sample, too (standalone only):

<img width="502" alt="image" src="https://github.com/user-attachments/assets/5d0ca188-50eb-4753-8ab6-ea1ff9964511">
