### PR TITLE
Remove ktlint IJ plugin from required plugins

### DIFF
--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalDependencies">
-    <plugin id="com.nbadal.ktlint" />
     <plugin id="detekt" />
     <plugin id="org.jetbrains.compose.desktop.ide" />
   </component>


### PR DESCRIPTION
While it's nice to get ktlint warnings in the IDE, the ktlint IJ plugin shows an obnoxious editor banner when working on projects where it's not used.

Since we all work on other projects, and because their maintainers are not open to improving the UX, I don't recommend keeping this plugin anymore.