### PR TITLE
Fix menu border width in bridge

### DIFF
--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridge.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridge.kt
@@ -737,7 +737,7 @@ private fun readMenuStyle(): MenuStyle {
                 contentPadding = PaddingValues(horizontal = 0.dp, vertical = 6.dp),
                 offset = DpOffset(0.dp, 2.dp),
                 shadowSize = 12.dp,
-                borderWidth = retrieveIntAsDpOrUnspecified("Popup.borderWidth").takeOrElse { 2.dp },
+                borderWidth = retrieveIntAsDpOrUnspecified("Popup.borderWidth").takeOrElse { 1.dp },
                 itemMetrics =
                     MenuItemMetrics(
                         selectionCornerSize = CornerSize(JBUI.CurrentTheme.PopupMenu.Selection.ARC.dp / 2),


### PR DESCRIPTION
This bug does not affect standalone, only bridge.

 Before | After
 --- | ---
 <img width="185" alt="before: border is too chonk" src="https://github.com/user-attachments/assets/5f02bd3c-e63a-4437-8487-a8188140d1ee"> | <img width="174" alt="after: border fixed" src="https://github.com/user-attachments/assets/12c3163e-aa14-4817-8c43-20edb8e2dcd3">
