### PR TITLE
Be more specific in IDE sample run config

### DIFF
--- a/.idea/runConfigurations/IDE_sample.xml
+++ b/.idea/runConfigurations/IDE_sample.xml
@@ -11,7 +11,7 @@
       </option>
       <option name="taskNames">
         <list>
-          <option value="runIde" />
+          <option value=":samples:ide-plugin:runIde" />
         </list>
       </option>
       <option name="vmOptions" />


### PR DESCRIPTION
This somehow fixes the random `java.lang.NoClassDefFoundError: org/jetbrains/jewel/bridge/ToolWindowExtensionsKt` that we've been seeing on main when using JBR-21 as the project JDK. At least for me.