### PR TITLE
Fix Markdown rendering issues

### DIFF
--- a/markdown/core/api/core.api
+++ b/markdown/core/api/core.api
@@ -1,188 +1,102 @@
-public abstract interface class org/jetbrains/jewel/markdown/BlockWithInlineMarkdown {
-	public abstract fun getInlineContent ()Ljava/lang/Iterable;
-}
-
 public abstract interface class org/jetbrains/jewel/markdown/InlineMarkdown {
-	public abstract fun getChildren ()Ljava/lang/Iterable;
-	public abstract fun getNativeNode ()Lorg/commonmark/node/Node;
 }
 
-public final class org/jetbrains/jewel/markdown/InlineMarkdown$Code : org/jetbrains/jewel/markdown/InlineMarkdown {
-	public static final synthetic fun box-impl (Lorg/commonmark/node/Code;)Lorg/jetbrains/jewel/markdown/InlineMarkdown$Code;
-	public static fun constructor-impl (Lorg/commonmark/node/Code;)Lorg/commonmark/node/Code;
+public final class org/jetbrains/jewel/markdown/InlineMarkdown$Code : org/jetbrains/jewel/markdown/InlineMarkdown, org/jetbrains/jewel/markdown/WithTextContent {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;)V
 	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Lorg/commonmark/node/Code;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Lorg/commonmark/node/Code;Lorg/commonmark/node/Code;)Z
-	public fun getChildren ()Ljava/lang/Iterable;
-	public static fun getChildren-impl (Lorg/commonmark/node/Code;)Ljava/lang/Iterable;
-	public fun getNativeNode ()Lorg/commonmark/node/Code;
-	public synthetic fun getNativeNode ()Lorg/commonmark/node/Node;
+	public fun getContent ()Ljava/lang/String;
 	public fun hashCode ()I
-	public static fun hashCode-impl (Lorg/commonmark/node/Code;)I
 	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Lorg/commonmark/node/Code;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Lorg/commonmark/node/Code;
 }
 
-public final class org/jetbrains/jewel/markdown/InlineMarkdown$CustomNode : org/jetbrains/jewel/markdown/InlineMarkdown {
-	public static final synthetic fun box-impl (Lorg/commonmark/node/CustomNode;)Lorg/jetbrains/jewel/markdown/InlineMarkdown$CustomNode;
-	public static fun constructor-impl (Lorg/commonmark/node/CustomNode;)Lorg/commonmark/node/CustomNode;
+public abstract interface class org/jetbrains/jewel/markdown/InlineMarkdown$CustomNode : org/jetbrains/jewel/markdown/InlineMarkdown {
+	public abstract fun contentOrNull ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/markdown/InlineMarkdown$CustomNode$DefaultImpls {
+	public static fun contentOrNull (Lorg/jetbrains/jewel/markdown/InlineMarkdown$CustomNode;)Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/markdown/InlineMarkdown$Emphasis : org/jetbrains/jewel/markdown/InlineMarkdown, org/jetbrains/jewel/markdown/WithInlineMarkdown {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public fun <init> (Ljava/lang/String;[Lorg/jetbrains/jewel/markdown/InlineMarkdown;)V
 	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Lorg/commonmark/node/CustomNode;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Lorg/commonmark/node/CustomNode;Lorg/commonmark/node/CustomNode;)Z
-	public fun getChildren ()Ljava/lang/Iterable;
-	public static fun getChildren-impl (Lorg/commonmark/node/CustomNode;)Ljava/lang/Iterable;
-	public fun getNativeNode ()Lorg/commonmark/node/CustomNode;
-	public synthetic fun getNativeNode ()Lorg/commonmark/node/Node;
+	public final fun getDelimiter ()Ljava/lang/String;
+	public fun getInlineContent ()Ljava/util/List;
 	public fun hashCode ()I
-	public static fun hashCode-impl (Lorg/commonmark/node/CustomNode;)I
 	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Lorg/commonmark/node/CustomNode;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Lorg/commonmark/node/CustomNode;
-}
-
-public final class org/jetbrains/jewel/markdown/InlineMarkdown$DefaultImpls {
-	public static fun getChildren (Lorg/jetbrains/jewel/markdown/InlineMarkdown;)Ljava/lang/Iterable;
-}
-
-public final class org/jetbrains/jewel/markdown/InlineMarkdown$Emphasis : org/jetbrains/jewel/markdown/InlineMarkdown {
-	public static final synthetic fun box-impl (Lorg/commonmark/node/Emphasis;)Lorg/jetbrains/jewel/markdown/InlineMarkdown$Emphasis;
-	public static fun constructor-impl (Lorg/commonmark/node/Emphasis;)Lorg/commonmark/node/Emphasis;
-	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Lorg/commonmark/node/Emphasis;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Lorg/commonmark/node/Emphasis;Lorg/commonmark/node/Emphasis;)Z
-	public fun getChildren ()Ljava/lang/Iterable;
-	public static fun getChildren-impl (Lorg/commonmark/node/Emphasis;)Ljava/lang/Iterable;
-	public fun getNativeNode ()Lorg/commonmark/node/Emphasis;
-	public synthetic fun getNativeNode ()Lorg/commonmark/node/Node;
-	public fun hashCode ()I
-	public static fun hashCode-impl (Lorg/commonmark/node/Emphasis;)I
-	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Lorg/commonmark/node/Emphasis;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Lorg/commonmark/node/Emphasis;
 }
 
 public final class org/jetbrains/jewel/markdown/InlineMarkdown$HardLineBreak : org/jetbrains/jewel/markdown/InlineMarkdown {
-	public static final synthetic fun box-impl (Lorg/commonmark/node/HardLineBreak;)Lorg/jetbrains/jewel/markdown/InlineMarkdown$HardLineBreak;
-	public static fun constructor-impl (Lorg/commonmark/node/HardLineBreak;)Lorg/commonmark/node/HardLineBreak;
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/markdown/InlineMarkdown$HardLineBreak;
 	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Lorg/commonmark/node/HardLineBreak;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Lorg/commonmark/node/HardLineBreak;Lorg/commonmark/node/HardLineBreak;)Z
-	public fun getChildren ()Ljava/lang/Iterable;
-	public static fun getChildren-impl (Lorg/commonmark/node/HardLineBreak;)Ljava/lang/Iterable;
-	public fun getNativeNode ()Lorg/commonmark/node/HardLineBreak;
-	public synthetic fun getNativeNode ()Lorg/commonmark/node/Node;
 	public fun hashCode ()I
-	public static fun hashCode-impl (Lorg/commonmark/node/HardLineBreak;)I
 	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Lorg/commonmark/node/HardLineBreak;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Lorg/commonmark/node/HardLineBreak;
 }
 
-public final class org/jetbrains/jewel/markdown/InlineMarkdown$HtmlInline : org/jetbrains/jewel/markdown/InlineMarkdown {
-	public static final synthetic fun box-impl (Lorg/commonmark/node/HtmlInline;)Lorg/jetbrains/jewel/markdown/InlineMarkdown$HtmlInline;
-	public static fun constructor-impl (Lorg/commonmark/node/HtmlInline;)Lorg/commonmark/node/HtmlInline;
+public final class org/jetbrains/jewel/markdown/InlineMarkdown$HtmlInline : org/jetbrains/jewel/markdown/InlineMarkdown, org/jetbrains/jewel/markdown/WithTextContent {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;)V
 	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Lorg/commonmark/node/HtmlInline;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Lorg/commonmark/node/HtmlInline;Lorg/commonmark/node/HtmlInline;)Z
-	public fun getChildren ()Ljava/lang/Iterable;
-	public static fun getChildren-impl (Lorg/commonmark/node/HtmlInline;)Ljava/lang/Iterable;
-	public fun getNativeNode ()Lorg/commonmark/node/HtmlInline;
-	public synthetic fun getNativeNode ()Lorg/commonmark/node/Node;
+	public fun getContent ()Ljava/lang/String;
 	public fun hashCode ()I
-	public static fun hashCode-impl (Lorg/commonmark/node/HtmlInline;)I
 	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Lorg/commonmark/node/HtmlInline;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Lorg/commonmark/node/HtmlInline;
 }
 
-public final class org/jetbrains/jewel/markdown/InlineMarkdown$Image : org/jetbrains/jewel/markdown/InlineMarkdown {
-	public static final synthetic fun box-impl (Lorg/commonmark/node/Image;)Lorg/jetbrains/jewel/markdown/InlineMarkdown$Image;
-	public static fun constructor-impl (Lorg/commonmark/node/Image;)Lorg/commonmark/node/Image;
+public final class org/jetbrains/jewel/markdown/InlineMarkdown$Image : org/jetbrains/jewel/markdown/InlineMarkdown, org/jetbrains/jewel/markdown/WithInlineMarkdown {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;[Lorg/jetbrains/jewel/markdown/InlineMarkdown;)V
 	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Lorg/commonmark/node/Image;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Lorg/commonmark/node/Image;Lorg/commonmark/node/Image;)Z
-	public fun getChildren ()Ljava/lang/Iterable;
-	public static fun getChildren-impl (Lorg/commonmark/node/Image;)Ljava/lang/Iterable;
-	public fun getNativeNode ()Lorg/commonmark/node/Image;
-	public synthetic fun getNativeNode ()Lorg/commonmark/node/Node;
+	public final fun getAlt ()Ljava/lang/String;
+	public fun getInlineContent ()Ljava/util/List;
+	public final fun getSource ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
 	public fun hashCode ()I
-	public static fun hashCode-impl (Lorg/commonmark/node/Image;)I
 	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Lorg/commonmark/node/Image;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Lorg/commonmark/node/Image;
 }
 
-public final class org/jetbrains/jewel/markdown/InlineMarkdown$Link : org/jetbrains/jewel/markdown/InlineMarkdown {
-	public static final synthetic fun box-impl (Lorg/commonmark/node/Link;)Lorg/jetbrains/jewel/markdown/InlineMarkdown$Link;
-	public static fun constructor-impl (Lorg/commonmark/node/Link;)Lorg/commonmark/node/Link;
+public final class org/jetbrains/jewel/markdown/InlineMarkdown$Link : org/jetbrains/jewel/markdown/InlineMarkdown, org/jetbrains/jewel/markdown/WithInlineMarkdown {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;[Lorg/jetbrains/jewel/markdown/InlineMarkdown;)V
 	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Lorg/commonmark/node/Link;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Lorg/commonmark/node/Link;Lorg/commonmark/node/Link;)Z
-	public fun getChildren ()Ljava/lang/Iterable;
-	public static fun getChildren-impl (Lorg/commonmark/node/Link;)Ljava/lang/Iterable;
-	public fun getNativeNode ()Lorg/commonmark/node/Link;
-	public synthetic fun getNativeNode ()Lorg/commonmark/node/Node;
+	public final fun getDestination ()Ljava/lang/String;
+	public fun getInlineContent ()Ljava/util/List;
+	public final fun getTitle ()Ljava/lang/String;
 	public fun hashCode ()I
-	public static fun hashCode-impl (Lorg/commonmark/node/Link;)I
 	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Lorg/commonmark/node/Link;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Lorg/commonmark/node/Link;
 }
 
 public final class org/jetbrains/jewel/markdown/InlineMarkdown$SoftLineBreak : org/jetbrains/jewel/markdown/InlineMarkdown {
-	public static final synthetic fun box-impl (Lorg/commonmark/node/SoftLineBreak;)Lorg/jetbrains/jewel/markdown/InlineMarkdown$SoftLineBreak;
-	public static fun constructor-impl (Lorg/commonmark/node/SoftLineBreak;)Lorg/commonmark/node/SoftLineBreak;
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/markdown/InlineMarkdown$SoftLineBreak;
 	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Lorg/commonmark/node/SoftLineBreak;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Lorg/commonmark/node/SoftLineBreak;Lorg/commonmark/node/SoftLineBreak;)Z
-	public fun getChildren ()Ljava/lang/Iterable;
-	public static fun getChildren-impl (Lorg/commonmark/node/SoftLineBreak;)Ljava/lang/Iterable;
-	public synthetic fun getNativeNode ()Lorg/commonmark/node/Node;
-	public fun getNativeNode ()Lorg/commonmark/node/SoftLineBreak;
 	public fun hashCode ()I
-	public static fun hashCode-impl (Lorg/commonmark/node/SoftLineBreak;)I
 	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Lorg/commonmark/node/SoftLineBreak;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Lorg/commonmark/node/SoftLineBreak;
 }
 
-public final class org/jetbrains/jewel/markdown/InlineMarkdown$StrongEmphasis : org/jetbrains/jewel/markdown/InlineMarkdown {
-	public static final synthetic fun box-impl (Lorg/commonmark/node/StrongEmphasis;)Lorg/jetbrains/jewel/markdown/InlineMarkdown$StrongEmphasis;
-	public static fun constructor-impl (Lorg/commonmark/node/StrongEmphasis;)Lorg/commonmark/node/StrongEmphasis;
+public final class org/jetbrains/jewel/markdown/InlineMarkdown$StrongEmphasis : org/jetbrains/jewel/markdown/InlineMarkdown, org/jetbrains/jewel/markdown/WithInlineMarkdown {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public fun <init> (Ljava/lang/String;[Lorg/jetbrains/jewel/markdown/InlineMarkdown;)V
 	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Lorg/commonmark/node/StrongEmphasis;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Lorg/commonmark/node/StrongEmphasis;Lorg/commonmark/node/StrongEmphasis;)Z
-	public fun getChildren ()Ljava/lang/Iterable;
-	public static fun getChildren-impl (Lorg/commonmark/node/StrongEmphasis;)Ljava/lang/Iterable;
-	public synthetic fun getNativeNode ()Lorg/commonmark/node/Node;
-	public fun getNativeNode ()Lorg/commonmark/node/StrongEmphasis;
+	public final fun getDelimiter ()Ljava/lang/String;
+	public fun getInlineContent ()Ljava/util/List;
 	public fun hashCode ()I
-	public static fun hashCode-impl (Lorg/commonmark/node/StrongEmphasis;)I
 	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Lorg/commonmark/node/StrongEmphasis;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Lorg/commonmark/node/StrongEmphasis;
 }
 
-public final class org/jetbrains/jewel/markdown/InlineMarkdown$Text : org/jetbrains/jewel/markdown/InlineMarkdown {
-	public static final synthetic fun box-impl (Lorg/commonmark/node/Text;)Lorg/jetbrains/jewel/markdown/InlineMarkdown$Text;
-	public static fun constructor-impl (Lorg/commonmark/node/Text;)Lorg/commonmark/node/Text;
+public final class org/jetbrains/jewel/markdown/InlineMarkdown$Text : org/jetbrains/jewel/markdown/InlineMarkdown, org/jetbrains/jewel/markdown/WithTextContent {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;)V
 	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Lorg/commonmark/node/Text;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Lorg/commonmark/node/Text;Lorg/commonmark/node/Text;)Z
-	public fun getChildren ()Ljava/lang/Iterable;
-	public static fun getChildren-impl (Lorg/commonmark/node/Text;)Ljava/lang/Iterable;
-	public synthetic fun getNativeNode ()Lorg/commonmark/node/Node;
-	public fun getNativeNode ()Lorg/commonmark/node/Text;
+	public fun getContent ()Ljava/lang/String;
 	public fun hashCode ()I
-	public static fun hashCode-impl (Lorg/commonmark/node/Text;)I
 	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Lorg/commonmark/node/Text;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Lorg/commonmark/node/Text;
-}
-
-public final class org/jetbrains/jewel/markdown/InlineMarkdownKt {
-	public static final fun toInlineNode (Lorg/commonmark/node/Node;)Lorg/jetbrains/jewel/markdown/InlineMarkdown;
 }
 
 public abstract interface class org/jetbrains/jewel/markdown/MarkdownBlock {
@@ -191,9 +105,7 @@ public abstract interface class org/jetbrains/jewel/markdown/MarkdownBlock {
 public final class org/jetbrains/jewel/markdown/MarkdownBlock$BlockQuote : org/jetbrains/jewel/markdown/MarkdownBlock {
 	public static final field $stable I
 	public fun <init> (Ljava/util/List;)V
-	public final fun component1 ()Ljava/util/List;
-	public final fun copy (Ljava/util/List;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$BlockQuote;
-	public static synthetic fun copy$default (Lorg/jetbrains/jewel/markdown/MarkdownBlock$BlockQuote;Ljava/util/List;ILjava/lang/Object;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$BlockQuote;
+	public fun <init> ([Lorg/jetbrains/jewel/markdown/MarkdownBlock;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
@@ -207,10 +119,6 @@ public abstract interface class org/jetbrains/jewel/markdown/MarkdownBlock$CodeB
 public final class org/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$FencedCodeBlock : org/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock {
 	public static final field $stable I
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2-EIRQHX8 ()Ljava/lang/String;
-	public final fun copy-k5OzbWQ (Ljava/lang/String;Ljava/lang/String;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$FencedCodeBlock;
-	public static synthetic fun copy-k5OzbWQ$default (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$FencedCodeBlock;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$FencedCodeBlock;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getContent ()Ljava/lang/String;
 	public final fun getMimeType-EIRQHX8 ()Ljava/lang/String;
@@ -221,9 +129,6 @@ public final class org/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$FencedCo
 public final class org/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$IndentedCodeBlock : org/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock {
 	public static final field $stable I
 	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$IndentedCodeBlock;
-	public static synthetic fun copy$default (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$IndentedCodeBlock;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$IndentedCodeBlock;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getContent ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -233,28 +138,20 @@ public final class org/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$Indented
 public abstract interface class org/jetbrains/jewel/markdown/MarkdownBlock$CustomBlock : org/jetbrains/jewel/markdown/MarkdownBlock {
 }
 
-public final class org/jetbrains/jewel/markdown/MarkdownBlock$Heading : org/jetbrains/jewel/markdown/BlockWithInlineMarkdown, org/jetbrains/jewel/markdown/MarkdownBlock {
-	public static final synthetic fun box-impl (Lorg/commonmark/node/Heading;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$Heading;
-	public static fun constructor-impl (Lorg/commonmark/node/Heading;)Lorg/commonmark/node/Heading;
+public final class org/jetbrains/jewel/markdown/MarkdownBlock$Heading : org/jetbrains/jewel/markdown/MarkdownBlock, org/jetbrains/jewel/markdown/WithInlineMarkdown {
+	public static final field $stable I
+	public fun <init> (I[Lorg/jetbrains/jewel/markdown/InlineMarkdown;)V
+	public fun <init> (Ljava/util/List;I)V
 	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Lorg/commonmark/node/Heading;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Lorg/commonmark/node/Heading;Lorg/commonmark/node/Heading;)Z
-	public fun getInlineContent ()Ljava/lang/Iterable;
-	public static fun getInlineContent-impl (Lorg/commonmark/node/Heading;)Ljava/lang/Iterable;
-	public static final fun getLevel-impl (Lorg/commonmark/node/Heading;)I
+	public fun getInlineContent ()Ljava/util/List;
+	public final fun getLevel ()I
 	public fun hashCode ()I
-	public static fun hashCode-impl (Lorg/commonmark/node/Heading;)I
 	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Lorg/commonmark/node/Heading;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Lorg/commonmark/node/Heading;
 }
 
 public final class org/jetbrains/jewel/markdown/MarkdownBlock$HtmlBlock : org/jetbrains/jewel/markdown/MarkdownBlock {
 	public static final field $stable I
 	public fun <init> (Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$HtmlBlock;
-	public static synthetic fun copy$default (Lorg/jetbrains/jewel/markdown/MarkdownBlock$HtmlBlock;Ljava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$HtmlBlock;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getContent ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -269,12 +166,7 @@ public abstract interface class org/jetbrains/jewel/markdown/MarkdownBlock$ListB
 public final class org/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$OrderedList : org/jetbrains/jewel/markdown/MarkdownBlock$ListBlock {
 	public static final field $stable I
 	public fun <init> (Ljava/util/List;ZILjava/lang/String;)V
-	public final fun component1 ()Ljava/util/List;
-	public final fun component2 ()Z
-	public final fun component3 ()I
-	public final fun component4 ()Ljava/lang/String;
-	public final fun copy (Ljava/util/List;ZILjava/lang/String;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$OrderedList;
-	public static synthetic fun copy$default (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$OrderedList;Ljava/util/List;ZILjava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$OrderedList;
+	public fun <init> (ZILjava/lang/String;[Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListItem;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
 	public final fun getDelimiter ()Ljava/lang/String;
@@ -287,11 +179,7 @@ public final class org/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$OrderedL
 public final class org/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$UnorderedList : org/jetbrains/jewel/markdown/MarkdownBlock$ListBlock {
 	public static final field $stable I
 	public fun <init> (Ljava/util/List;ZLjava/lang/String;)V
-	public final fun component1 ()Ljava/util/List;
-	public final fun component2 ()Z
-	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/util/List;ZLjava/lang/String;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$UnorderedList;
-	public static synthetic fun copy$default (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$UnorderedList;Ljava/util/List;ZLjava/lang/String;ILjava/lang/Object;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$UnorderedList;
+	public fun <init> (ZLjava/lang/String;[Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListItem;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChildren ()Ljava/util/List;
 	public final fun getMarker ()Ljava/lang/String;
@@ -303,33 +191,29 @@ public final class org/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$Unordere
 public final class org/jetbrains/jewel/markdown/MarkdownBlock$ListItem : org/jetbrains/jewel/markdown/MarkdownBlock {
 	public static final field $stable I
 	public fun <init> (Ljava/util/List;)V
-	public final fun component1 ()Ljava/util/List;
-	public final fun copy (Ljava/util/List;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListItem;
-	public static synthetic fun copy$default (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListItem;Ljava/util/List;ILjava/lang/Object;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListItem;
+	public fun <init> ([Lorg/jetbrains/jewel/markdown/MarkdownBlock;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChildren ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class org/jetbrains/jewel/markdown/MarkdownBlock$Paragraph : org/jetbrains/jewel/markdown/BlockWithInlineMarkdown, org/jetbrains/jewel/markdown/MarkdownBlock {
-	public static final synthetic fun box-impl (Lorg/commonmark/node/Paragraph;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$Paragraph;
-	public static fun constructor-impl (Lorg/commonmark/node/Paragraph;)Lorg/commonmark/node/Paragraph;
+public final class org/jetbrains/jewel/markdown/MarkdownBlock$Paragraph : org/jetbrains/jewel/markdown/MarkdownBlock, org/jetbrains/jewel/markdown/WithInlineMarkdown {
+	public static final field $stable I
+	public fun <init> (Ljava/util/List;)V
+	public fun <init> ([Lorg/jetbrains/jewel/markdown/InlineMarkdown;)V
 	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Lorg/commonmark/node/Paragraph;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Lorg/commonmark/node/Paragraph;Lorg/commonmark/node/Paragraph;)Z
-	public fun getInlineContent ()Ljava/lang/Iterable;
-	public static fun getInlineContent-impl (Lorg/commonmark/node/Paragraph;)Ljava/lang/Iterable;
+	public fun getInlineContent ()Ljava/util/List;
 	public fun hashCode ()I
-	public static fun hashCode-impl (Lorg/commonmark/node/Paragraph;)I
 	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Lorg/commonmark/node/Paragraph;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Lorg/commonmark/node/Paragraph;
 }
 
 public final class org/jetbrains/jewel/markdown/MarkdownBlock$ThematicBreak : org/jetbrains/jewel/markdown/MarkdownBlock {
 	public static final field $stable I
 	public static final field INSTANCE Lorg/jetbrains/jewel/markdown/MarkdownBlock$ThematicBreak;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class org/jetbrains/jewel/markdown/MarkdownKt {
@@ -413,6 +297,14 @@ public final class org/jetbrains/jewel/markdown/SemanticsKt {
 	public static final fun setRawMarkdown (Landroidx/compose/ui/semantics/SemanticsPropertyReceiver;Ljava/lang/String;)V
 }
 
+public abstract interface class org/jetbrains/jewel/markdown/WithInlineMarkdown {
+	public abstract fun getInlineContent ()Ljava/util/List;
+}
+
+public abstract interface class org/jetbrains/jewel/markdown/WithTextContent {
+	public abstract fun getContent ()Ljava/lang/String;
+}
+
 public abstract interface class org/jetbrains/jewel/markdown/extensions/MarkdownBlockProcessorExtension {
 	public abstract fun canProcess (Lorg/commonmark/node/CustomBlock;)Z
 	public abstract fun processMarkdownBlock (Lorg/commonmark/node/CustomBlock;Lorg/jetbrains/jewel/markdown/processing/MarkdownProcessor;)Lorg/jetbrains/jewel/markdown/MarkdownBlock$CustomBlock;
@@ -421,6 +313,11 @@ public abstract interface class org/jetbrains/jewel/markdown/extensions/Markdown
 public abstract interface class org/jetbrains/jewel/markdown/extensions/MarkdownBlockRendererExtension {
 	public abstract fun canRender (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CustomBlock;)Z
 	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CustomBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Lorg/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+}
+
+public abstract interface class org/jetbrains/jewel/markdown/extensions/MarkdownInlineProcessorExtension {
+	public abstract fun canProcess (Lorg/commonmark/node/CustomNode;)Z
+	public abstract fun processInlineMarkdown (Lorg/commonmark/node/CustomNode;Lorg/jetbrains/jewel/markdown/processing/MarkdownProcessor;)Lorg/jetbrains/jewel/markdown/InlineMarkdown$CustomNode;
 }
 
 public final class org/jetbrains/jewel/markdown/extensions/MarkdownKt {
@@ -433,9 +330,17 @@ public final class org/jetbrains/jewel/markdown/extensions/MarkdownKt {
 }
 
 public abstract interface class org/jetbrains/jewel/markdown/extensions/MarkdownProcessorExtension {
+	public abstract fun getBlockProcessorExtension ()Lorg/jetbrains/jewel/markdown/extensions/MarkdownBlockProcessorExtension;
+	public abstract fun getInlineProcessorExtension ()Lorg/jetbrains/jewel/markdown/extensions/MarkdownInlineProcessorExtension;
 	public abstract fun getParserExtension ()Lorg/commonmark/parser/Parser$ParserExtension;
-	public abstract fun getProcessorExtension ()Lorg/jetbrains/jewel/markdown/extensions/MarkdownBlockProcessorExtension;
 	public abstract fun getTextRendererExtension ()Lorg/commonmark/renderer/text/TextContentRenderer$TextContentRendererExtension;
+}
+
+public final class org/jetbrains/jewel/markdown/extensions/MarkdownProcessorExtension$DefaultImpls {
+	public static fun getBlockProcessorExtension (Lorg/jetbrains/jewel/markdown/extensions/MarkdownProcessorExtension;)Lorg/jetbrains/jewel/markdown/extensions/MarkdownBlockProcessorExtension;
+	public static fun getInlineProcessorExtension (Lorg/jetbrains/jewel/markdown/extensions/MarkdownProcessorExtension;)Lorg/jetbrains/jewel/markdown/extensions/MarkdownInlineProcessorExtension;
+	public static fun getParserExtension (Lorg/jetbrains/jewel/markdown/extensions/MarkdownProcessorExtension;)Lorg/commonmark/parser/Parser$ParserExtension;
+	public static fun getTextRendererExtension (Lorg/jetbrains/jewel/markdown/extensions/MarkdownProcessorExtension;)Lorg/commonmark/renderer/text/TextContentRenderer$TextContentRendererExtension;
 }
 
 public abstract interface class org/jetbrains/jewel/markdown/extensions/MarkdownRendererExtension {
@@ -454,8 +359,6 @@ public final class org/jetbrains/jewel/markdown/processing/MarkdownProcessor {
 	public fun <init> ()V
 	public fun <init> (Ljava/util/List;ZLorg/commonmark/parser/Parser;)V
 	public synthetic fun <init> (Ljava/util/List;ZLorg/commonmark/parser/Parser;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun <init> (Z[Lorg/jetbrains/jewel/markdown/extensions/MarkdownProcessorExtension;)V
-	public synthetic fun <init> (Z[Lorg/jetbrains/jewel/markdown/extensions/MarkdownProcessorExtension;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun processChildren (Lorg/commonmark/node/Node;)Ljava/util/List;
 	public final fun processMarkdownDocument (Ljava/lang/String;)Ljava/util/List;
 }
@@ -480,15 +383,15 @@ public class org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer
 	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$FencedCodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code$Fenced;Landroidx/compose/runtime/Composer;I)V
 	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$IndentedCodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code$Indented;Landroidx/compose/runtime/Composer;I)V
 	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading$HN;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$HtmlBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$HtmlBlock;Landroidx/compose/runtime/Composer;I)V
 	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$OrderedList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Ordered;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$UnorderedList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Unordered;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListItem;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Paragraph;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Paragraph;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public fun render-EPtGD7Q (Lorg/commonmark/node/Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading$HN;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public fun render-EPtGD7Q (Lorg/commonmark/node/Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public fun render-VUzZlgQ (Lorg/commonmark/node/Paragraph;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Paragraph;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public fun renderThematicBreak (Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$ThematicBreak;Landroidx/compose/runtime/Composer;I)V
 }
 
@@ -522,6 +425,7 @@ public final class org/jetbrains/jewel/markdown/rendering/InlinesStyling {
 	public final fun getLinkVisited ()Landroidx/compose/ui/text/SpanStyle;
 	public final fun getRenderInlineHtml ()Z
 	public final fun getStrongEmphasis ()Landroidx/compose/ui/text/SpanStyle;
+	public final fun getTextLinkStyles ()Landroidx/compose/ui/text/TextLinkStyles;
 	public final fun getTextStyle ()Landroidx/compose/ui/text/TextStyle;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -537,15 +441,15 @@ public abstract interface class org/jetbrains/jewel/markdown/rendering/MarkdownB
 	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$FencedCodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code$Fenced;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$IndentedCodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code$Indented;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Code;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading$HN;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$HtmlBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$HtmlBlock;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$OrderedList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Ordered;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock$UnorderedList;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List$Unordered;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListBlock;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$List;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$ListItem;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock$Paragraph;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Paragraph;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun render (Lorg/jetbrains/jewel/markdown/MarkdownBlock;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render-EPtGD7Q (Lorg/commonmark/node/Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading$HN;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render-EPtGD7Q (Lorg/commonmark/node/Heading;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Heading;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
-	public abstract fun render-VUzZlgQ (Lorg/commonmark/node/Paragraph;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$Paragraph;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun renderThematicBreak (Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling$ThematicBreak;Landroidx/compose/runtime/Composer;I)V
 }
 

--- a/markdown/core/api/core.api
+++ b/markdown/core/api/core.api
@@ -320,6 +320,11 @@ public abstract interface class org/jetbrains/jewel/markdown/extensions/Markdown
 	public abstract fun processInlineMarkdown (Lorg/commonmark/node/CustomNode;Lorg/jetbrains/jewel/markdown/processing/MarkdownProcessor;)Lorg/jetbrains/jewel/markdown/InlineMarkdown$CustomNode;
 }
 
+public abstract interface class org/jetbrains/jewel/markdown/extensions/MarkdownInlineRendererExtension {
+	public abstract fun canRender (Lorg/jetbrains/jewel/markdown/InlineMarkdown$CustomNode;)Z
+	public abstract fun render (Lorg/jetbrains/jewel/markdown/InlineMarkdown$CustomNode;Lorg/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer;Z)V
+}
+
 public final class org/jetbrains/jewel/markdown/extensions/MarkdownKt {
 	public static final fun getLocalMarkdownBlockRenderer ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 	public static final fun getLocalMarkdownProcessor ()Landroidx/compose/runtime/ProvidableCompositionLocal;
@@ -345,6 +350,12 @@ public final class org/jetbrains/jewel/markdown/extensions/MarkdownProcessorExte
 
 public abstract interface class org/jetbrains/jewel/markdown/extensions/MarkdownRendererExtension {
 	public abstract fun getBlockRenderer ()Lorg/jetbrains/jewel/markdown/extensions/MarkdownBlockRendererExtension;
+	public abstract fun getInlineRenderer ()Lorg/jetbrains/jewel/markdown/extensions/MarkdownInlineRendererExtension;
+}
+
+public final class org/jetbrains/jewel/markdown/extensions/MarkdownRendererExtension$DefaultImpls {
+	public static fun getBlockRenderer (Lorg/jetbrains/jewel/markdown/extensions/MarkdownRendererExtension;)Lorg/jetbrains/jewel/markdown/extensions/MarkdownBlockRendererExtension;
+	public static fun getInlineRenderer (Lorg/jetbrains/jewel/markdown/extensions/MarkdownRendererExtension;)Lorg/jetbrains/jewel/markdown/extensions/MarkdownInlineRendererExtension;
 }
 
 public final class org/jetbrains/jewel/markdown/processing/MarkdownParserFactory {
@@ -367,7 +378,6 @@ public class org/jetbrains/jewel/markdown/rendering/DefaultInlineMarkdownRendere
 	public static final field $stable I
 	public static final field Companion Lorg/jetbrains/jewel/markdown/rendering/DefaultInlineMarkdownRenderer$Companion;
 	public fun <init> (Ljava/util/List;)V
-	public fun <init> ([Lorg/jetbrains/jewel/markdown/extensions/MarkdownProcessorExtension;)V
 	public fun renderAsAnnotatedString (Ljava/lang/Iterable;Lorg/jetbrains/jewel/markdown/rendering/InlinesStyling;ZLkotlin/jvm/functions/Function1;)Landroidx/compose/ui/text/AnnotatedString;
 }
 
@@ -396,13 +406,7 @@ public class org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer
 }
 
 public abstract interface class org/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer {
-	public static final field Companion Lorg/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer$Companion;
 	public abstract fun renderAsAnnotatedString (Ljava/lang/Iterable;Lorg/jetbrains/jewel/markdown/rendering/InlinesStyling;ZLkotlin/jvm/functions/Function1;)Landroidx/compose/ui/text/AnnotatedString;
-}
-
-public final class org/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer$Companion {
-	public final fun default (Ljava/util/List;)Lorg/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer;
-	public static synthetic fun default$default (Lorg/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer$Companion;Ljava/util/List;ILjava/lang/Object;)Lorg/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer;
 }
 
 public final class org/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer$DefaultImpls {

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/InlineMarkdown.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/InlineMarkdown.kt
@@ -1,96 +1,80 @@
 package org.jetbrains.jewel.markdown
 
-import org.commonmark.node.Node
-import org.jetbrains.jewel.markdown.InlineMarkdown.Code
-import org.jetbrains.jewel.markdown.InlineMarkdown.CustomNode
-import org.jetbrains.jewel.markdown.InlineMarkdown.Emphasis
-import org.jetbrains.jewel.markdown.InlineMarkdown.HardLineBreak
-import org.jetbrains.jewel.markdown.InlineMarkdown.HtmlInline
-import org.jetbrains.jewel.markdown.InlineMarkdown.Image
-import org.jetbrains.jewel.markdown.InlineMarkdown.Link
-import org.jetbrains.jewel.markdown.InlineMarkdown.SoftLineBreak
-import org.jetbrains.jewel.markdown.InlineMarkdown.StrongEmphasis
-import org.jetbrains.jewel.markdown.InlineMarkdown.Text
-import org.commonmark.node.Code as CMCode
-import org.commonmark.node.CustomNode as CMCustomNode
-import org.commonmark.node.Emphasis as CMEmphasis
-import org.commonmark.node.HardLineBreak as CMHardLineBreak
-import org.commonmark.node.HtmlInline as CMHtmlInline
-import org.commonmark.node.Image as CMImage
-import org.commonmark.node.Link as CMLink
-import org.commonmark.node.SoftLineBreak as CMSoftLineBreak
-import org.commonmark.node.StrongEmphasis as CMStrongEmphasis
-import org.commonmark.node.Text as CMText
+import org.jetbrains.jewel.foundation.GenerateDataFunctions
 
 /**
  * A run of inline Markdown used as content for
  * [block-level elements][MarkdownBlock].
  */
 public sealed interface InlineMarkdown {
-    public val nativeNode: Node
+    @GenerateDataFunctions
+    public class Code(override val content: String) : InlineMarkdown, WithTextContent
 
-    @JvmInline
-    public value class Code(override val nativeNode: CMCode) : InlineMarkdown
-
-    @JvmInline
-    public value class CustomNode(override val nativeNode: CMCustomNode) : InlineMarkdown
-
-    @JvmInline
-    public value class Emphasis(override val nativeNode: CMEmphasis) : InlineMarkdown
-
-    @JvmInline
-    public value class HardLineBreak(override val nativeNode: CMHardLineBreak) : InlineMarkdown
-
-    @JvmInline
-    public value class HtmlInline(override val nativeNode: CMHtmlInline) : InlineMarkdown
-
-    @JvmInline
-    public value class Image(override val nativeNode: CMImage) : InlineMarkdown
-
-    @JvmInline
-    public value class Link(override val nativeNode: CMLink) : InlineMarkdown
-
-    @JvmInline
-    public value class SoftLineBreak(override val nativeNode: CMSoftLineBreak) : InlineMarkdown
-
-    @JvmInline
-    public value class StrongEmphasis(override val nativeNode: CMStrongEmphasis) : InlineMarkdown
-
-    @JvmInline
-    public value class Text(override val nativeNode: CMText) : InlineMarkdown
-
-    public val children: Iterable<InlineMarkdown>
-        get() =
-            object : Iterable<InlineMarkdown> {
-                override fun iterator(): Iterator<InlineMarkdown> =
-                    object : Iterator<InlineMarkdown> {
-                        var current = this@InlineMarkdown.nativeNode.firstChild
-
-                        override fun hasNext(): Boolean = current != null
-
-                        override fun next(): InlineMarkdown =
-                            if (hasNext()) {
-                                current.toInlineNode().also {
-                                    current = current.next
-                                }
-                            } else {
-                                throw NoSuchElementException()
-                            }
-                    }
-            }
-}
-
-public fun Node.toInlineNode(): InlineMarkdown =
-    when (this) {
-        is CMText -> Text(this)
-        is CMLink -> Link(this)
-        is CMEmphasis -> Emphasis(this)
-        is CMStrongEmphasis -> StrongEmphasis(this)
-        is CMCode -> Code(this)
-        is CMHtmlInline -> HtmlInline(this)
-        is CMImage -> Image(this)
-        is CMHardLineBreak -> HardLineBreak(this)
-        is CMSoftLineBreak -> SoftLineBreak(this)
-        is CMCustomNode -> CustomNode(this)
-        else -> error("Unexpected block $this")
+    public interface CustomNode : InlineMarkdown {
+        /**
+         * If this custom node has a text-based representation, this function
+         * should return it. Otherwise, it should return null.
+         */
+        public fun contentOrNull(): String? = null
     }
+
+    @GenerateDataFunctions
+    public class Emphasis(
+        public val delimiter: String,
+        override val inlineContent: List<InlineMarkdown>,
+    ) : InlineMarkdown, WithInlineMarkdown {
+        public constructor(
+            delimiter: String,
+            vararg inlineContent: InlineMarkdown,
+        ) : this(delimiter, inlineContent.toList())
+    }
+
+    public data object HardLineBreak : InlineMarkdown
+
+    @GenerateDataFunctions
+    public class HtmlInline(override val content: String) : InlineMarkdown, WithTextContent
+
+    @GenerateDataFunctions
+    public class Image(
+        public val source: String,
+        public val alt: String,
+        public val title: String?,
+        override val inlineContent: List<InlineMarkdown>,
+    ) : InlineMarkdown, WithInlineMarkdown {
+        public constructor(
+            source: String,
+            alt: String,
+            title: String?,
+            vararg inlineContent: InlineMarkdown,
+        ) : this(source, alt, title, inlineContent.toList())
+    }
+
+    @GenerateDataFunctions
+    public class Link(
+        public val destination: String,
+        public val title: String?,
+        override val inlineContent: List<InlineMarkdown>,
+    ) : InlineMarkdown, WithInlineMarkdown {
+        public constructor(
+            destination: String,
+            title: String?,
+            vararg inlineContent: InlineMarkdown,
+        ) : this(destination, title, inlineContent.toList())
+    }
+
+    public data object SoftLineBreak : InlineMarkdown
+
+    @GenerateDataFunctions
+    public class StrongEmphasis(
+        public val delimiter: String,
+        override val inlineContent: List<InlineMarkdown>,
+    ) : InlineMarkdown, WithInlineMarkdown {
+        public constructor(
+            delimiter: String,
+            vararg inlineContent: InlineMarkdown,
+        ) : this(delimiter, inlineContent.toList())
+    }
+
+    @GenerateDataFunctions
+    public class Text(override val content: String) : InlineMarkdown, WithTextContent
+}

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/MarkdownBlock.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/MarkdownBlock.kt
@@ -1,80 +1,79 @@
 package org.jetbrains.jewel.markdown
 
 import org.commonmark.node.Block
-import org.commonmark.node.Heading as CMHeading
-import org.commonmark.node.Paragraph as CMParagraph
+import org.jetbrains.jewel.foundation.GenerateDataFunctions
+import org.jetbrains.jewel.foundation.InternalJewelApi
 
 public sealed interface MarkdownBlock {
-    public data class BlockQuote(val children: List<MarkdownBlock>) : MarkdownBlock
+
+    @GenerateDataFunctions
+    public class BlockQuote(public val children: List<MarkdownBlock>) : MarkdownBlock
 
     public sealed interface CodeBlock : MarkdownBlock {
         public val content: String
 
-        public data class IndentedCodeBlock(
-            override val content: String,
-        ) : CodeBlock
+        @GenerateDataFunctions
+        public class IndentedCodeBlock(override val content: String) : CodeBlock
 
-        public data class FencedCodeBlock(
+        @GenerateDataFunctions
+        public class FencedCodeBlock(
             override val content: String,
-            val mimeType: MimeType?,
+            public val mimeType: MimeType?,
         ) : CodeBlock
     }
 
     public interface CustomBlock : MarkdownBlock
 
-    @JvmInline
-    public value class Heading(
-        private val nativeBlock: CMHeading,
-    ) : MarkdownBlock, BlockWithInlineMarkdown {
-        override val inlineContent: Iterable<InlineMarkdown>
-            get() = nativeBlock.inlineContent()
+    @GenerateDataFunctions
+    public class Heading(
+        override val inlineContent: List<InlineMarkdown>,
+        public val level: Int,
+    ) : MarkdownBlock, BlockWithInlineMarkdown
 
-        public val level: Int
-            get() = nativeBlock.level
-    }
-
-    public data class HtmlBlock(val content: String) : MarkdownBlock
+    @GenerateDataFunctions
+    public class HtmlBlock(public val content: String) : MarkdownBlock
 
     public sealed interface ListBlock : MarkdownBlock {
         public val children: List<ListItem>
         public val isTight: Boolean
 
-        public data class OrderedList(
+        @GenerateDataFunctions
+        public class OrderedList(
             override val children: List<ListItem>,
             override val isTight: Boolean,
-            val startFrom: Int,
-            val delimiter: String,
+            public val startFrom: Int,
+            public val delimiter: String,
         ) : ListBlock
 
-        public data class UnorderedList(
+        @GenerateDataFunctions
+        public class UnorderedList(
             override val children: List<ListItem>,
             override val isTight: Boolean,
-            val marker: String,
+            public val marker: String,
         ) : ListBlock
     }
 
-    public data class ListItem(
-        val children: List<MarkdownBlock>,
-    ) : MarkdownBlock
+    @GenerateDataFunctions
+    public class ListItem(public val children: List<MarkdownBlock>) : MarkdownBlock
 
-    public object ThematicBreak : MarkdownBlock
+    public data object ThematicBreak : MarkdownBlock
 
-    @JvmInline
-    public value class Paragraph(private val nativeBlock: CMParagraph) : MarkdownBlock, BlockWithInlineMarkdown {
-        override val inlineContent: Iterable<InlineMarkdown>
-            get() = nativeBlock.inlineContent()
-    }
+    @GenerateDataFunctions
+    public class Paragraph(
+        override val inlineContent: List<InlineMarkdown>,
+    ) : MarkdownBlock, BlockWithInlineMarkdown
 }
 
 public interface BlockWithInlineMarkdown {
     public val inlineContent: Iterable<InlineMarkdown>
 }
 
-private fun Block.inlineContent(): Iterable<InlineMarkdown> =
+@InternalJewelApi
+public fun Block.readInlineContent(): Iterable<InlineMarkdown> =
     object : Iterable<InlineMarkdown> {
         override fun iterator(): Iterator<InlineMarkdown> =
             object : Iterator<InlineMarkdown> {
-                var current = this@inlineContent.firstChild
+                var current = this@readInlineContent.firstChild
 
                 override fun hasNext(): Boolean = current != null
 

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/WithInlineMarkdown.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/WithInlineMarkdown.kt
@@ -1,0 +1,5 @@
+package org.jetbrains.jewel.markdown
+
+public interface WithInlineMarkdown {
+    public val inlineContent: List<InlineMarkdown>
+}

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/WithTextContent.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/WithTextContent.kt
@@ -1,0 +1,5 @@
+package org.jetbrains.jewel.markdown
+
+public interface WithTextContent {
+    public val content: String
+}

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/MarkdownInlineProcessorExtension.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/MarkdownInlineProcessorExtension.kt
@@ -1,0 +1,25 @@
+package org.jetbrains.jewel.markdown.extensions
+
+import org.commonmark.node.CustomNode
+import org.jetbrains.jewel.markdown.InlineMarkdown
+import org.jetbrains.jewel.markdown.processing.MarkdownProcessor
+
+public interface MarkdownInlineProcessorExtension {
+    /**
+     * Returns true if the [node] can be processed by this extension instance.
+     *
+     * @param node The [CustomNode] to parse
+     */
+    public fun canProcess(node: CustomNode): Boolean
+
+    /**
+     * Processes the [node] as a [InlineMarkdown.CustomNode], if possible. Note
+     * that you should always check that [canProcess] returns true for the same
+     * [node], as implementations might throw an exception for unsupported node
+     * types.
+     */
+    public fun processInlineMarkdown(
+        node: CustomNode,
+        processor: MarkdownProcessor,
+    ): InlineMarkdown.CustomNode?
+}

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/MarkdownInlineRendererExtension.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/MarkdownInlineRendererExtension.kt
@@ -1,0 +1,24 @@
+package org.jetbrains.jewel.markdown.extensions
+
+import org.jetbrains.jewel.markdown.InlineMarkdown
+import org.jetbrains.jewel.markdown.InlineMarkdown.CustomNode
+import org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer
+
+/**
+ * An extension for [InlineMarkdownRenderer] that can render one or more
+ * [InlineMarkdown.CustomNode]s.
+ */
+public interface MarkdownInlineRendererExtension {
+    /** Check whether the provided [inline] can be rendered by this extension. */
+    public fun canRender(inline: CustomNode): Boolean
+
+    /**
+     * Render a [CustomNode] as an annotated string. Note that if
+     * [canRender] returns `false` for [inline], the implementation might throw.
+     */
+    public fun render(
+        inline: CustomNode,
+        inlineRenderer: InlineMarkdownRenderer,
+        enabled: Boolean,
+    )
+}

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/MarkdownProcessorExtension.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/MarkdownProcessorExtension.kt
@@ -1,36 +1,58 @@
 package org.jetbrains.jewel.markdown.extensions
 
-import org.commonmark.node.CustomBlock
 import org.commonmark.parser.Parser.ParserExtension
 import org.commonmark.renderer.text.TextContentRenderer.TextContentRendererExtension
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
-import org.jetbrains.jewel.markdown.MarkdownBlock
 
 /** An extension for the Jewel Markdown processing engine. */
 @ExperimentalJewelApi
 public interface MarkdownProcessorExtension {
     /**
      * A CommonMark [ParserExtension] that will be used to parse the extended
-     * syntax represented by this extension instance. Null in the case where
-     * parsing is already handled by an existing [org.commonmark.parser.Parser].
+     * syntax represented by this extension instance.
+     *
+     * Can be null if all required processing is already handled by an existing
+     * [org.commonmark.parser.Parser].
      */
     public val parserExtension: ParserExtension?
+        get() = null
 
     /**
      * A CommonMark [TextContentRendererExtension] that will be used to render
-     * the text content of the CommonMark [CustomBlock] produced by the
-     * [parserExtension]. Null in the case where rendering is already
-     * handled by an existing [org.commonmark.renderer.Renderer].
+     * the text content of the CommonMark [org.commonmark.node.CustomBlock]
+     * produced by the [parserExtension].
+     *
+     * Can be null if all required processing is already handled by an existing
+     * [org.commonmark.renderer.Renderer].
      */
     public val textRendererExtension: TextContentRendererExtension?
+        get() = null
 
     /**
      * An extension for
-     * [`MarkdownParser`][org.jetbrains.jewel.markdown.parsing.MarkdownParser]
-     * that will transform a supported [CustomBlock] into the corresponding
-     * [MarkdownBlock.CustomBlock]. Null in the case where processing
-     * is already be handled by [org.jetbrains.jewel.markdown.processing.MarkdownProcessor]
-     * or another [org.jetbrains.jewel.markdown.extensions.MarkdownProcessorExtension].
+     * [`MarkdownProcessor`][org.jetbrains.jewel.markdown.processing.MarkdownProcessor]
+     * that will transform a supported [org.commonmark.node.CustomBlock] into
+     * the corresponding
+     * [org.jetbrains.jewel.markdown.MarkdownBlock.CustomBlock].
+     *
+     * Can be null if all required processing is already handled by
+     * [org.jetbrains.jewel.markdown.processing.MarkdownProcessor] or another
+     * [org.jetbrains.jewel.markdown.extensions.MarkdownProcessorExtension].
      */
-    public val processorExtension: MarkdownBlockProcessorExtension?
+    public val blockProcessorExtension: MarkdownBlockProcessorExtension?
+        get() = null
+
+    /**
+     * An extension for
+     * [`MarkdownProcessor`][org.jetbrains.jewel.markdown.processing.MarkdownProcessor]
+     * that will transform a supported [org.commonmark.node.CustomNode] into
+     * the corresponding
+     * [org.jetbrains.jewel.markdown.InlineMarkdown.CustomNode].
+     *
+     * Can be null if all required processing is already handled by
+     * [org.jetbrains.jewel.markdown.processing.MarkdownProcessor] or another
+     * [org.jetbrains.jewel.markdown.extensions.MarkdownProcessorExtension].
+     */
+    public val inlineProcessorExtension: MarkdownInlineProcessorExtension?
+        get() = null
 }

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/MarkdownRendererExtension.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/MarkdownRendererExtension.kt
@@ -11,6 +11,21 @@ public interface MarkdownRendererExtension {
      * that will render a supported
      * [`CustomBlock`][org.jetbrains.jewel.markdown.MarkdownBlock.CustomBlock] into
      * a native Jewel UI.
+     *
+     * Can be null if this extension doesn't support rendering blocks.
      */
-    public val blockRenderer: MarkdownBlockRendererExtension
+    public val blockRenderer: MarkdownBlockRendererExtension?
+        get() = null
+
+    /**
+     * An extension for
+     * [`InlineMarkdownRenderer`][org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer]
+     * that will render a supported
+     * [`CustomNode`][org.jetbrains.jewel.markdown.InlineMarkdown.CustomNode] into
+     * an annotated string.
+     *
+     * Can be null if this extension doesn't support rendering inline nodes.
+     */
+    public val inlineRenderer: MarkdownInlineRendererExtension?
+        get() = null
 }

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/processing/MarkdownProcessor.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/processing/MarkdownProcessor.kt
@@ -176,7 +176,7 @@ public class MarkdownProcessor(
     private fun Node.tryProcessMarkdownBlock(): MarkdownBlock? =
         // Non-Block children are ignored
         when (this) {
-            is Paragraph -> MarkdownBlock.Paragraph(this)
+            is Paragraph -> toMarkdownParagraph()
             is Heading -> toMarkdownHeadingOrNull()
             is BulletList -> toMarkdownListOrNull()
             is OrderedList -> toMarkdownListOrNull()
@@ -193,11 +193,18 @@ public class MarkdownProcessor(
             else -> null
         }
 
-    private fun BlockQuote.toMarkdownBlockQuote(): MarkdownBlock.BlockQuote = MarkdownBlock.BlockQuote(processChildren(this))
+    private fun Paragraph.toMarkdownParagraph(): MarkdownBlock.Paragraph =
+        MarkdownBlock.Paragraph(readInlineContent().toList())
+
+    private fun BlockQuote.toMarkdownBlockQuote(): MarkdownBlock.BlockQuote =
+        MarkdownBlock.BlockQuote(processChildren(this))
 
     private fun Heading.toMarkdownHeadingOrNull(): MarkdownBlock.Heading? {
         if (level < 1 || level > 6) return null
-        return MarkdownBlock.Heading(this)
+        return MarkdownBlock.Heading(
+            inlineContent = readInlineContent().toList(),
+            level = level
+        )
     }
 
     private fun FencedCodeBlock.toMarkdownCodeBlockOrNull(): CodeBlock.FencedCodeBlock =

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/processing/MarkdownProcessor.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/processing/MarkdownProcessor.kt
@@ -19,33 +19,45 @@ import org.intellij.lang.annotations.Language
 import org.jetbrains.annotations.TestOnly
 import org.jetbrains.annotations.VisibleForTesting
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
+import org.jetbrains.jewel.foundation.InternalJewelApi
 import org.jetbrains.jewel.markdown.InlineMarkdown
 import org.jetbrains.jewel.markdown.MarkdownBlock
 import org.jetbrains.jewel.markdown.MarkdownBlock.CodeBlock
 import org.jetbrains.jewel.markdown.MarkdownBlock.ListBlock
 import org.jetbrains.jewel.markdown.MimeType
 import org.jetbrains.jewel.markdown.extensions.MarkdownProcessorExtension
+import org.jetbrains.jewel.markdown.readInlineContent
 import org.jetbrains.jewel.markdown.rendering.DefaultInlineMarkdownRenderer
 import org.commonmark.node.ListBlock as CMListBlock
 
 /**
- * @param optimizeEdits Optional. Indicates whether the processing should
- *    only update the changed blocks by keeping a previous state in memory.
- *    Default is `true`, use `false` for immutable data.
+ * Reads raw Markdown strings and processes them into a list of
+ * [MarkdownBlock].
+ *
+ * @param extensions Extensions to use when processing the Markdown (e.g.,
+ *    to support parsing custom block-level Markdown).
+ * @param optimizeEdits Indicates whether the processing should only update
+ *    the changed blocks by keeping a previous state in memory. Default is
+ *    `false`; set this to `true` if this parser will be used in an editor
+ *    scenario, where the raw Markdown is only ever going to change
+ *    slightly but frequently (e.g., as the user types). Setting this to
+ *    `true` has a memory cost, and can be a performance regression if the
+ *    parse input is not always small variations of the same basic text.
+ *    When this is `true`, the instance of [MarkdownProcessor] is **not**
+ *    thread-safe!
+ * @param commonMarkParser The CommonMark [Parser] used to parse the
+ *    Markdown. By default it's a vanilla instance provided by the
+ *    [MarkdownParserFactory], but you can provide your own if you need to
+ *    customize the parser — e.g., to ignore certain tags. If
+ *    [optimizeEdits] is `true`, make sure you set
+ *    `includeSourceSpans(IncludeSourceSpans.BLOCKS)` on the parser.
  */
 @ExperimentalJewelApi
 public class MarkdownProcessor(
     private val extensions: List<MarkdownProcessorExtension> = emptyList(),
-    private val optimizeEdits: Boolean = true,
+    private val optimizeEdits: Boolean = false,
     private val commonMarkParser: Parser = MarkdownParserFactory.create(optimizeEdits, extensions),
 ) {
-    public constructor(
-        optimizeEdits: Boolean = true,
-        vararg extensions: MarkdownProcessorExtension,
-    ) : this(extensions.toList(), optimizeEdits)
-
-    private data class State(val lines: List<String>, val blocks: List<Block>, val indexes: List<Pair<Int, Int>>)
-
     private var currentState = State(emptyList(), emptyList(), emptyList())
 
     @TestOnly
@@ -58,47 +70,26 @@ public class MarkdownProcessor(
      * to an [androidx.compose.ui.text.AnnotatedString] by using
      * [DefaultInlineMarkdownRenderer.renderAsAnnotatedString].
      *
-     * The contents of [InlineMarkdown] is equivalent to the original, but
-     * normalized and simplified, and cleaned up as follows:
-     * * Replace HTML entities with the corresponding character (escaped, if it
-     *   is necessary)
-     * * Inline link and image references and omit the reference blocks
-     * * Use the destination as text for links when no text is set (escaped, if
-     *   it is necessary)
-     * * Normalize link titles to always use double quotes as enclosing
-     *   character
-     * * Normalize backticks in inline code runs
-     * * Convert links in image descriptions to plain text
-     * * Drop empty nodes with no visual representation (e.g., links with no
-     *   text and destination)
-     * * Remove unnecessary escapes
-     * * Escape non-formatting instances of ``*_`~<>[]()!`` for clarity
-     *
-     * The contents of code blocks aren't transformed in any way. HTML blocks
-     * get their outer whitespace trimmed, and so does inline HTML.
-     *
+     * @param rawMarkdown the raw Markdown string to process.
      * @see DefaultInlineMarkdownRenderer
      */
-    public fun processMarkdownDocument(
-        @Language("Markdown") rawMarkdown: String,
-    ): List<MarkdownBlock> {
-        return if (!optimizeEdits) {
-            textToBlocks(rawMarkdown)
-        } else {
+    public fun processMarkdownDocument(@Language("Markdown") rawMarkdown: String): List<MarkdownBlock> {
+        val blocks = if (optimizeEdits) {
             processWithQuickEdits(rawMarkdown)
-        }.mapNotNull { child ->
-            child.tryProcessMarkdownBlock()
+        } else {
+            parseRawMarkdown(rawMarkdown)
         }
+
+        return blocks.mapNotNull { child -> child.tryProcessMarkdownBlock() }
     }
 
     @VisibleForTesting
-    internal fun processWithQuickEdits(
-        @Language("Markdown") rawMarkdown: String,
-    ): List<Block> {
+    internal fun processWithQuickEdits(@Language("Markdown") rawMarkdown: String): List<Block> {
         val (previousLines, previousBlocks, previousIndexes) = currentState
         val newLines = rawMarkdown.lines()
         val nLinesDelta = newLines.size - previousLines.size
-        // find a block prior to the first one changed in case some elements merge during the update
+
+        // Find a block prior to the first one changed in case some elements merge during the update
         var firstBlock = 0
         var firstLine = 0
         var currFirstBlock = 0
@@ -115,7 +106,8 @@ public class MarkdownProcessor(
             currFirstBlock = i + 1
             currFirstLine = end + 1
         }
-        // find a block following the last one changed in case some elements merge during the update
+
+        // Find a block following the last one changed in case some elements merge during the update
         var lastBlock = previousBlocks.size
         var lastLine = previousLines.size
         var currLastBlock = lastBlock
@@ -133,12 +125,14 @@ public class MarkdownProcessor(
             currLastBlock = i
             currLastLine = begin
         }
+
         if (firstLine > lastLine + nLinesDelta) {
             // no change
             return previousBlocks
         }
+
         val updatedText = newLines.subList(firstLine, lastLine + nLinesDelta).joinToString("\n", postfix = "\n")
-        val updatedBlocks: List<Block> = textToBlocks(updatedText)
+        val updatedBlocks: List<Block> = parseRawMarkdown(updatedText)
         val updatedIndexes =
             updatedBlocks.map { node ->
                 // special case for a bug where LinkReferenceDefinition is a Node,
@@ -146,34 +140,37 @@ public class MarkdownProcessor(
                 if (node.sourceSpans.isEmpty()) {
                     node.sourceSpans = node.previous.sourceSpans
                 }
-                (node.sourceSpans.first().lineIndex + firstLine) to
-                    (node.sourceSpans.last().lineIndex + firstLine)
+
+                val firstLineIndex = node.sourceSpans.first().lineIndex + firstLine
+                val lastLineIndex = node.sourceSpans.last().lineIndex + firstLine
+
+                firstLineIndex to lastLineIndex
             }
+
         val suffixIndexes =
             previousIndexes.subList(lastBlock, previousBlocks.size).map {
                 (it.first + nLinesDelta) to (it.second + nLinesDelta)
             }
-        val newBlocks = (
+
+        val newBlocks =
             previousBlocks.subList(0, firstBlock) +
                 updatedBlocks +
                 previousBlocks.subList(lastBlock, previousBlocks.size)
-        )
+
         val newIndexes = previousIndexes.subList(0, firstBlock) + updatedIndexes + suffixIndexes
         currentState = State(newLines, newBlocks, newIndexes)
+
         return newBlocks
     }
 
-    private fun textToBlocks(strings: String): List<Block> {
+    private fun parseRawMarkdown(@Language("Markdown") rawMarkdown: String): List<Block> {
         val document =
-            commonMarkParser.parse(strings) as? Document
+            commonMarkParser.parse(rawMarkdown) as? Document
                 ?: error("This doesn't look like a Markdown document")
-        val updatedBlocks: List<Block> =
-            buildList {
-                document.forEachChild { child ->
-                    (child as? Block)?.let { add(it) }
-                }
-            }
-        return updatedBlocks
+
+        return buildList {
+            document.forEachChild { child -> if (child is Block) add(child) }
+        }
     }
 
     private fun Node.tryProcessMarkdownBlock(): MarkdownBlock? =
@@ -205,24 +202,34 @@ public class MarkdownProcessor(
 
     private fun FencedCodeBlock.toMarkdownCodeBlockOrNull(): CodeBlock.FencedCodeBlock =
         CodeBlock.FencedCodeBlock(
-            literal.trimEnd('\n'),
-            MimeType.Known.fromMarkdownLanguageName(info),
+            content = literal.trimEnd('\n'),
+            mimeType = MimeType.Known.fromMarkdownLanguageName(info),
         )
 
-    private fun IndentedCodeBlock.toMarkdownCodeBlockOrNull(): CodeBlock.IndentedCodeBlock = CodeBlock.IndentedCodeBlock(literal.trimEnd('\n'))
+    private fun IndentedCodeBlock.toMarkdownCodeBlockOrNull(): CodeBlock.IndentedCodeBlock =
+        CodeBlock.IndentedCodeBlock(literal.trimEnd('\n'))
 
     private fun BulletList.toMarkdownListOrNull(): ListBlock.UnorderedList? {
         val children = processListItems()
         if (children.isEmpty()) return null
 
-        return ListBlock.UnorderedList(children, isTight, marker)
+        return ListBlock.UnorderedList(
+            children = children,
+            isTight = isTight,
+            marker = marker
+        )
     }
 
     private fun OrderedList.toMarkdownListOrNull(): ListBlock.OrderedList? {
         val children = processListItems()
         if (children.isEmpty()) return null
 
-        return ListBlock.OrderedList(children, isTight, markerStartNumber, markerDelimiter)
+        return ListBlock.OrderedList(
+            children = children,
+            isTight = isTight,
+            startFrom = markerStartNumber,
+            delimiter = markerDelimiter
+        )
     }
 
     private fun CMListBlock.processListItems() =
@@ -233,12 +240,18 @@ public class MarkdownProcessor(
             }
         }
 
+    /**
+     * Processes the children of a CommonMark [Node]. This function is public
+     * so that it can be accessed from [MarkdownProcessorExtension]s, but
+     * should not be used in other scenarios.
+     */
+    @InternalJewelApi
     public fun processChildren(node: Node): List<MarkdownBlock> =
         buildList {
             node.forEachChild { child ->
                 val parsedBlock = child.tryProcessMarkdownBlock()
                 if (parsedBlock != null) {
-                    this.add(parsedBlock)
+                    add(parsedBlock)
                 }
             }
         }
@@ -254,6 +267,8 @@ public class MarkdownProcessor(
 
     private fun HtmlBlock.toMarkdownHtmlBlockOrNull(): MarkdownBlock.HtmlBlock? {
         if (literal.isBlank()) return null
-        return MarkdownBlock.HtmlBlock(content = literal.trimEnd('\n'))
+        return MarkdownBlock.HtmlBlock(literal.trimEnd('\n'))
     }
+
+    private data class State(val lines: List<String>, val blocks: List<Block>, val indexes: List<Pair<Int, Int>>)
 }

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/processing/ProcessingUtil.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/processing/ProcessingUtil.kt
@@ -1,0 +1,122 @@
+package org.jetbrains.jewel.markdown.processing
+
+import org.commonmark.node.Node
+import org.jetbrains.annotations.VisibleForTesting
+import org.jetbrains.jewel.markdown.InlineMarkdown
+import org.jetbrains.jewel.markdown.WithInlineMarkdown
+import org.jetbrains.jewel.markdown.WithTextContent
+import org.jetbrains.jewel.markdown.extensions.MarkdownProcessorExtension
+import org.commonmark.node.Code as CMCode
+import org.commonmark.node.CustomNode as CMCustomNode
+import org.commonmark.node.Emphasis as CMEmphasis
+import org.commonmark.node.HardLineBreak as CMHardLineBreak
+import org.commonmark.node.HtmlInline as CMHtmlInline
+import org.commonmark.node.Image as CMImage
+import org.commonmark.node.Link as CMLink
+import org.commonmark.node.SoftLineBreak as CMSoftLineBreak
+import org.commonmark.node.StrongEmphasis as CMStrongEmphasis
+import org.commonmark.node.Text as CMText
+
+@VisibleForTesting
+internal fun Node.readInlineContent(
+    markdownProcessor: MarkdownProcessor,
+    extensions: List<MarkdownProcessorExtension>,
+): List<InlineMarkdown> =
+    object : Iterable<InlineMarkdown> {
+        override fun iterator(): Iterator<InlineMarkdown> =
+            object : Iterator<InlineMarkdown> {
+                var current = this@readInlineContent.firstChild
+
+                override fun hasNext(): Boolean = current != null
+
+                override fun next(): InlineMarkdown {
+                    while (hasNext()) {
+                        val inline = current.toInlineMarkdownOrNull(markdownProcessor, extensions)
+
+                        current = current.next
+
+                        if (inline == null) {
+                            continue
+                        } else {
+                            return inline
+                        }
+                    }
+
+                    throw NoSuchElementException()
+                }
+            }
+    }.toList()
+
+@VisibleForTesting
+internal fun Node.toInlineMarkdownOrNull(
+    markdownProcessor: MarkdownProcessor,
+    extensions: List<MarkdownProcessorExtension>,
+) = when (this) {
+    is CMText -> InlineMarkdown.Text(literal)
+    is CMLink ->
+        InlineMarkdown.Link(
+            destination = destination,
+            title = title,
+            inlineContent = readInlineContent(markdownProcessor, extensions),
+        )
+
+    is CMEmphasis ->
+        InlineMarkdown.Emphasis(
+            delimiter = openingDelimiter,
+            inlineContent = readInlineContent(markdownProcessor, extensions),
+        )
+
+    is CMStrongEmphasis ->
+        InlineMarkdown.StrongEmphasis(
+            openingDelimiter,
+            readInlineContent(markdownProcessor, extensions),
+        )
+
+    is CMCode -> InlineMarkdown.Code(literal)
+    is CMHtmlInline -> InlineMarkdown.HtmlInline(literal)
+    is CMImage -> {
+        val inlineContent = readInlineContent(markdownProcessor, extensions)
+        InlineMarkdown.Image(
+            source = destination,
+            alt = inlineContent.renderAsSimpleText().trim(),
+            title = title,
+            inlineContent = inlineContent,
+        )
+    }
+
+    is CMHardLineBreak -> InlineMarkdown.HardLineBreak
+    is CMSoftLineBreak -> InlineMarkdown.SoftLineBreak
+    is CMCustomNode ->
+        extensions.find { it.inlineProcessorExtension?.canProcess(this) == true }
+            ?.inlineProcessorExtension?.processInlineMarkdown(this, markdownProcessor)
+
+    else -> error("Unexpected block $this")
+}
+
+/**
+ * Used to render content as simple plain text, used when creating image
+ * alt text.
+ */
+internal fun List<InlineMarkdown>.renderAsSimpleText(): String =
+    buildString {
+        for (node in this@renderAsSimpleText) {
+            when (node) {
+                is WithInlineMarkdown -> append(node.inlineContent.renderAsSimpleText())
+                is WithTextContent -> append(node.content)
+
+                is InlineMarkdown.CustomNode -> {
+                    val textContent = node.contentOrNull()
+                    if (textContent != null) {
+                        append(' ')
+                        append(textContent)
+                    }
+                }
+
+                is InlineMarkdown.HardLineBreak -> append('\n')
+                is InlineMarkdown.SoftLineBreak -> append(' ')
+                else -> {
+                    // Ignore other nodes
+                }
+            }
+        }
+    }

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
@@ -75,7 +75,7 @@ import org.jetbrains.jewel.ui.component.Text
 public open class DefaultMarkdownBlockRenderer(
     private val rootStyling: MarkdownStyling,
     private val rendererExtensions: List<MarkdownRendererExtension> = emptyList(),
-    private val inlineRenderer: InlineMarkdownRenderer = DefaultInlineMarkdownRenderer(),
+    private val inlineRenderer: InlineMarkdownRenderer = DefaultInlineMarkdownRenderer(rendererExtensions),
 ) : MarkdownBlockRenderer {
     @Composable
     override fun render(
@@ -111,7 +111,7 @@ public open class DefaultMarkdownBlockRenderer(
             ThematicBreak -> renderThematicBreak(rootStyling.thematicBreak)
             is CustomBlock -> {
                 rendererExtensions
-                    .find { it.blockRenderer.canRender(block) }
+                    .find { it.blockRenderer?.canRender(block) == true }
                     ?.blockRenderer
                     ?.render(block, blockRenderer = this, inlineRenderer, enabled, onUrlClick, onTextClick)
             }

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
@@ -51,7 +51,6 @@ import androidx.compose.ui.unit.dp
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.foundation.modifier.onHover
 import org.jetbrains.jewel.foundation.theme.LocalContentColor
-import org.jetbrains.jewel.markdown.BlockWithInlineMarkdown
 import org.jetbrains.jewel.markdown.MarkdownBlock
 import org.jetbrains.jewel.markdown.MarkdownBlock.BlockQuote
 import org.jetbrains.jewel.markdown.MarkdownBlock.CodeBlock
@@ -66,6 +65,7 @@ import org.jetbrains.jewel.markdown.MarkdownBlock.ListBlock.UnorderedList
 import org.jetbrains.jewel.markdown.MarkdownBlock.ListItem
 import org.jetbrains.jewel.markdown.MarkdownBlock.Paragraph
 import org.jetbrains.jewel.markdown.MarkdownBlock.ThematicBreak
+import org.jetbrains.jewel.markdown.WithInlineMarkdown
 import org.jetbrains.jewel.markdown.extensions.MarkdownRendererExtension
 import org.jetbrains.jewel.ui.Orientation.Horizontal
 import org.jetbrains.jewel.ui.component.Divider
@@ -477,7 +477,7 @@ public open class DefaultMarkdownBlockRenderer(
 
     @Composable
     private fun rememberRenderedContent(
-        block: BlockWithInlineMarkdown,
+        block: WithInlineMarkdown,
         styling: InlinesStyling,
         enabled: Boolean,
         onUrlClick: ((String) -> Unit)? = null,

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/InlineMarkdownRenderer.kt
@@ -3,7 +3,6 @@ package org.jetbrains.jewel.markdown.rendering
 import androidx.compose.ui.text.AnnotatedString
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.markdown.InlineMarkdown
-import org.jetbrains.jewel.markdown.extensions.MarkdownProcessorExtension
 
 @ExperimentalJewelApi
 public interface InlineMarkdownRenderer {
@@ -17,10 +16,4 @@ public interface InlineMarkdownRenderer {
         enabled: Boolean,
         onUrlClicked: ((String) -> Unit)? = null,
     ): AnnotatedString
-
-    public companion object {
-        /** Create a default inline renderer, with the [extensions] provided. */
-        public fun default(extensions: List<MarkdownProcessorExtension> = emptyList()): InlineMarkdownRenderer =
-            DefaultInlineMarkdownRenderer(extensions)
-    }
 }

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/MarkdownStyling.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/MarkdownStyling.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.TextLinkStyles
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
@@ -279,6 +280,14 @@ public class InlinesStyling(
     public val inlineHtml: SpanStyle,
     public val renderInlineHtml: Boolean,
 ) {
+    public val textLinkStyles: TextLinkStyles =
+        TextLinkStyles(
+            style = link,
+            focusedStyle = linkFocused,
+            hoveredStyle = linkHovered,
+            pressedStyle = linkPressed,
+        )
+
     public companion object
 }
 

--- a/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/MarkdownProcessorDocumentParsingExtraTest.kt
+++ b/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/MarkdownProcessorDocumentParsingExtraTest.kt
@@ -1,5 +1,10 @@
 package org.jetbrains.jewel.markdown
 
+import org.jetbrains.jewel.markdown.InlineMarkdown.Emphasis
+import org.jetbrains.jewel.markdown.InlineMarkdown.Link
+import org.jetbrains.jewel.markdown.InlineMarkdown.StrongEmphasis
+import org.jetbrains.jewel.markdown.InlineMarkdown.Text
+import org.jetbrains.jewel.markdown.MarkdownBlock.Paragraph
 import org.jetbrains.jewel.markdown.processing.MarkdownProcessor
 import org.junit.Test
 
@@ -14,7 +19,7 @@ class MarkdownProcessorDocumentParsingExtraTest {
          * Expected HTML:
          * <p><a href="/bar*" title="ti*tle">foo</a></p>
          */
-        parsed.assertEquals(paragraph("[](/bar* \"ti*tle\")"))
+        parsed.assertEquals(Paragraph(Link("/bar*", "ti*tle", emptyList())))
     }
 
     @Test
@@ -25,7 +30,18 @@ class MarkdownProcessorDocumentParsingExtraTest {
          * Expected HTML:
          * <p><em><em>foo <em>bar</em></em></em></p>
          */
-        parsed.assertEquals(paragraph("*_foo *bar*_*"))
+        parsed.assertEquals(
+            Paragraph(
+                Emphasis(
+                    "*",
+                    Emphasis(
+                        "_",
+                        Text("foo "),
+                        Emphasis("*", Text("bar")),
+                    ),
+                ),
+            ),
+        )
     }
 
     @Test
@@ -36,7 +52,15 @@ class MarkdownProcessorDocumentParsingExtraTest {
          * Expected HTML:
          * <p><strong>foo <em>bar</em></strong></p>
          */
-        parsed.assertEquals(paragraph("**foo *bar***"))
+        parsed.assertEquals(
+            Paragraph(
+                StrongEmphasis(
+                    "**",
+                    Text("foo "),
+                    Emphasis("*", Text("bar")),
+                ),
+            ),
+        )
     }
 
     @Test
@@ -47,7 +71,19 @@ class MarkdownProcessorDocumentParsingExtraTest {
          * Expected HTML:
          * <p><em><em>foo <em>bar</em> a</em></em></p>
          */
-        parsed.assertEquals(paragraph("*_foo *bar* a_*"))
+        parsed.assertEquals(
+            Paragraph(
+                Emphasis(
+                    "*",
+                    Emphasis(
+                        "_",
+                        Text("foo "),
+                        Emphasis("*", Text("bar")),
+                        Text(" a"),
+                    ),
+                ),
+            ),
+        )
     }
 
     @Test
@@ -58,7 +94,16 @@ class MarkdownProcessorDocumentParsingExtraTest {
          * Expected HTML:
          * <p><strong>foo <em>bar</em> a</strong></p>
          */
-        parsed.assertEquals(paragraph("**foo *bar* a**"))
+        parsed.assertEquals(
+            Paragraph(
+                StrongEmphasis(
+                    "**",
+                    Text("foo "),
+                    Emphasis("*", Text("bar")),
+                    Text(" a"),
+                ),
+            ),
+        )
     }
 
     @Test
@@ -67,8 +112,23 @@ class MarkdownProcessorDocumentParsingExtraTest {
 
         /*
          * Expected HTML:
-         * <p><strong>foo <em>bar</em> a</strong></p>
+         * <p><em><em><em>foo <em>bar</em> a</em></em></em></p>
          */
-        parsed.assertEquals(paragraph("*_*foo *bar* a*_*"))
+        parsed.assertEquals(
+            Paragraph(
+                Emphasis(
+                    "*",
+                    Emphasis(
+                        "_",
+                        Emphasis(
+                            "*",
+                            Text("foo "),
+                            Emphasis("*", Text("bar")),
+                            Text(" a"),
+                        ),
+                    ),
+                ),
+            ),
+        )
     }
 }

--- a/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/TestUtils.kt
+++ b/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/TestUtils.kt
@@ -12,11 +12,11 @@ import org.jetbrains.jewel.markdown.MarkdownBlock.ListBlock.UnorderedList
 import org.jetbrains.jewel.markdown.MarkdownBlock.ListItem
 import org.jetbrains.jewel.markdown.MarkdownBlock.Paragraph
 import org.jetbrains.jewel.markdown.MarkdownBlock.ThematicBreak
-import org.junit.Assert
+import org.junit.Assert.assertTrue
 
 fun List<MarkdownBlock>.assertEquals(vararg expected: MarkdownBlock) {
     val differences = findDifferences(expected.toList(), indentSize = 0)
-    Assert.assertTrue(
+    assertTrue(
         "The following differences were found:\n\n" +
             "${differences.joinToString("\n").replace('\t', '→')}\n\n",
         differences.isEmpty(),

--- a/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/TestUtils.kt
+++ b/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/TestUtils.kt
@@ -1,15 +1,5 @@
 package org.jetbrains.jewel.markdown
 
-import org.commonmark.internal.InlineParserContextImpl
-import org.commonmark.internal.InlineParserImpl
-import org.commonmark.internal.LinkReferenceDefinitions
-import org.commonmark.node.Block
-import org.commonmark.node.Node
-import org.commonmark.parser.Parser
-import org.commonmark.parser.SourceLine
-import org.commonmark.parser.SourceLines
-import org.commonmark.renderer.html.HtmlRenderer
-import org.intellij.lang.annotations.Language
 import org.jetbrains.jewel.markdown.MarkdownBlock.BlockQuote
 import org.jetbrains.jewel.markdown.MarkdownBlock.CodeBlock
 import org.jetbrains.jewel.markdown.MarkdownBlock.CodeBlock.FencedCodeBlock
@@ -23,8 +13,6 @@ import org.jetbrains.jewel.markdown.MarkdownBlock.ListItem
 import org.jetbrains.jewel.markdown.MarkdownBlock.Paragraph
 import org.jetbrains.jewel.markdown.MarkdownBlock.ThematicBreak
 import org.junit.Assert
-import org.commonmark.node.Heading as CMHeading
-import org.commonmark.node.Paragraph as CMParagraph
 
 fun List<MarkdownBlock>.assertEquals(vararg expected: MarkdownBlock) {
     val differences = findDifferences(expected.toList(), indentSize = 0)
@@ -88,28 +76,16 @@ private fun MarkdownBlock.findDifferenceWith(
     }
 }
 
-private var htmlRenderer = HtmlRenderer.builder().build()
-
-fun BlockWithInlineMarkdown.toHtml() =
-    buildString {
-        for (node in this@toHtml.inlineContent) {
-            // new lines are rendered as spaces in tests
-            append(htmlRenderer.render(node.nativeNode).replace("\n", " "))
-        }
-    }
-
 private fun diffParagraph(
     actual: Paragraph,
     expected: MarkdownBlock,
     indent: String,
 ) = buildList {
-    val actualInlineHtml = actual.toHtml()
-    val expectedInlineHtml = (expected as Paragraph).toHtml()
-    if (actualInlineHtml != expectedInlineHtml) {
+    if (actual != expected) {
         add(
             "$indent * Paragraph raw content mismatch.\n\n" +
-                "$indent     Actual:   $actualInlineHtml\n" +
-                "$indent     Expected: $expectedInlineHtml\n",
+                "$indent     Actual:   $actual\n" +
+                "$indent     Expected: $expected\n",
         )
     }
 }
@@ -169,13 +145,11 @@ private fun diffHeading(
     expected: MarkdownBlock,
     indent: String,
 ) = buildList {
-    val actualInlineHtml = actual.toHtml()
-    val expectedInlineHtml = (expected as Heading).toHtml()
-    if (actualInlineHtml != expectedInlineHtml) {
+    if (actual != expected) {
         add(
             "$indent * Heading raw content mismatch.\n\n" +
-                "$indent     Actual:   $actualInlineHtml\n" +
-                "$indent     Expected: $expectedInlineHtml",
+                "$indent     Actual:   $actual\n" +
+                "$indent     Expected: $expected",
         )
     }
 }
@@ -227,52 +201,19 @@ private fun diffList(
     }
 }
 
-private val parser = Parser.builder().build()
-
-private fun Node.children() =
-    buildList {
-        var child = firstChild
-        while (child != null) {
-            add(child)
-            child = child.next
-        }
-    }
-
-/** skip root Document and Paragraph nodes */
-private fun inlineMarkdowns(content: String): List<InlineMarkdown> {
-    val document = parser.parse(content).firstChild ?: return emptyList()
-    return if (document.firstChild is CMParagraph) {
-        document.firstChild
-    } else {
-        document
-    }.children().map { x -> x.toInlineNode() }
-}
-
-private val inlineParser = InlineParserImpl(InlineParserContextImpl(emptyList(), LinkReferenceDefinitions()))
-
-fun paragraph(
-    @Language("Markdown") content: String,
-) =
-    Paragraph(CMParagraph().parseInline(content))
+fun paragraph(content: String) = Paragraph(InlineMarkdown.Text(content))
 
 fun heading(
     level: Int,
-    @Language("Markdown") content: String,
-) =
-    Heading(inlineContent = CMHeading().parseInline(content), level = level)
-
-private fun Block.parseInline(content: String): List<InlineMarkdown> {
-    inlineParser.parse(SourceLines.of(SourceLine.of(content, null)), this)
-    return readInlineContent().toList()
-}
+    vararg inlineContent: InlineMarkdown,
+) = Heading(inlineContent = inlineContent, level = level)
 
 fun indentedCodeBlock(content: String) = IndentedCodeBlock(content)
 
 fun fencedCodeBlock(
     content: String,
     mimeType: MimeType? = null,
-) =
-    FencedCodeBlock(content, mimeType)
+) = FencedCodeBlock(content, mimeType)
 
 fun blockQuote(vararg contents: MarkdownBlock) = BlockQuote(contents.toList())
 
@@ -280,18 +221,16 @@ fun unorderedList(
     vararg items: ListItem,
     isTight: Boolean = true,
     marker: String = "-",
-) =
-    UnorderedList(items.toList(), isTight, marker)
+) = UnorderedList(items.toList(), isTight, marker)
 
 fun orderedList(
     vararg items: ListItem,
     isTight: Boolean = true,
     startFrom: Int = 1,
     delimiter: String = ".",
-) =
-    OrderedList(items.toList(), isTight, startFrom, delimiter)
+) = OrderedList(items.toList(), isTight, startFrom, delimiter)
 
-fun listItem(vararg items: MarkdownBlock) = ListItem(items.toList())
+fun listItem(vararg items: MarkdownBlock) = ListItem(*items)
 
 fun htmlBlock(content: String) = HtmlBlock(content)
 

--- a/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/processing/MarkdownProcessorOptimizeEditsTest.kt
+++ b/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/processing/MarkdownProcessorOptimizeEditsTest.kt
@@ -40,12 +40,12 @@ private val rawMarkdown =
 @Suppress(
     "LargeClass", // Detekt triggers on files > 600 lines
 )
-class MarkdownProcessorTest {
+class MarkdownProcessorOptimizeEditsTest {
     private val htmlRenderer = HtmlRenderer.builder().build()
 
     @Test
     fun `first blocks stay the same`() {
-        val processor = MarkdownProcessor()
+        val processor = MarkdownProcessor(optimizeEdits = true)
         val firstRun = processor.processWithQuickEdits(rawMarkdown)
         val secondRun =
             processor.processWithQuickEdits(
@@ -80,7 +80,7 @@ class MarkdownProcessorTest {
 
     @Test
     fun `first block edited`() {
-        val processor = MarkdownProcessor()
+        val processor = MarkdownProcessor(optimizeEdits = true)
         val firstRun = processor.processWithQuickEdits(rawMarkdown)
         val secondRun =
             processor.processWithQuickEdits(
@@ -136,7 +136,7 @@ class MarkdownProcessorTest {
 
     @Test
     fun `last block edited`() {
-        val processor = MarkdownProcessor()
+        val processor = MarkdownProcessor(optimizeEdits = true)
         val firstRun = processor.processWithQuickEdits(rawMarkdown)
         val secondRun =
             processor.processWithQuickEdits(
@@ -195,7 +195,7 @@ class MarkdownProcessorTest {
 
     @Test
     fun `middle block edited`() {
-        val processor = MarkdownProcessor()
+        val processor = MarkdownProcessor(optimizeEdits = true)
         val firstRun = processor.processWithQuickEdits(rawMarkdown)
         val secondRun =
             processor.processWithQuickEdits(
@@ -256,7 +256,7 @@ class MarkdownProcessorTest {
 
     @Test
     fun `blocks merged`() {
-        val processor = MarkdownProcessor()
+        val processor = MarkdownProcessor(optimizeEdits = true)
         val firstRun = processor.processWithQuickEdits(rawMarkdown)
         val secondRun =
             processor.processWithQuickEdits(
@@ -313,7 +313,7 @@ class MarkdownProcessorTest {
 
     @Test
     fun `blocks split`() {
-        val processor = MarkdownProcessor()
+        val processor = MarkdownProcessor(optimizeEdits = true)
         val firstRun = processor.processWithQuickEdits(rawMarkdown)
         val secondRun =
             processor.processWithQuickEdits(
@@ -371,7 +371,7 @@ class MarkdownProcessorTest {
 
     @Test
     fun `blocks deleted`() {
-        val processor = MarkdownProcessor()
+        val processor = MarkdownProcessor(optimizeEdits = true)
         val firstRun = processor.processWithQuickEdits(rawMarkdown)
         val secondRun =
             processor.processWithQuickEdits(
@@ -423,7 +423,7 @@ class MarkdownProcessorTest {
 
     @Test
     fun `blocks added`() {
-        val processor = MarkdownProcessor()
+        val processor = MarkdownProcessor(optimizeEdits = true)
         val firstRun = processor.processWithQuickEdits(rawMarkdown)
         val secondDocument =
             """
@@ -491,7 +491,7 @@ class MarkdownProcessorTest {
 
     @Test
     fun `no changes`() {
-        val processor = MarkdownProcessor()
+        val processor = MarkdownProcessor(optimizeEdits = true)
         val firstRun = processor.processWithQuickEdits(rawMarkdown)
         val secondRun = processor.processWithQuickEdits(rawMarkdown)
         assertHtmlEquals(
@@ -523,7 +523,7 @@ class MarkdownProcessorTest {
 
     @Test
     fun `empty line added`() {
-        val processor = MarkdownProcessor()
+        val processor = MarkdownProcessor(optimizeEdits = true)
         val firstRun = processor.processWithQuickEdits(rawMarkdown)
         val secondRun = processor.processWithQuickEdits("\n" + rawMarkdown)
         assertHtmlEquals(
@@ -557,7 +557,7 @@ class MarkdownProcessorTest {
     /** Regression https://github.com/JetBrains/jewel/issues/344 */
     @Test
     fun `content if empty`() {
-        val processor = MarkdownProcessor()
+        val processor = MarkdownProcessor(optimizeEdits = true)
         processor.processWithQuickEdits(rawMarkdown)
         val secondRun = processor.processWithQuickEdits("")
         assertHtmlEquals(
@@ -570,7 +570,7 @@ class MarkdownProcessorTest {
 
     @Test
     fun `chained changes`() {
-        val processor = MarkdownProcessor()
+        val processor = MarkdownProcessor(optimizeEdits = true)
         processor.processWithQuickEdits(
             """
             # Header 0

--- a/markdown/extension/autolink/api/autolink.api
+++ b/markdown/extension/autolink/api/autolink.api
@@ -1,8 +1,9 @@
 public final class org/jetbrains/jewel/markdown/extension/autolink/AutolinkProcessorExtension : org/jetbrains/jewel/markdown/extensions/MarkdownProcessorExtension {
 	public static final field $stable I
 	public static final field INSTANCE Lorg/jetbrains/jewel/markdown/extension/autolink/AutolinkProcessorExtension;
+	public fun getBlockProcessorExtension ()Lorg/jetbrains/jewel/markdown/extensions/MarkdownBlockProcessorExtension;
+	public fun getInlineProcessorExtension ()Lorg/jetbrains/jewel/markdown/extensions/MarkdownInlineProcessorExtension;
 	public fun getParserExtension ()Lorg/commonmark/parser/Parser$ParserExtension;
-	public fun getProcessorExtension ()Lorg/jetbrains/jewel/markdown/extensions/MarkdownBlockProcessorExtension;
 	public fun getTextRendererExtension ()Lorg/commonmark/renderer/text/TextContentRenderer$TextContentRendererExtension;
 }
 

--- a/markdown/extension/autolink/src/main/kotlin/org/jetbrains/jewel/markdown/extension/autolink/AutolinkProcessorExtension.kt
+++ b/markdown/extension/autolink/src/main/kotlin/org/jetbrains/jewel/markdown/extension/autolink/AutolinkProcessorExtension.kt
@@ -2,19 +2,9 @@ package org.jetbrains.jewel.markdown.extension.autolink
 
 import org.commonmark.ext.autolink.AutolinkExtension
 import org.commonmark.parser.Parser.ParserExtension
-import org.commonmark.renderer.text.TextContentRenderer
-import org.jetbrains.jewel.markdown.extensions.MarkdownBlockProcessorExtension
 import org.jetbrains.jewel.markdown.extensions.MarkdownProcessorExtension
 
 public object AutolinkProcessorExtension : MarkdownProcessorExtension {
-    override val parserExtension: ParserExtension
-        get() = AutolinkExtension.create() as ParserExtension
-
-    /**
-     * Rendering and processing is already handled by [org.jetbrains.jewel.markdown.rendering.DefaultInlineMarkdownRenderer]
-     */
-    override val textRendererExtension: TextContentRenderer.TextContentRendererExtension?
-        get() = null
-    override val processorExtension: MarkdownBlockProcessorExtension?
-        get() = null
+    override val parserExtension: ParserExtension =
+        AutolinkExtension.create() as ParserExtension
 }

--- a/markdown/extension/gfm-alerts/api/gfm-alerts.api
+++ b/markdown/extension/gfm-alerts/api/gfm-alerts.api
@@ -122,8 +122,9 @@ public final class org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubA
 public final class org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertProcessorExtension : org/jetbrains/jewel/markdown/extensions/MarkdownProcessorExtension {
 	public static final field $stable I
 	public static final field INSTANCE Lorg/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertProcessorExtension;
+	public fun getBlockProcessorExtension ()Lorg/jetbrains/jewel/markdown/extensions/MarkdownBlockProcessorExtension;
+	public fun getInlineProcessorExtension ()Lorg/jetbrains/jewel/markdown/extensions/MarkdownInlineProcessorExtension;
 	public fun getParserExtension ()Lorg/commonmark/parser/Parser$ParserExtension;
-	public fun getProcessorExtension ()Lorg/jetbrains/jewel/markdown/extensions/MarkdownBlockProcessorExtension;
 	public fun getTextRendererExtension ()Lorg/commonmark/renderer/text/TextContentRenderer$TextContentRendererExtension;
 }
 

--- a/markdown/extension/gfm-alerts/api/gfm-alerts.api
+++ b/markdown/extension/gfm-alerts/api/gfm-alerts.api
@@ -132,6 +132,7 @@ public final class org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubA
 	public static final field $stable I
 	public fun <init> (Lorg/jetbrains/jewel/markdown/extensions/github/alerts/AlertStyling;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;)V
 	public fun getBlockRenderer ()Lorg/jetbrains/jewel/markdown/extensions/MarkdownBlockRendererExtension;
+	public fun getInlineRenderer ()Lorg/jetbrains/jewel/markdown/extensions/MarkdownInlineRendererExtension;
 }
 
 public final class org/jetbrains/jewel/markdown/extensions/github/alerts/ImportantAlertStyling : org/jetbrains/jewel/markdown/extensions/github/alerts/BaseAlertStyling {

--- a/markdown/extension/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertProcessorExtension.kt
+++ b/markdown/extension/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertProcessorExtension.kt
@@ -33,7 +33,7 @@ public object GitHubAlertProcessorExtension : MarkdownProcessorExtension {
     override val textRendererExtension: TextContentRendererExtension =
         GitHubAlertCommonMarkExtension
 
-    override val processorExtension: MarkdownBlockProcessorExtension = GitHubAlertProcessorExtension
+    override val blockProcessorExtension: MarkdownBlockProcessorExtension = GitHubAlertProcessorExtension
 
     private object GitHubAlertProcessorExtension : MarkdownBlockProcessorExtension {
         override fun canProcess(block: CustomBlock): Boolean = block is AlertBlock

--- a/markdown/extension/gfm-alerts/src/test/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertBlockExtensionTest.kt
+++ b/markdown/extension/gfm-alerts/src/test/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertBlockExtensionTest.kt
@@ -30,9 +30,9 @@ class GitHubAlertBlockExtensionTest {
     fun `should parse note alert`() {
         val rawMarkdown =
             """
-        |> [!NOTE]  
-        |> Highlights information that users should take into account, even when skimming.
-        """
+            |> [!NOTE]  
+            |> Highlights information that users should take into account, even when skimming.
+            """
                 .trimMargin()
         val parsed = parser.parse(rawMarkdown)
 
@@ -65,13 +65,14 @@ class GitHubAlertBlockExtensionTest {
 
     @Test
     fun `should parse tip alert`() {
-        val rawMarkdown =
+        val parsed =
+            parser.parse(
+                """
+            |> [!TIP]  
+            |> Optional information to help a user be more successful.
             """
-        |> [!TIP]  
-        |> Optional information to help a user be more successful.
-        """
-                .trimMargin()
-        val parsed = parser.parse(rawMarkdown)
+                    .trimMargin(),
+            )
 
         assertTrue("Parse result is not a document", parsed is Document)
 
@@ -101,13 +102,14 @@ class GitHubAlertBlockExtensionTest {
 
     @Test
     fun `should parse important alert`() {
-        val rawMarkdown =
+        val parsed =
+            parser.parse(
+                """
+            |> [!IMPORTANT]  
+            |> Crucial information necessary for users to succeed.
             """
-        |> [!IMPORTANT]  
-        |> Crucial information necessary for users to succeed.
-        """
-                .trimMargin()
-        val parsed = parser.parse(rawMarkdown)
+                    .trimMargin(),
+            )
 
         assertTrue("Parse result is not a document", parsed is Document)
 
@@ -137,13 +139,14 @@ class GitHubAlertBlockExtensionTest {
 
     @Test
     fun `should parse warning alert`() {
-        val rawMarkdown =
+        val parsed =
+            parser.parse(
+                """
+            |> [!WARNING]  
+            |> Critical content demanding immediate user attention due to potential risks.
             """
-        |> [!WARNING]  
-        |> Critical content demanding immediate user attention due to potential risks.
-        """
-                .trimMargin()
-        val parsed = parser.parse(rawMarkdown)
+                    .trimMargin(),
+            )
 
         assertTrue("Parse result is not a document", parsed is Document)
 
@@ -173,13 +176,14 @@ class GitHubAlertBlockExtensionTest {
 
     @Test
     fun `should parse caution alert`() {
-        val rawMarkdown =
+        val parsed =
+            parser.parse(
+                """
+            |> [!CAUTION]  
+            |> Negative potential consequences of an action.
             """
-        |> [!CAUTION]  
-        |> Negative potential consequences of an action.
-        """
-                .trimMargin()
-        val parsed = parser.parse(rawMarkdown)
+                    .trimMargin(),
+            )
 
         assertTrue("Parse result is not a document", parsed is Document)
 
@@ -209,13 +213,14 @@ class GitHubAlertBlockExtensionTest {
 
     @Test
     fun `should parse lowercase note alert`() {
-        val rawMarkdown =
+        val parsed =
+            parser.parse(
+                """
+            |> [!note]  
+            |> Highlights information that users should take into account, even when skimming.
             """
-        |> [!note]  
-        |> Highlights information that users should take into account, even when skimming.
-        """
-                .trimMargin()
-        val parsed = parser.parse(rawMarkdown)
+                    .trimMargin(),
+            )
 
         assertTrue("Parse result is not a document", parsed is Document)
 
@@ -245,13 +250,14 @@ class GitHubAlertBlockExtensionTest {
 
     @Test
     fun `should parse lowercase tip alert`() {
-        val rawMarkdown =
+        val parsed =
+            parser.parse(
+                """
+            |> [!tip]  
+            |> Optional information to help a user be more successful.
             """
-        |> [!tip]  
-        |> Optional information to help a user be more successful.
-        """
-                .trimMargin()
-        val parsed = parser.parse(rawMarkdown)
+                    .trimMargin(),
+            )
 
         assertTrue("Parse result is not a document", parsed is Document)
 
@@ -281,13 +287,14 @@ class GitHubAlertBlockExtensionTest {
 
     @Test
     fun `should parse lowercase important alert`() {
-        val rawMarkdown =
+        val parsed =
+            parser.parse(
+                """
+            |> [!important]  
+            |> Crucial information necessary for users to succeed.
             """
-        |> [!important]  
-        |> Crucial information necessary for users to succeed.
-        """
-                .trimMargin()
-        val parsed = parser.parse(rawMarkdown)
+                    .trimMargin(),
+            )
 
         assertTrue("Parse result is not a document", parsed is Document)
 
@@ -317,13 +324,14 @@ class GitHubAlertBlockExtensionTest {
 
     @Test
     fun `should parse lowercase warning alert`() {
-        val rawMarkdown =
+        val parsed =
+            parser.parse(
+                """
+            |> [!warning]  
+            |> Critical content demanding immediate user attention due to potential risks.
             """
-        |> [!warning]  
-        |> Critical content demanding immediate user attention due to potential risks.
-        """
-                .trimMargin()
-        val parsed = parser.parse(rawMarkdown)
+                    .trimMargin(),
+            )
 
         assertTrue("Parse result is not a document", parsed is Document)
 
@@ -353,13 +361,14 @@ class GitHubAlertBlockExtensionTest {
 
     @Test
     fun `should parse lowercase caution alert`() {
-        val rawMarkdown =
+        val parsed =
+            parser.parse(
+                """
+            |> [!caution]  
+            |> Negative potential consequences of an action.
             """
-        |> [!caution]  
-        |> Negative potential consequences of an action.
-        """
-                .trimMargin()
-        val parsed = parser.parse(rawMarkdown)
+                    .trimMargin(),
+            )
 
         assertTrue("Parse result is not a document", parsed is Document)
 
@@ -389,15 +398,16 @@ class GitHubAlertBlockExtensionTest {
 
     @Test
     fun `should trim trailing and leading empty lines`() {
-        val rawMarkdown =
+        val parsed =
+            parser.parse(
+                """
+            |> [!CAUTION] 
+            |>
+            |> Negative potential consequences of an action.
+            |>
             """
-        |> [!CAUTION] 
-        |>
-        |> Negative potential consequences of an action.
-        |>
-        """
-                .trimMargin()
-        val parsed = parser.parse(rawMarkdown)
+                    .trimMargin(),
+            )
 
         assertTrue("Parse result is not a document", parsed is Document)
 
@@ -427,13 +437,14 @@ class GitHubAlertBlockExtensionTest {
 
     @Test
     fun `should parse malformed entry as blockquote - space after exclamation mark`() {
-        val rawMarkdown =
+        val parsed =
+            parser.parse(
+                """
+            |> [! CAUTION]  
+            |> Negative potential consequences of an action.
             """
-        |> [! CAUTION]  
-        |> Negative potential consequences of an action.
-        """
-                .trimMargin()
-        val parsed = parser.parse(rawMarkdown)
+                    .trimMargin(),
+            )
 
         assertTrue("Parse result is not a document", parsed is Document)
 
@@ -449,14 +460,15 @@ class GitHubAlertBlockExtensionTest {
 
     @Test
     fun `should parse malformed entry as blockquote - type not on first line`() {
-        val rawMarkdown =
+        val parsed =
+            parser.parse(
+                """
+            |>
+            |> [! CAUTION]  
+            |> Negative potential consequences of an action.
             """
-        |>
-        |> [! CAUTION]  
-        |> Negative potential consequences of an action.
-        """
-                .trimMargin()
-        val parsed = parser.parse(rawMarkdown)
+                    .trimMargin(),
+            )
 
         assertTrue("Parse result is not a document", parsed is Document)
 
@@ -472,13 +484,14 @@ class GitHubAlertBlockExtensionTest {
 
     @Test
     fun `should parse malformed entry as blockquote - space before exclamation mark`() {
-        val rawMarkdown =
+        val parsed =
+            parser.parse(
+                """
+            |> [ !CAUTION]  
+            |> Negative potential consequences of an action.
             """
-        |> [ !CAUTION]  
-        |> Negative potential consequences of an action.
-        """
-                .trimMargin()
-        val parsed = parser.parse(rawMarkdown)
+                    .trimMargin(),
+            )
 
         assertTrue("Parse result is not a document", parsed is Document)
 
@@ -494,13 +507,14 @@ class GitHubAlertBlockExtensionTest {
 
     @Test
     fun `should parse malformed entry as blockquote - space after type`() {
-        val rawMarkdown =
+        val parsed =
+            parser.parse(
+                """
+            |> [!CAUTION ]  
+            |> Negative potential consequences of an action.
             """
-        |> [!CAUTION ]  
-        |> Negative potential consequences of an action.
-        """
-                .trimMargin()
-        val parsed = parser.parse(rawMarkdown)
+                    .trimMargin(),
+            )
 
         assertTrue("Parse result is not a document", parsed is Document)
 
@@ -516,12 +530,13 @@ class GitHubAlertBlockExtensionTest {
 
     @Test
     fun `should parse malformed entry as blockquote - missing newline`() {
-        val rawMarkdown =
+        val parsed =
+            parser.parse(
+                """
+            |> [!CAUTION] Negative potential consequences of an action.
             """
-        |> [!CAUTION] Negative potential consequences of an action.
-        """
-                .trimMargin()
-        val parsed = parser.parse(rawMarkdown)
+                    .trimMargin(),
+            )
 
         assertTrue("Parse result is not a document", parsed is Document)
 

--- a/markdown/ide-laf-bridge-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/bridge/BridgeMarkdownBlockRendererExtensions.kt
+++ b/markdown/ide-laf-bridge-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/bridge/BridgeMarkdownBlockRendererExtensions.kt
@@ -2,6 +2,7 @@ package org.jetbrains.jewel.intui.markdown.bridge
 
 import org.jetbrains.jewel.intui.markdown.bridge.styling.create
 import org.jetbrains.jewel.markdown.extensions.MarkdownRendererExtension
+import org.jetbrains.jewel.markdown.rendering.DefaultInlineMarkdownRenderer
 import org.jetbrains.jewel.markdown.rendering.DefaultMarkdownBlockRenderer
 import org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer
 import org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer
@@ -10,5 +11,5 @@ import org.jetbrains.jewel.markdown.rendering.MarkdownStyling
 public fun MarkdownBlockRenderer.Companion.create(
     styling: MarkdownStyling = MarkdownStyling.create(),
     rendererExtensions: List<MarkdownRendererExtension> = emptyList(),
-    inlineRenderer: InlineMarkdownRenderer = InlineMarkdownRenderer.default(),
+    inlineRenderer: InlineMarkdownRenderer = DefaultInlineMarkdownRenderer(rendererExtensions),
 ): MarkdownBlockRenderer = DefaultMarkdownBlockRenderer(styling, rendererExtensions, inlineRenderer)

--- a/markdown/ide-laf-bridge-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/bridge/styling/BridgeMarkdownStyling.kt
+++ b/markdown/ide-laf-bridge-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/bridge/styling/BridgeMarkdownStyling.kt
@@ -387,7 +387,7 @@ public fun InlinesStyling.Companion.create(
     emphasis: SpanStyle = textStyle.copy(fontStyle = FontStyle.Italic).toSpanStyle(),
     strongEmphasis: SpanStyle = textStyle.copy(fontWeight = FontWeight.Bold).toSpanStyle(),
     inlineHtml: SpanStyle = textStyle.toSpanStyle(),
-    renderInlineHtml: Boolean = false,
+    renderInlineHtml: Boolean = true,
 ): InlinesStyling =
     InlinesStyling(
         textStyle = textStyle,

--- a/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/IntUiMarkdownBlockRendererExtensions.kt
+++ b/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/IntUiMarkdownBlockRendererExtensions.kt
@@ -3,6 +3,7 @@ package org.jetbrains.jewel.intui.markdown.standalone
 import org.jetbrains.jewel.intui.markdown.standalone.styling.dark
 import org.jetbrains.jewel.intui.markdown.standalone.styling.light
 import org.jetbrains.jewel.markdown.extensions.MarkdownRendererExtension
+import org.jetbrains.jewel.markdown.rendering.DefaultInlineMarkdownRenderer
 import org.jetbrains.jewel.markdown.rendering.DefaultMarkdownBlockRenderer
 import org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer
 import org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer
@@ -11,11 +12,11 @@ import org.jetbrains.jewel.markdown.rendering.MarkdownStyling
 public fun MarkdownBlockRenderer.Companion.light(
     styling: MarkdownStyling = MarkdownStyling.light(),
     rendererExtensions: List<MarkdownRendererExtension> = emptyList(),
-    inlineRenderer: InlineMarkdownRenderer = InlineMarkdownRenderer.default(),
+    inlineRenderer: InlineMarkdownRenderer = DefaultInlineMarkdownRenderer(rendererExtensions),
 ): MarkdownBlockRenderer = DefaultMarkdownBlockRenderer(styling, rendererExtensions, inlineRenderer)
 
 public fun MarkdownBlockRenderer.Companion.dark(
     styling: MarkdownStyling = MarkdownStyling.dark(),
     rendererExtensions: List<MarkdownRendererExtension> = emptyList(),
-    inlineRenderer: InlineMarkdownRenderer = InlineMarkdownRenderer.default(),
+    inlineRenderer: InlineMarkdownRenderer = DefaultInlineMarkdownRenderer(rendererExtensions),
 ): MarkdownBlockRenderer = DefaultMarkdownBlockRenderer(styling, rendererExtensions, inlineRenderer)

--- a/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/styling/IntUiMarkdownStyling.kt
+++ b/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/styling/IntUiMarkdownStyling.kt
@@ -662,7 +662,7 @@ public fun InlinesStyling.Companion.light(
     emphasis: SpanStyle = textStyle.copy(fontStyle = FontStyle.Italic).toSpanStyle(),
     strongEmphasis: SpanStyle = textStyle.copy(fontWeight = FontWeight.Bold).toSpanStyle(),
     inlineHtml: SpanStyle = textStyle.toSpanStyle(),
-    renderInlineHtml: Boolean = false,
+    renderInlineHtml: Boolean = true,
 ): InlinesStyling =
     InlinesStyling(
         textStyle = textStyle,
@@ -698,7 +698,7 @@ public fun InlinesStyling.Companion.dark(
     emphasis: SpanStyle = textStyle.copy(fontStyle = FontStyle.Italic).toSpanStyle(),
     strongEmphasis: SpanStyle = textStyle.copy(fontWeight = FontWeight.Bold).toSpanStyle(),
     inlineHtml: SpanStyle = textStyle.toSpanStyle(),
-    renderInlineHtml: Boolean = false,
+    renderInlineHtml: Boolean = true,
 ): InlinesStyling =
     InlinesStyling(
         textStyle = textStyle,

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/markdown/JewelReadme.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/markdown/JewelReadme.kt
@@ -7,7 +7,7 @@ internal val JewelReadme =
     """
 # Jewel: a Compose for Desktop theme
 
-<img alt="Jewel logo" src="art/jewel-logo.svg" width="20%"/>
+<img alt="Jewel logo" src="https://raw.githubusercontent.com/JetBrains/jewel/6ef2344561f7b4d1325750417145b9ecb06ac23c/art/jewel-logo.svg?raw=true" width="20%"/>
 
 Jewel aims at recreating the IntelliJ Platform's _New UI_ Swing Look and Feel in Compose for Desktop, providing a
 desktop-optimized theme and set of components.
@@ -130,7 +130,7 @@ The standalone theme can be used in any Compose for Desktop app. You use it as a
 to your heart's content. By default, it matches the official Int UI specs.
 
 For an example on how to set up a standalone app, you can refer to
-the [`standalone` sample](samples/standalone/build.gradle.kts).
+the [`standalone` sample](https://github.com/JetBrains/jewel/blob/main/samples/standalone/build.gradle.kts).
 
 > [!WARNING]
 > Note that Jewel **requires** the JetBrains Runtime to work correctly. Some features like font loading depend on it,
@@ -152,7 +152,7 @@ If you want more control over the theming, you can use other `IntUiTheme` overlo
 
 The JetBrains Runtime allows windows to have a custom decoration instead of the regular title bar.
 
-![A screenshot of the custom window decoration in the standalone sample](art/docs/custom-chrome.png)
+![A screenshot of the custom window decoration in the standalone sample](https://github.com/JetBrains/jewel/blob/main/art/docs/custom-chrome.png?raw=true)
 
 The standalone sample app shows how to easily get something that looks like a JetBrains IDE; if you want to go _very_
 custom, you only need to depend on the `decorated-window` module, which contains all the required primitives, but not
@@ -214,7 +214,7 @@ and the branch on which the corresponding bridge code lives:
 | 2023.1 or older              | **Not supported** |
 
 For an example on how to set up an IntelliJ Plugin, you can refer to
-the [`ide-plugin` sample](samples/ide-plugin/build.gradle.kts).
+the [`ide-plugin` sample](https://github.com/JetBrains/jewel/blob/main/samples/ide-plugin/build.gradle.kts).
 
 #### Accessing icons
 

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/markdown/MarkdownPreview.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/markdown/MarkdownPreview.kt
@@ -34,7 +34,6 @@ import org.jetbrains.jewel.markdown.extensions.github.alerts.AlertStyling
 import org.jetbrains.jewel.markdown.extensions.github.alerts.GitHubAlertProcessorExtension
 import org.jetbrains.jewel.markdown.extensions.github.alerts.GitHubAlertRendererExtension
 import org.jetbrains.jewel.markdown.processing.MarkdownProcessor
-import org.jetbrains.jewel.markdown.rendering.InlineMarkdownRenderer
 import org.jetbrains.jewel.markdown.rendering.MarkdownBlockRenderer
 import org.jetbrains.jewel.markdown.rendering.MarkdownStyling
 import org.jetbrains.jewel.ui.component.VerticalScrollbar
@@ -75,13 +74,11 @@ internal fun MarkdownPreview(
                 MarkdownBlockRenderer.dark(
                     styling = markdownStyling,
                     rendererExtensions = listOf(GitHubAlertRendererExtension(AlertStyling.dark(), markdownStyling)),
-                    inlineRenderer = InlineMarkdownRenderer.default(extensions),
                 )
             } else {
                 MarkdownBlockRenderer.light(
                     styling = markdownStyling,
                     rendererExtensions = listOf(GitHubAlertRendererExtension(AlertStyling.light(), markdownStyling)),
-                    inlineRenderer = InlineMarkdownRenderer.default(extensions),
                 )
             }
         }

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/markdown/MarkdownPreview.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/markdown/MarkdownPreview.kt
@@ -52,12 +52,12 @@ internal fun MarkdownPreview(
         remember(isDark) { if (isDark) MarkdownStyling.dark() else MarkdownStyling.light() }
 
     var markdownBlocks by remember { mutableStateOf(emptyList<MarkdownBlock>()) }
-    val extensions = listOf(GitHubAlertProcessorExtension, AutolinkProcessorExtension)
+    val extensions = remember { listOf(GitHubAlertProcessorExtension, AutolinkProcessorExtension) }
 
     // We are doing this here for the sake of simplicity.
     // In a real-world scenario you would be doing this outside your Composables,
     // potentially involving ViewModels, dependency injection, etc.
-    val processor = remember { MarkdownProcessor(extensions) }
+    val processor = remember { MarkdownProcessor(extensions, optimizeEdits = true) }
 
     LaunchedEffect(rawMarkdown) {
         // TODO you may want to debounce or drop on backpressure, in real usages. You should also not do this


### PR DESCRIPTION
This PR changes a number of things in the Markdown rendering pipeline:

### 1. We will not optimise for edits by default anymore
The vast majority of Markdown usages are in UI text, which will never change. Having optimise for edits enabled by default added an enormous overhead since the same processor instance was shared across all usages, and we were doing pointless work every time some UI text was shown. All strings in this case are different, and they don't change often (or at all).

The flag is now off by default. Users who want to implement an editor preview will need to provide their own processor instance with the flag set (see standalone sample).

### 2. Models implement equals and hashCode
Using value classes had a small rendering performance and memory improvement, but it meant that we relied on CommonMark's models for equality checking and hashcode calculation. CommonMark's models do not implement these methods, so we were stuck with reference checks, which even if the content was identical would result in a recomposition.

This PR gets rid of the value classes and switches to normal classes, backed by Poko autogenerated equals/hashCode/toString. Inline Markdown is not passed through as a string anymore, to be rendered into inline models during UI rendering. Now the rendering phase only needs to visit our models, making it significantly faster.

Also, models don't contain business logic anymore; it's the processor's job to know how to translate CommonMark models to our own.

A huge amount of changes in this PR are needed to adapt tests accordingly. Feel free to ignore the changes in `MarkdownProcessorDocumentParsingTest`, they're all mechanical changes but functionally equivalent.

### 3. Inline extensions are now (tentatively) supported
There is a new extension API for custom inline node processing and rendering. We have not tested it yet, nor we have used it yet. However, it should make possible to implement #325 properly in a separate module, instead of dumping it in markdown-core.

I expect the inline rendering API might need some more work before being fully functional; we'll see as we start using it.

### 4. Code cleanup
✨ 