### PR TITLE
Rename optimizeEdits to editorMode in MarkdownProcessor

### DIFF
--- a/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/processing/MarkdownProcessorOptimizeEditsTest.kt
+++ b/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/processing/MarkdownProcessorOptimizeEditsTest.kt
@@ -45,7 +45,7 @@ class MarkdownProcessorOptimizeEditsTest {
 
     @Test
     fun `first blocks stay the same`() {
-        val processor = MarkdownProcessor(optimizeEdits = true)
+        val processor = MarkdownProcessor(editorMode = true)
         val firstRun = processor.processWithQuickEdits(rawMarkdown)
         val secondRun =
             processor.processWithQuickEdits(
@@ -80,7 +80,7 @@ class MarkdownProcessorOptimizeEditsTest {
 
     @Test
     fun `first block edited`() {
-        val processor = MarkdownProcessor(optimizeEdits = true)
+        val processor = MarkdownProcessor(editorMode = true)
         val firstRun = processor.processWithQuickEdits(rawMarkdown)
         val secondRun =
             processor.processWithQuickEdits(
@@ -136,7 +136,7 @@ class MarkdownProcessorOptimizeEditsTest {
 
     @Test
     fun `last block edited`() {
-        val processor = MarkdownProcessor(optimizeEdits = true)
+        val processor = MarkdownProcessor(editorMode = true)
         val firstRun = processor.processWithQuickEdits(rawMarkdown)
         val secondRun =
             processor.processWithQuickEdits(
@@ -195,7 +195,7 @@ class MarkdownProcessorOptimizeEditsTest {
 
     @Test
     fun `middle block edited`() {
-        val processor = MarkdownProcessor(optimizeEdits = true)
+        val processor = MarkdownProcessor(editorMode = true)
         val firstRun = processor.processWithQuickEdits(rawMarkdown)
         val secondRun =
             processor.processWithQuickEdits(
@@ -256,7 +256,7 @@ class MarkdownProcessorOptimizeEditsTest {
 
     @Test
     fun `blocks merged`() {
-        val processor = MarkdownProcessor(optimizeEdits = true)
+        val processor = MarkdownProcessor(editorMode = true)
         val firstRun = processor.processWithQuickEdits(rawMarkdown)
         val secondRun =
             processor.processWithQuickEdits(
@@ -313,7 +313,7 @@ class MarkdownProcessorOptimizeEditsTest {
 
     @Test
     fun `blocks split`() {
-        val processor = MarkdownProcessor(optimizeEdits = true)
+        val processor = MarkdownProcessor(editorMode = true)
         val firstRun = processor.processWithQuickEdits(rawMarkdown)
         val secondRun =
             processor.processWithQuickEdits(
@@ -371,7 +371,7 @@ class MarkdownProcessorOptimizeEditsTest {
 
     @Test
     fun `blocks deleted`() {
-        val processor = MarkdownProcessor(optimizeEdits = true)
+        val processor = MarkdownProcessor(editorMode = true)
         val firstRun = processor.processWithQuickEdits(rawMarkdown)
         val secondRun =
             processor.processWithQuickEdits(
@@ -423,7 +423,7 @@ class MarkdownProcessorOptimizeEditsTest {
 
     @Test
     fun `blocks added`() {
-        val processor = MarkdownProcessor(optimizeEdits = true)
+        val processor = MarkdownProcessor(editorMode = true)
         val firstRun = processor.processWithQuickEdits(rawMarkdown)
         val secondDocument =
             """
@@ -491,7 +491,7 @@ class MarkdownProcessorOptimizeEditsTest {
 
     @Test
     fun `no changes`() {
-        val processor = MarkdownProcessor(optimizeEdits = true)
+        val processor = MarkdownProcessor(editorMode = true)
         val firstRun = processor.processWithQuickEdits(rawMarkdown)
         val secondRun = processor.processWithQuickEdits(rawMarkdown)
         assertHtmlEquals(
@@ -523,7 +523,7 @@ class MarkdownProcessorOptimizeEditsTest {
 
     @Test
     fun `empty line added`() {
-        val processor = MarkdownProcessor(optimizeEdits = true)
+        val processor = MarkdownProcessor(editorMode = true)
         val firstRun = processor.processWithQuickEdits(rawMarkdown)
         val secondRun = processor.processWithQuickEdits("\n" + rawMarkdown)
         assertHtmlEquals(
@@ -557,7 +557,7 @@ class MarkdownProcessorOptimizeEditsTest {
     /** Regression https://github.com/JetBrains/jewel/issues/344 */
     @Test
     fun `content if empty`() {
-        val processor = MarkdownProcessor(optimizeEdits = true)
+        val processor = MarkdownProcessor(editorMode = true)
         processor.processWithQuickEdits(rawMarkdown)
         val secondRun = processor.processWithQuickEdits("")
         assertHtmlEquals(
@@ -570,7 +570,7 @@ class MarkdownProcessorOptimizeEditsTest {
 
     @Test
     fun `chained changes`() {
-        val processor = MarkdownProcessor(optimizeEdits = true)
+        val processor = MarkdownProcessor(editorMode = true)
         processor.processWithQuickEdits(
             """
             # Header 0

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/markdown/MarkdownPreview.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/markdown/MarkdownPreview.kt
@@ -56,7 +56,7 @@ internal fun MarkdownPreview(
     // We are doing this here for the sake of simplicity.
     // In a real-world scenario you would be doing this outside your Composables,
     // potentially involving ViewModels, dependency injection, etc.
-    val processor = remember { MarkdownProcessor(extensions, optimizeEdits = true) }
+    val processor = remember { MarkdownProcessor(extensions, editorMode = true) }
 
     LaunchedEffect(rawMarkdown) {
         // TODO you may want to debounce or drop on backpressure, in real usages. You should also not do this


### PR DESCRIPTION
Also improve the documentation. Precursor/companion to #482 