### PR TITLE
Add underline style to links

### DIFF
--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridge.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridge.kt
@@ -85,6 +85,7 @@ import org.jetbrains.jewel.ui.component.styling.LinkColors
 import org.jetbrains.jewel.ui.component.styling.LinkIcons
 import org.jetbrains.jewel.ui.component.styling.LinkMetrics
 import org.jetbrains.jewel.ui.component.styling.LinkStyle
+import org.jetbrains.jewel.ui.component.styling.LinkUnderlineBehavior
 import org.jetbrains.jewel.ui.component.styling.MenuColors
 import org.jetbrains.jewel.ui.component.styling.MenuIcons
 import org.jetbrains.jewel.ui.component.styling.MenuItemColors
@@ -652,6 +653,7 @@ private fun readLinkStyle(): LinkStyle {
                 dropdownChevron = AllIconsKeys.General.ChevronDown,
                 externalLink = AllIconsKeys.Ide.External_link_arrow,
             ),
+        underlineBehavior = LinkUnderlineBehavior.ShowOnHover,
     )
 }
 

--- a/int-ui/int-ui-standalone/api/int-ui-standalone.api
+++ b/int-ui/int-ui-standalone/api/int-ui-standalone.api
@@ -193,14 +193,18 @@ public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLazyTreeSty
 }
 
 public final class org/jetbrains/jewel/intui/standalone/styling/IntUiLinkStylingKt {
-	public static final fun dark (Lorg/jetbrains/jewel/ui/component/styling/LinkStyle$Companion;Lorg/jetbrains/jewel/ui/component/styling/LinkColors;Lorg/jetbrains/jewel/ui/component/styling/LinkMetrics;Lorg/jetbrains/jewel/ui/component/styling/LinkIcons;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/ui/component/styling/LinkStyle;
-	public static final fun dark-dPtIKUs (Lorg/jetbrains/jewel/ui/component/styling/LinkColors$Companion;JJJJJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/ui/component/styling/LinkColors;
+	public static final fun dark (Lorg/jetbrains/jewel/ui/component/styling/LinkStyle$Companion;Lorg/jetbrains/jewel/ui/component/styling/LinkColors;Lorg/jetbrains/jewel/ui/component/styling/LinkMetrics;Lorg/jetbrains/jewel/ui/component/styling/LinkIcons;Lorg/jetbrains/jewel/ui/component/styling/LinkUnderlineBehavior;)Lorg/jetbrains/jewel/ui/component/styling/LinkStyle;
+	public static synthetic fun dark$default (Lorg/jetbrains/jewel/ui/component/styling/LinkStyle$Companion;Lorg/jetbrains/jewel/ui/component/styling/LinkColors;Lorg/jetbrains/jewel/ui/component/styling/LinkMetrics;Lorg/jetbrains/jewel/ui/component/styling/LinkIcons;Lorg/jetbrains/jewel/ui/component/styling/LinkUnderlineBehavior;ILjava/lang/Object;)Lorg/jetbrains/jewel/ui/component/styling/LinkStyle;
+	public static final fun dark-40kPL-U (Lorg/jetbrains/jewel/ui/component/styling/LinkColors$Companion;JJJJJJ)Lorg/jetbrains/jewel/ui/component/styling/LinkColors;
+	public static synthetic fun dark-40kPL-U$default (Lorg/jetbrains/jewel/ui/component/styling/LinkColors$Companion;JJJJJJILjava/lang/Object;)Lorg/jetbrains/jewel/ui/component/styling/LinkColors;
 	public static final fun defaults (Lorg/jetbrains/jewel/ui/component/styling/LinkIcons$Companion;Lorg/jetbrains/jewel/ui/icon/IconKey;Lorg/jetbrains/jewel/ui/icon/IconKey;)Lorg/jetbrains/jewel/ui/component/styling/LinkIcons;
 	public static synthetic fun defaults$default (Lorg/jetbrains/jewel/ui/component/styling/LinkIcons$Companion;Lorg/jetbrains/jewel/ui/icon/IconKey;Lorg/jetbrains/jewel/ui/icon/IconKey;ILjava/lang/Object;)Lorg/jetbrains/jewel/ui/component/styling/LinkIcons;
 	public static final fun defaults-7dA9OmY (Lorg/jetbrains/jewel/ui/component/styling/LinkMetrics$Companion;Landroidx/compose/foundation/shape/CornerSize;FJ)Lorg/jetbrains/jewel/ui/component/styling/LinkMetrics;
 	public static synthetic fun defaults-7dA9OmY$default (Lorg/jetbrains/jewel/ui/component/styling/LinkMetrics$Companion;Landroidx/compose/foundation/shape/CornerSize;FJILjava/lang/Object;)Lorg/jetbrains/jewel/ui/component/styling/LinkMetrics;
-	public static final fun light (Lorg/jetbrains/jewel/ui/component/styling/LinkStyle$Companion;Lorg/jetbrains/jewel/ui/component/styling/LinkColors;Lorg/jetbrains/jewel/ui/component/styling/LinkMetrics;Lorg/jetbrains/jewel/ui/component/styling/LinkIcons;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/ui/component/styling/LinkStyle;
-	public static final fun light-dPtIKUs (Lorg/jetbrains/jewel/ui/component/styling/LinkColors$Companion;JJJJJJLandroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/ui/component/styling/LinkColors;
+	public static final fun light (Lorg/jetbrains/jewel/ui/component/styling/LinkStyle$Companion;Lorg/jetbrains/jewel/ui/component/styling/LinkColors;Lorg/jetbrains/jewel/ui/component/styling/LinkMetrics;Lorg/jetbrains/jewel/ui/component/styling/LinkIcons;Lorg/jetbrains/jewel/ui/component/styling/LinkUnderlineBehavior;)Lorg/jetbrains/jewel/ui/component/styling/LinkStyle;
+	public static synthetic fun light$default (Lorg/jetbrains/jewel/ui/component/styling/LinkStyle$Companion;Lorg/jetbrains/jewel/ui/component/styling/LinkColors;Lorg/jetbrains/jewel/ui/component/styling/LinkMetrics;Lorg/jetbrains/jewel/ui/component/styling/LinkIcons;Lorg/jetbrains/jewel/ui/component/styling/LinkUnderlineBehavior;ILjava/lang/Object;)Lorg/jetbrains/jewel/ui/component/styling/LinkStyle;
+	public static final fun light-40kPL-U (Lorg/jetbrains/jewel/ui/component/styling/LinkColors$Companion;JJJJJJ)Lorg/jetbrains/jewel/ui/component/styling/LinkColors;
+	public static synthetic fun light-40kPL-U$default (Lorg/jetbrains/jewel/ui/component/styling/LinkColors$Companion;JJJJJJILjava/lang/Object;)Lorg/jetbrains/jewel/ui/component/styling/LinkColors;
 }
 
 public final class org/jetbrains/jewel/intui/standalone/styling/IntUiMenuStylingKt {

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiLinkStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiLinkStyling.kt
@@ -1,7 +1,6 @@
 package org.jetbrains.jewel.intui.standalone.styling
 
 import androidx.compose.foundation.shape.CornerSize
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
@@ -12,24 +11,24 @@ import org.jetbrains.jewel.ui.component.styling.LinkColors
 import org.jetbrains.jewel.ui.component.styling.LinkIcons
 import org.jetbrains.jewel.ui.component.styling.LinkMetrics
 import org.jetbrains.jewel.ui.component.styling.LinkStyle
+import org.jetbrains.jewel.ui.component.styling.LinkUnderlineBehavior
 import org.jetbrains.jewel.ui.icon.IconKey
 import org.jetbrains.jewel.ui.icons.AllIconsKeys
 
-@Composable
 public fun LinkStyle.Companion.light(
     colors: LinkColors = LinkColors.light(),
     metrics: LinkMetrics = LinkMetrics.defaults(),
     icons: LinkIcons = LinkIcons.defaults(),
-): LinkStyle = LinkStyle(colors, metrics, icons)
+    underlineBehavior: LinkUnderlineBehavior = LinkUnderlineBehavior.ShowOnHover,
+): LinkStyle = LinkStyle(colors, metrics, icons, underlineBehavior)
 
-@Composable
 public fun LinkStyle.Companion.dark(
     colors: LinkColors = LinkColors.dark(),
     metrics: LinkMetrics = LinkMetrics.defaults(),
     icons: LinkIcons = LinkIcons.defaults(),
-): LinkStyle = LinkStyle(colors, metrics, icons)
+    underlineBehavior: LinkUnderlineBehavior = LinkUnderlineBehavior.ShowOnHover,
+): LinkStyle = LinkStyle(colors, metrics, icons, underlineBehavior)
 
-@Composable
 public fun LinkColors.Companion.light(
     content: Color = IntUiLightTheme.colors.blue(2),
     contentDisabled: Color = IntUiLightTheme.colors.gray(8),
@@ -47,7 +46,6 @@ public fun LinkColors.Companion.light(
         contentVisited = contentVisited,
     )
 
-@Composable
 public fun LinkColors.Companion.dark(
     content: Color = IntUiDarkTheme.colors.blue(9),
     contentDisabled: Color = IntUiDarkTheme.colors.gray(7),

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/component/Links.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/component/Links.kt
@@ -25,13 +25,14 @@ import org.jetbrains.jewel.ui.component.styling.LinkUnderlineBehavior
 @View(title = "Links", position = 4, icon = "icons/components/links.svg")
 fun Links() {
     val isDark = JewelTheme.isDark
-    val alwaysUnderlinedStyle = remember(isDark) {
-        if (isDark) {
-            LinkStyle.dark(underlineBehavior = LinkUnderlineBehavior.ShowAlways)
-        } else {
-            LinkStyle.light(underlineBehavior = LinkUnderlineBehavior.ShowAlways)
+    val alwaysUnderlinedStyle =
+        remember(isDark) {
+            if (isDark) {
+                LinkStyle.dark(underlineBehavior = LinkUnderlineBehavior.ShowAlways)
+            } else {
+                LinkStyle.light(underlineBehavior = LinkUnderlineBehavior.ShowAlways)
+            }
         }
-    }
 
     Row(
         horizontalArrangement = Arrangement.spacedBy(10.dp),

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/component/Links.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/component/Links.kt
@@ -9,21 +9,37 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.intui.standalone.styling.dark
+import org.jetbrains.jewel.intui.standalone.styling.light
 import org.jetbrains.jewel.samples.standalone.viewmodel.View
 import org.jetbrains.jewel.ui.component.DropdownLink
 import org.jetbrains.jewel.ui.component.ExternalLink
 import org.jetbrains.jewel.ui.component.Link
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.component.separator
+import org.jetbrains.jewel.ui.component.styling.LinkStyle
+import org.jetbrains.jewel.ui.component.styling.LinkUnderlineBehavior
 
 @Composable
 @View(title = "Links", position = 4, icon = "icons/components/links.svg")
 fun Links() {
+    val isDark = JewelTheme.isDark
+    val alwaysUnderlinedStyle = remember(isDark) {
+        if (isDark) {
+            LinkStyle.dark(underlineBehavior = LinkUnderlineBehavior.ShowAlways)
+        } else {
+            LinkStyle.light(underlineBehavior = LinkUnderlineBehavior.ShowAlways)
+        }
+    }
+
     Row(
         horizontalArrangement = Arrangement.spacedBy(10.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Link("Link", {})
+
+        Link("Always underlined", {}, style = alwaysUnderlinedStyle)
 
         ExternalLink("ExternalLink", {})
 
@@ -61,6 +77,8 @@ fun Links() {
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Link("Link", {}, enabled = false)
+
+        Link("Always underlined", {}, style = alwaysUnderlinedStyle, enabled = false)
 
         ExternalLink("ExternalLink", {}, enabled = false)
 

--- a/ui/api/ui.api
+++ b/ui/api/ui.api
@@ -1551,11 +1551,12 @@ public final class org/jetbrains/jewel/ui/component/styling/LinkMetrics$Companio
 public final class org/jetbrains/jewel/ui/component/styling/LinkStyle {
 	public static final field $stable I
 	public static final field Companion Lorg/jetbrains/jewel/ui/component/styling/LinkStyle$Companion;
-	public fun <init> (Lorg/jetbrains/jewel/ui/component/styling/LinkColors;Lorg/jetbrains/jewel/ui/component/styling/LinkMetrics;Lorg/jetbrains/jewel/ui/component/styling/LinkIcons;)V
+	public fun <init> (Lorg/jetbrains/jewel/ui/component/styling/LinkColors;Lorg/jetbrains/jewel/ui/component/styling/LinkMetrics;Lorg/jetbrains/jewel/ui/component/styling/LinkIcons;Lorg/jetbrains/jewel/ui/component/styling/LinkUnderlineBehavior;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getColors ()Lorg/jetbrains/jewel/ui/component/styling/LinkColors;
 	public final fun getIcons ()Lorg/jetbrains/jewel/ui/component/styling/LinkIcons;
 	public final fun getMetrics ()Lorg/jetbrains/jewel/ui/component/styling/LinkMetrics;
+	public final fun getUnderlineBehavior ()Lorg/jetbrains/jewel/ui/component/styling/LinkUnderlineBehavior;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -1565,6 +1566,14 @@ public final class org/jetbrains/jewel/ui/component/styling/LinkStyle$Companion 
 
 public final class org/jetbrains/jewel/ui/component/styling/LinkStylingKt {
 	public static final fun getLocalLinkStyle ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public final class org/jetbrains/jewel/ui/component/styling/LinkUnderlineBehavior : java/lang/Enum {
+	public static final field ShowAlways Lorg/jetbrains/jewel/ui/component/styling/LinkUnderlineBehavior;
+	public static final field ShowOnHover Lorg/jetbrains/jewel/ui/component/styling/LinkUnderlineBehavior;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lorg/jetbrains/jewel/ui/component/styling/LinkUnderlineBehavior;
+	public static fun values ()[Lorg/jetbrains/jewel/ui/component/styling/LinkUnderlineBehavior;
 }
 
 public final class org/jetbrains/jewel/ui/component/styling/MenuColors {

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Link.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Link.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.platform.LocalInputModeManager
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextOverflow
 import org.jetbrains.jewel.foundation.modifier.onHover
 import org.jetbrains.jewel.foundation.state.CommonStateBitMask
@@ -39,6 +40,8 @@ import org.jetbrains.jewel.foundation.state.FocusableComponentState
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.foundation.theme.JewelTheme.Companion.isSwingCompatMode
 import org.jetbrains.jewel.ui.component.styling.LinkStyle
+import org.jetbrains.jewel.ui.component.styling.LinkUnderlineBehavior.ShowAlways
+import org.jetbrains.jewel.ui.component.styling.LinkUnderlineBehavior.ShowOnHover
 import org.jetbrains.jewel.ui.component.styling.LocalLinkStyle
 import org.jetbrains.jewel.ui.component.styling.LocalMenuStyle
 import org.jetbrains.jewel.ui.component.styling.MenuStyle
@@ -188,29 +191,39 @@ private fun LinkImpl(
     }
 
     val textColor by style.colors.contentFor(linkState)
+    val mergedTextStyle = remember(style.underlineBehavior, textStyle, linkState, textColor) {
+        val decoration =
+            when {
+                style.underlineBehavior == ShowAlways -> TextDecoration.Underline
+                style.underlineBehavior == ShowOnHover && linkState.isHovered -> TextDecoration.Underline
+                else -> TextDecoration.None
+            }
+
+        textStyle.merge(textDecoration = decoration, color = textColor)
+    }
 
     val pointerChangeModifier = Modifier.pointerHoverIcon(PointerIcon(Cursor(Cursor.HAND_CURSOR)))
 
     Row(
         modifier =
-            modifier
-                .thenIf(linkState.isEnabled) { pointerChangeModifier }
-                .clickable(
-                    onClick = {
-                        linkState = linkState.copy(visited = true)
-                        onClick()
-                    },
-                    enabled = enabled,
-                    role = Role.Button,
-                    interactionSource = interactionSource,
-                    indication = null,
-                ).focusOutline(linkState, RoundedCornerShape(style.metrics.focusHaloCornerSize)),
+        modifier
+            .thenIf(linkState.isEnabled) { pointerChangeModifier }
+            .clickable(
+                onClick = {
+                    linkState = linkState.copy(visited = true)
+                    onClick()
+                },
+                enabled = enabled,
+                role = Role.Button,
+                interactionSource = interactionSource,
+                indication = null,
+            ).focusOutline(linkState, RoundedCornerShape(style.metrics.focusHaloCornerSize)),
         horizontalArrangement = Arrangement.spacedBy(style.metrics.textIconGap),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         BasicText(
             text = text,
-            style = textStyle.merge(textColor),
+            style = mergedTextStyle,
             overflow = overflow,
             softWrap = true,
             maxLines = 1,

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/styling/LinkStyling.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/styling/LinkStyling.kt
@@ -20,6 +20,7 @@ public class LinkStyle(
     public val colors: LinkColors,
     public val metrics: LinkMetrics,
     public val icons: LinkIcons,
+    public val underlineBehavior: LinkUnderlineBehavior,
 ) {
     public companion object
 }
@@ -74,3 +75,7 @@ public val LocalLinkStyle: ProvidableCompositionLocal<LinkStyle> =
     staticCompositionLocalOf {
         error("No LinkStyle provided. Have you forgotten the theme?")
     }
+
+public enum class LinkUnderlineBehavior {
+    ShowAlways, ShowOnHover
+}


### PR DESCRIPTION
We removed text styles in #490, but links can still either show underlined when they are hovered (default), or always. This adds a way to set that.