### PR TITLE
Lower target JDK for 242

### DIFF
--- a/.idea/runConfigurations/Check_IJP_updates.xml
+++ b/.idea/runConfigurations/Check_IJP_updates.xml
@@ -1,17 +1,16 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Regenerate themes" type="GradleRunConfiguration" factoryName="Gradle">
+  <configuration default="false" name="Check IJP updates" type="GradleRunConfiguration" factoryName="Gradle" folderName="Checks">
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="--rerun-tasks" />
+      <option name="scriptParameters" value="" />
       <option name="taskDescriptions">
         <list />
       </option>
       <option name="taskNames">
         <list>
-          <option value="generateIntUiDarkTheme" />
-          <option value="generateIntUiLightTheme" />
+          <option value="checkLatestIntelliJPlatformBuild" />
         </list>
       </option>
       <option name="vmOptions" />

--- a/.idea/runConfigurations/Test_publication.xml
+++ b/.idea/runConfigurations/Test_publication.xml
@@ -1,16 +1,17 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Update API signatures" type="GradleRunConfiguration" factoryName="Gradle">
+  <configuration default="false" name="Test publication" type="GradleRunConfiguration" factoryName="Gradle" folderName="Publish">
     <ExternalSystemSettings>
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="" />
+      <option name="scriptParameters" value="-PuseCurrentVersion -Pno-sign=true" />
       <option name="taskDescriptions">
         <list />
       </option>
       <option name="taskNames">
         <list>
-          <option value="apiDump" />
+          <option value="cleanTestPublishArtifacts" />
+          <option value="publishAllPublicationsToLocalTestRepository" />
         </list>
       </option>
       <option name="vmOptions" />

--- a/buildSrc/src/main/kotlin/jewel.gradle.kts
+++ b/buildSrc/src/main/kotlin/jewel.gradle.kts
@@ -10,9 +10,25 @@ group = "org.jetbrains.jewel"
 val gitHubRef: String? = System.getenv("GITHUB_REF")
 
 version = when {
+    properties.containsKey("versionOverride") -> {
+        val rawVersion = (properties["versionOverride"] as String).trim()
+        if (!rawVersion.matches("^\\d\\.\\d{2,}\\.\\d+$".toRegex())) {
+            throw GradleException("Invalid versionOverride: $rawVersion")
+        }
+        logger.warn("Using version override: $rawVersion")
+        rawVersion
+    }
     gitHubRef?.startsWith("refs/tags/") == true -> {
         gitHubRef.substringAfter("refs/tags/")
             .removePrefix("v")
+    }
+    properties.containsKey("useCurrentVersion") -> {
+        val rawVersion = (properties["jewel.release.version"] as String).trim()
+        if (!rawVersion.matches("^\\d\\.\\d{2,}\\.\\d+$".toRegex())) {
+            throw GradleException("Invalid jewel.release.version found in gradle.properties: $rawVersion")
+        }
+        logger.warn("Using jewel.release.version: $rawVersion")
+        rawVersion
     }
 
     else -> "1.0.0-SNAPSHOT"

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,6 @@ kotlin.incremental.useClasspathSnapshot=false
 
 org.jetbrains.intellij.platform.buildFeature.useBinaryReleases=false
 
-jdk.level=21
+jdk.level=17
 ijp.target=242
 jewel.release.version=0.22.0


### PR DESCRIPTION
We had set 21 as that was the JDK that the IJP 242 runs on, but that was causing issues in some other places. Since the target JDK is a _minimum_ level, code targeting 17 also works fine in 21. Because of this, we have no reason not to lower it back to 17.