### PR TITLE
Add basic shortcuts to Standalone L1 navigation screens

### DIFF
--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/Main.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/Main.kt
@@ -1,6 +1,12 @@
 package org.jetbrains.jewel.samples.standalone
 
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEvent
+import androidx.compose.ui.input.key.KeyEventType.Companion.KeyDown
+import androidx.compose.ui.input.key.isAltPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.res.ResourceLoader
 import androidx.compose.ui.res.loadSvgPainter
 import androidx.compose.ui.text.font.FontFamily
@@ -22,6 +28,8 @@ import org.jetbrains.jewel.intui.window.styling.light
 import org.jetbrains.jewel.intui.window.styling.lightWithLightHeader
 import org.jetbrains.jewel.samples.standalone.view.TitleBarView
 import org.jetbrains.jewel.samples.standalone.viewmodel.MainViewModel
+import org.jetbrains.jewel.samples.standalone.viewmodel.MainViewModel.currentView
+import org.jetbrains.jewel.samples.standalone.viewmodel.MainViewModel.views
 import org.jetbrains.jewel.ui.ComponentStyling
 import org.jetbrains.jewel.window.DecoratedWindow
 import org.jetbrains.jewel.window.styling.TitleBarStyle
@@ -48,33 +56,60 @@ fun main() {
         IntUiTheme(
             theme = themeDefinition,
             styling =
-                ComponentStyling.default().decoratedWindow(
-                    titleBarStyle =
-                        when (MainViewModel.theme) {
-                            IntUiThemes.Light -> TitleBarStyle.light()
-                            IntUiThemes.LightWithLightHeader -> TitleBarStyle.lightWithLightHeader()
-                            IntUiThemes.Dark -> TitleBarStyle.dark()
-                            IntUiThemes.System ->
-                                if (MainViewModel.theme.isDark()) {
-                                    TitleBarStyle.dark()
-                                } else {
-                                    TitleBarStyle.light()
-                                }
-                        },
-                ),
+            ComponentStyling.default().decoratedWindow(
+                titleBarStyle =
+                when (MainViewModel.theme) {
+                    IntUiThemes.Light -> TitleBarStyle.light()
+                    IntUiThemes.LightWithLightHeader -> TitleBarStyle.lightWithLightHeader()
+                    IntUiThemes.Dark -> TitleBarStyle.dark()
+                    IntUiThemes.System ->
+                        if (MainViewModel.theme.isDark()) {
+                            TitleBarStyle.dark()
+                        } else {
+                            TitleBarStyle.light()
+                        }
+                },
+            ),
             swingCompatMode = MainViewModel.swingCompat,
         ) {
             DecoratedWindow(
                 onCloseRequest = { exitApplication() },
                 title = "Jewel standalone sample",
                 icon = icon,
-            ) {
-                TitleBarView()
-                MainViewModel.currentView.content()
-            }
+                onKeyEvent = ::processKeyShortcuts,
+                content = {
+                    TitleBarView()
+                    currentView.content()
+                },
+            )
         }
     }
 }
+
+/*
+    Alt + W -> Welcome
+    Alt + M -> Markdown
+    Alt + C -> Components
+ */
+private fun processKeyShortcuts(it: KeyEvent) =
+    when {
+        it.isAltPressed && it.key == Key.W && it.type == KeyDown -> {
+            currentView = views.first { viewInfo -> viewInfo.title == "Welcome" }
+            true
+        }
+
+        it.isAltPressed && it.key == Key.M && it.type == KeyDown -> {
+            currentView = views.first { viewInfo -> viewInfo.title == "Markdown" }
+            true
+        }
+
+        it.isAltPressed && it.key == Key.C && it.type == KeyDown -> {
+            currentView = views.first { viewInfo -> viewInfo.title == "Components" }
+            true
+        }
+
+        else -> false
+    }
 
 private fun svgResource(
     resourcePath: String,

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/Main.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/Main.kt
@@ -56,20 +56,20 @@ fun main() {
         IntUiTheme(
             theme = themeDefinition,
             styling =
-            ComponentStyling.default().decoratedWindow(
-                titleBarStyle =
-                when (MainViewModel.theme) {
-                    IntUiThemes.Light -> TitleBarStyle.light()
-                    IntUiThemes.LightWithLightHeader -> TitleBarStyle.lightWithLightHeader()
-                    IntUiThemes.Dark -> TitleBarStyle.dark()
-                    IntUiThemes.System ->
-                        if (MainViewModel.theme.isDark()) {
-                            TitleBarStyle.dark()
-                        } else {
-                            TitleBarStyle.light()
-                        }
-                },
-            ),
+                ComponentStyling.default().decoratedWindow(
+                    titleBarStyle =
+                        when (MainViewModel.theme) {
+                            IntUiThemes.Light -> TitleBarStyle.light()
+                            IntUiThemes.LightWithLightHeader -> TitleBarStyle.lightWithLightHeader()
+                            IntUiThemes.Dark -> TitleBarStyle.dark()
+                            IntUiThemes.System ->
+                                if (MainViewModel.theme.isDark()) {
+                                    TitleBarStyle.dark()
+                                } else {
+                                    TitleBarStyle.light()
+                                }
+                        },
+                ),
             swingCompatMode = MainViewModel.swingCompat,
         ) {
             DecoratedWindow(

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/Main.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/Main.kt
@@ -3,7 +3,7 @@ package org.jetbrains.jewel.samples.standalone
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.input.key.KeyEvent
-import androidx.compose.ui.input.key.KeyEventType.Companion.KeyDown
+import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.isAltPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
@@ -29,7 +29,6 @@ import org.jetbrains.jewel.intui.window.styling.lightWithLightHeader
 import org.jetbrains.jewel.samples.standalone.view.TitleBarView
 import org.jetbrains.jewel.samples.standalone.viewmodel.MainViewModel
 import org.jetbrains.jewel.samples.standalone.viewmodel.MainViewModel.currentView
-import org.jetbrains.jewel.samples.standalone.viewmodel.MainViewModel.views
 import org.jetbrains.jewel.ui.ComponentStyling
 import org.jetbrains.jewel.window.DecoratedWindow
 import org.jetbrains.jewel.window.styling.TitleBarStyle
@@ -76,7 +75,12 @@ fun main() {
                 onCloseRequest = { exitApplication() },
                 title = "Jewel standalone sample",
                 icon = icon,
-                onKeyEvent = ::processKeyShortcuts,
+                onKeyEvent = { keyEvent ->
+                    processKeyShortcuts(
+                        keyEvent = keyEvent,
+                        onNavigateTo = MainViewModel::onNavigateTo,
+                    )
+                },
                 content = {
                     TitleBarView()
                     currentView.content()
@@ -91,25 +95,30 @@ fun main() {
     Alt + M -> Markdown
     Alt + C -> Components
  */
-private fun processKeyShortcuts(it: KeyEvent) =
-    when {
-        it.isAltPressed && it.key == Key.W && it.type == KeyDown -> {
-            currentView = views.first { viewInfo -> viewInfo.title == "Welcome" }
+private fun processKeyShortcuts(
+    keyEvent: KeyEvent,
+    onNavigateTo: (String) -> Unit,
+): Boolean {
+    if (!keyEvent.isAltPressed || keyEvent.type != KeyEventType.KeyDown) return false
+    return when (keyEvent.key) {
+        Key.W -> {
+            onNavigateTo("Welcome")
             true
         }
 
-        it.isAltPressed && it.key == Key.M && it.type == KeyDown -> {
-            currentView = views.first { viewInfo -> viewInfo.title == "Markdown" }
+        Key.M -> {
+            onNavigateTo("Markdown")
             true
         }
 
-        it.isAltPressed && it.key == Key.C && it.type == KeyDown -> {
-            currentView = views.first { viewInfo -> viewInfo.title == "Components" }
+        Key.C -> {
+            onNavigateTo("Components")
             true
         }
 
         else -> false
     }
+}
 
 private fun svgResource(
     resourcePath: String,

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/viewmodel/MainViewModel.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/viewmodel/MainViewModel.kt
@@ -9,6 +9,10 @@ import org.jetbrains.jewel.samples.standalone.IntUiThemes
 import org.jetbrains.jewel.samples.standalone.reflection.findViews
 
 object MainViewModel {
+    fun onNavigateTo(destination: String) {
+        currentView = views.first { viewInfo -> viewInfo.title == destination }
+    }
+
     var theme: IntUiThemes by mutableStateOf(IntUiThemes.Light)
 
     var swingCompat: Boolean by mutableStateOf(false)


### PR DESCRIPTION
As a developer quality of life improvement, we can navigate to the three L1 screens using the keyboard:

```
Alt + W -> Welcome
Alt + M -> Markdown
Alt + C -> Components
```

Shortcuts are different from the originally suggested ones because those will conflict with the system ones I'm using on Windows and would make the quality of my life the same, if not worse 😄 

The dropdown menu will not show the keybindings for now. We will iterate on this after https://github.com/JetBrains/jewel/issues/483.

This work was initially done in https://github.com/JetBrains/jewel/pull/457 and extracted to reduce the PR size.