### PR TITLE
Compose 1.7 FillMaxSize+Jpanels Workaround

### DIFF
--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/JewelComposePanel.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/JewelComposePanel.kt
@@ -1,10 +1,16 @@
 package org.jetbrains.jewel.bridge
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.ProvidableCompositionLocal
 import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposePanel
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.unit.toSize
 import org.jetbrains.jewel.bridge.actionSystem.ComponentDataProviderBridge
 import org.jetbrains.jewel.bridge.theme.SwingBridgeTheme
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
@@ -14,9 +20,11 @@ import javax.swing.JComponent
 public fun JewelComposePanel(content: @Composable () -> Unit): JComponent =
     ComposePanel().apply {
         setContent {
-            SwingBridgeTheme {
-                CompositionLocalProvider(LocalComponent provides this@apply) {
-                    ComponentDataProviderBridge(this@apply, content = content)
+            Compose17IJSizeBugWorkaround {
+                SwingBridgeTheme {
+                    CompositionLocalProvider(LocalComponent provides this@apply) {
+                        ComponentDataProviderBridge(this@apply, content = content)
+                    }
                 }
             }
         }
@@ -27,3 +35,15 @@ public val LocalComponent: ProvidableCompositionLocal<JComponent> =
     staticCompositionLocalOf {
         error("CompositionLocal LocalComponent not provided")
     }
+
+/**
+ * Workaround until the issue with Compose 1.7 + fillMax__ + IntelliJ Panels is fixed:
+ * https://github.com/JetBrains/jewel/issues/504
+ * https://youtrack.jetbrains.com/issue/CMP-5856
+ */
+@Composable
+private fun Compose17IJSizeBugWorkaround(content: @Composable () -> Unit) = with(LocalDensity.current) {
+    Box(modifier = Modifier.requiredSize(LocalWindowInfo.current.containerSize.toSize().toDpSize())) {
+        content()
+    }
+}

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/JewelComposePanel.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/JewelComposePanel.kt
@@ -42,8 +42,9 @@ public val LocalComponent: ProvidableCompositionLocal<JComponent> =
  * https://youtrack.jetbrains.com/issue/CMP-5856
  */
 @Composable
-private fun Compose17IJSizeBugWorkaround(content: @Composable () -> Unit) = with(LocalDensity.current) {
-    Box(modifier = Modifier.requiredSize(LocalWindowInfo.current.containerSize.toSize().toDpSize())) {
-        content()
+private fun Compose17IJSizeBugWorkaround(content: @Composable () -> Unit) =
+    with(LocalDensity.current) {
+        Box(modifier = Modifier.requiredSize(LocalWindowInfo.current.containerSize.toSize().toDpSize())) {
+            content()
+        }
     }
-}

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/JewelComposePanel.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/JewelComposePanel.kt
@@ -42,9 +42,10 @@ public val LocalComponent: ProvidableCompositionLocal<JComponent> =
  * https://youtrack.jetbrains.com/issue/CMP-5856
  */
 @Composable
-private fun Compose17IJSizeBugWorkaround(content: @Composable () -> Unit) =
+private fun Compose17IJSizeBugWorkaround(content: @Composable () -> Unit) {
     with(LocalDensity.current) {
         Box(modifier = Modifier.requiredSize(LocalWindowInfo.current.containerSize.toSize().toDpSize())) {
             content()
         }
     }
+}


### PR DESCRIPTION
 Workaround until the issue with Compose 1.7 + fillMax__ + IntelliJ Panels is fixed. 

It creates a box with a fixed required size at the root of `JewelComposePanel`, and uses the localcomposition to get the current panel (window) size.
 
 - https://github.com/JetBrains/jewel/issues/504
 - https://youtrack.jetbrains.com/issue/CMP-5856