### PR TITLE
Only apply workaround to CMP-5856 in toolwindows

### DIFF
--- a/ide-laf-bridge/api/ide-laf-bridge.api
+++ b/ide-laf-bridge/api/ide-laf-bridge.api
@@ -65,6 +65,7 @@ public final class org/jetbrains/jewel/bridge/JewelBridgeException$KeysNotFoundE
 
 public final class org/jetbrains/jewel/bridge/JewelComposePanelKt {
 	public static final fun JewelComposePanel (Lkotlin/jvm/functions/Function2;)Ljavax/swing/JComponent;
+	public static final fun JewelToolWindowComposePanel (Lkotlin/jvm/functions/Function2;)Ljavax/swing/JComponent;
 	public static final fun getLocalComponent ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 }
 

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/JewelComposePanel.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/JewelComposePanel.kt
@@ -14,10 +14,24 @@ import androidx.compose.ui.unit.toSize
 import org.jetbrains.jewel.bridge.actionSystem.ComponentDataProviderBridge
 import org.jetbrains.jewel.bridge.theme.SwingBridgeTheme
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
+import org.jetbrains.jewel.foundation.InternalJewelApi
 import javax.swing.JComponent
 
 @Suppress("ktlint:standard:function-naming", "FunctionName") // Swing to Compose bridge API
 public fun JewelComposePanel(content: @Composable () -> Unit): JComponent =
+    ComposePanel().apply {
+        setContent {
+            SwingBridgeTheme {
+                CompositionLocalProvider(LocalComponent provides this@apply) {
+                    ComponentDataProviderBridge(this@apply, content = content)
+                }
+            }
+        }
+    }
+
+@InternalJewelApi
+@Suppress("ktlint:standard:function-naming", "FunctionName") // Swing to Compose bridge API
+public fun JewelToolWindowComposePanel(content: @Composable () -> Unit): JComponent =
     ComposePanel().apply {
         setContent {
             Compose17IJSizeBugWorkaround {
@@ -37,9 +51,9 @@ public val LocalComponent: ProvidableCompositionLocal<JComponent> =
     }
 
 /**
- * Workaround until the issue with Compose 1.7 + fillMax__ + IntelliJ Panels is fixed:
- * https://github.com/JetBrains/jewel/issues/504
- * https://youtrack.jetbrains.com/issue/CMP-5856
+ * Workaround until the issue with Compose 1.7 + fillMax__ + IntelliJ
+ * Panels is fixed: https://github.com/JetBrains/jewel/issues/504
+ * https://youtrack.jetbrains.com/issue/CMP-5856.
  */
 @Composable
 private fun Compose17IJSizeBugWorkaround(content: @Composable () -> Unit) {

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/ToolWindowExtensions.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/ToolWindowExtensions.kt
@@ -17,7 +17,7 @@ public fun ToolWindow.addComposeTab(
 
     val tabContent =
         contentManager.factory.createContent(
-            JewelComposePanel {
+            JewelToolWindowComposePanel {
                 val scope =
                     object : ToolWindowScope {
                         override val toolWindow: ToolWindow


### PR DESCRIPTION
This workaround should not be applied to _all_ JewelComposePanels, since it breaks auto-sizing for the panels based on their contents. This change creates a separate JewelToolWindowComposePanel that can be used for ToolWindows only, and removes the workaround from all other panels.