### PR TITLE
Expose PopupProperties in PopupMenu

### DIFF
--- a/ui/api/ui.api
+++ b/ui/api/ui.api
@@ -497,7 +497,7 @@ public final class org/jetbrains/jewel/ui/component/MenuItemState$Companion {
 public final class org/jetbrains/jewel/ui/component/MenuKt {
 	public static final fun MenuSeparator (Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/ui/component/styling/MenuItemMetrics;Lorg/jetbrains/jewel/ui/component/styling/MenuItemColors;Landroidx/compose/runtime/Composer;II)V
 	public static final fun MenuSubmenuItem (Landroidx/compose/ui/Modifier;ZZLjava/lang/String;Ljava/lang/Class;Landroidx/compose/foundation/interaction/MutableInteractionSource;Lorg/jetbrains/jewel/ui/component/styling/MenuStyle;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
-	public static final fun PopupMenu (Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/ui/component/styling/MenuStyle;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun PopupMenu (Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Alignment$Horizontal;Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/ui/component/styling/MenuStyle;Landroidx/compose/ui/window/PopupProperties;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun items (Lorg/jetbrains/jewel/ui/component/MenuScope;ILkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;)V
 	public static final fun items (Lorg/jetbrains/jewel/ui/component/MenuScope;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;)V
 	public static final fun separator (Lorg/jetbrains/jewel/ui/component/MenuScope;)V

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Menu.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Menu.kt
@@ -91,6 +91,7 @@ public fun PopupMenu(
     horizontalAlignment: Alignment.Horizontal,
     modifier: Modifier = Modifier,
     style: MenuStyle = JewelTheme.menuStyle,
+    popupProperties: PopupProperties = PopupProperties(focusable = true),
     content: MenuScope.() -> Unit,
 ) {
     val density = LocalDensity.current
@@ -110,7 +111,7 @@ public fun PopupMenu(
     Popup(
         popupPositionProvider = popupPositionProvider,
         onDismissRequest = { onDismissRequest(InputMode.Touch) },
-        properties = PopupProperties(focusable = true),
+        properties = popupProperties,
         onPreviewKeyEvent = { false },
         onKeyEvent = {
             val currentFocusManager = checkNotNull(focusManager) { "FocusManager must not be null" }


### PR DESCRIPTION
PopupMenu internally uses Popup, but uses a hardcoded PopupPropterties object. This exposes it as a param and uses the old hard coded values as the default parameter value.