### PR TITLE
Migrated ActionSystem to Compose Traversal API & UiDataProvider API

### DIFF
--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/JewelComposePanel.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/JewelComposePanel.kt
@@ -11,19 +11,23 @@ import androidx.compose.ui.awt.ComposePanel
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.toSize
+import com.intellij.openapi.actionSystem.DataSink
+import com.intellij.openapi.actionSystem.UiDataProvider
 import org.jetbrains.jewel.bridge.actionSystem.ComponentDataProviderBridge
 import org.jetbrains.jewel.bridge.theme.SwingBridgeTheme
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.foundation.InternalJewelApi
+import java.awt.GridLayout
 import javax.swing.JComponent
+import javax.swing.JPanel
 
 @Suppress("ktlint:standard:function-naming", "FunctionName") // Swing to Compose bridge API
 public fun JewelComposePanel(content: @Composable () -> Unit): JComponent =
-    ComposePanel().apply {
+    createJewelComposePanel { jewelPanel ->
         setContent {
             SwingBridgeTheme {
-                CompositionLocalProvider(LocalComponent provides this@apply) {
-                    ComponentDataProviderBridge(this@apply, content = content)
+                CompositionLocalProvider(LocalComponent provides this@createJewelComposePanel) {
+                    ComponentDataProviderBridge(jewelPanel, content = content)
                 }
             }
         }
@@ -32,17 +36,34 @@ public fun JewelComposePanel(content: @Composable () -> Unit): JComponent =
 @InternalJewelApi
 @Suppress("ktlint:standard:function-naming", "FunctionName") // Swing to Compose bridge API
 public fun JewelToolWindowComposePanel(content: @Composable () -> Unit): JComponent =
-    ComposePanel().apply {
+    createJewelComposePanel { jewelPanel ->
         setContent {
             Compose17IJSizeBugWorkaround {
                 SwingBridgeTheme {
-                    CompositionLocalProvider(LocalComponent provides this@apply) {
-                        ComponentDataProviderBridge(this@apply, content = content)
+                    CompositionLocalProvider(LocalComponent provides this@createJewelComposePanel) {
+                        ComponentDataProviderBridge(jewelPanel, content = content)
                     }
                 }
             }
         }
     }
+
+private fun createJewelComposePanel(config: ComposePanel.(JewelComposePanel) -> Unit): JewelComposePanel {
+    val jewelPanel = JewelComposePanel()
+    jewelPanel.layout = GridLayout()
+    val composePanel = ComposePanel()
+    jewelPanel.add(composePanel)
+    composePanel.config(jewelPanel)
+    return jewelPanel
+}
+
+internal class JewelComposePanel: JPanel(), UiDataProvider {
+    internal var targetProvider: UiDataProvider? = null
+
+    override fun uiDataSnapshot(sink: DataSink) {
+        targetProvider?.uiDataSnapshot(sink)
+    }
+}
 
 @ExperimentalJewelApi
 public val LocalComponent: ProvidableCompositionLocal<JComponent> =

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/actionSystem/ComponentDataProviderBridge.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/actionSystem/ComponentDataProviderBridge.kt
@@ -1,0 +1,31 @@
+package org.jetbrains.jewel.bridge.actionSystem
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import org.jetbrains.jewel.bridge.JewelComposePanel
+
+@Suppress("FunctionName")
+@Composable internal fun ComponentDataProviderBridge(
+    component: JewelComposePanel,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    val rootDataProviderModifier = remember { RootDataProviderModifier() }
+
+    Box(modifier = Modifier.then(rootDataProviderModifier).then(modifier)) {
+        content()
+    }
+
+    DisposableEffect(component) {
+        component.targetProvider = rootDataProviderModifier
+
+        onDispose {
+            if (component.targetProvider == rootDataProviderModifier) {
+                component.targetProvider = null
+            }
+        }
+    }
+}

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/actionSystem/DataProviderElement.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/actionSystem/DataProviderElement.kt
@@ -3,13 +3,12 @@ package org.jetbrains.jewel.bridge.actionSystem
 import androidx.compose.ui.node.ModifierNodeElement
 
 internal class DataProviderElement(
-    val dataProvider: (dataId: String) -> Any?,
+    val dataProvider: DataProviderContext.() -> Unit,
 ) : ModifierNodeElement<DataProviderNode>() {
     override fun create(): DataProviderNode = DataProviderNode(dataProvider)
 
     override fun update(node: DataProviderNode) {
         node.dataProvider = dataProvider
-        node.updateParent()
     }
 
     override fun equals(other: Any?): Boolean {

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/actionSystem/DataProviderNode.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/actionSystem/DataProviderNode.kt
@@ -3,53 +3,26 @@ package org.jetbrains.jewel.bridge.actionSystem
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusEventModifierNode
 import androidx.compose.ui.focus.FocusState
-import androidx.compose.ui.modifier.ModifierLocalMap
-import androidx.compose.ui.modifier.ModifierLocalModifierNode
-import androidx.compose.ui.modifier.modifierLocalMapOf
-import androidx.compose.ui.modifier.modifierLocalOf
+import androidx.compose.ui.node.TraversableNode
+import com.intellij.openapi.actionSystem.DataKey
 
-/**
- * Holder for parent node of current [DataProviderNode]. So, each
- * [DataProviderNode] provides itself and read parent node. It allows
- * building tree of [DataProviderNode] and traverse it later on.
- *
- * @see ModifierLocalModifierNode
- */
-private val LocalDataProviderNode = modifierLocalOf<DataProviderNode?> { null }
+public interface DataProviderContext {
+    public fun <TValue: Any> set(key: DataKey<TValue>, value: TValue?)
+    public fun <TValue: Any> lazy(key: DataKey<TValue>, initializer: () -> TValue?)
+}
 
 internal class DataProviderNode(
-    var dataProvider: (dataId: String) -> Any?,
-) : Modifier.Node(), ModifierLocalModifierNode, FocusEventModifierNode {
+    var dataProvider: DataProviderContext.() -> Unit,
+) : Modifier.Node(), FocusEventModifierNode, TraversableNode {
     // TODO: should we use state here and in parent with children for thread safety? Will it trigger
     // recompositions?
     var hasFocus = false
-
-    var parent: DataProviderNode? = null
-
-    private val _children = mutableSetOf<DataProviderNode>()
-    val children: Set<DataProviderNode> = _children
-
-    override val providedValues: ModifierLocalMap = modifierLocalMapOf(LocalDataProviderNode to this)
-
-    override fun onAttach() {
-        val oldParent = parent
-        parent = LocalDataProviderNode.current
-        if (parent !== oldParent) {
-            oldParent?._children?.remove(this)
-            parent?._children?.add(this)
-        }
-    }
-
-    override fun onDetach() {
-        parent?._children?.remove(this)
-        parent = null
-    }
 
     override fun onFocusEvent(focusState: FocusState) {
         hasFocus = focusState.hasFocus
     }
 
-    public fun updateParent() {
-        parent = LocalDataProviderNode.current
-    }
+    override val traverseKey = TraverseKey
+
+    companion object TraverseKey
 }

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/actionSystem/ProvideData.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/actionSystem/ProvideData.kt
@@ -1,49 +1,10 @@
 package org.jetbrains.jewel.bridge.actionSystem
 
 import androidx.compose.foundation.focusable
-import androidx.compose.foundation.layout.Box
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusEventModifierNode
-import androidx.compose.ui.node.ModifierNodeElement
-import com.intellij.ide.DataManager
 import com.intellij.openapi.actionSystem.DataContext
 import com.intellij.openapi.actionSystem.DataProvider
-import org.jetbrains.annotations.VisibleForTesting
-import javax.swing.JComponent
-
-// TODO: choose better naming?
-
-/**
- * Layout composable that create the bridge between [Modifier.provideData]
- * used inside [content] and [component]. So, IntelliJ's [DataManager] can
- * use [component] as [DataProvider].
- *
- * When IntelliJ requests [getData] from [component] Compose will traverse
- * [DataProviderNode] hierarchy and collect it according [DataProvider]
- * rules (see javadoc).
- */
-@Suppress("unused", "FunctionName")
-@Composable
-public fun ComponentDataProviderBridge(
-    component: JComponent,
-    modifier: Modifier = Modifier,
-    content: @Composable () -> Unit,
-) {
-    val rootDataProviderModifier = remember { RootDataProviderModifier() }
-
-    Box(modifier = Modifier.then(rootDataProviderModifier).then(modifier)) {
-        content()
-    }
-
-    DisposableEffect(component) {
-        DataManager.registerDataProvider(component, rootDataProviderModifier.dataProvider)
-
-        onDispose { DataManager.removeDataProvider(component) }
-    }
-}
 
 /**
  * Configure component to provide data for IntelliJ Actions system.
@@ -60,49 +21,4 @@ public fun ComponentDataProviderBridge(
  * @see ComponentDataProviderBridge
  */
 @Suppress("unused")
-public fun Modifier.provideData(dataProvider: (dataId: String) -> Any?): Modifier = this then DataProviderElement(dataProvider)
-
-@VisibleForTesting
-internal class RootDataProviderModifier : ModifierNodeElement<DataProviderNode>() {
-    private val rootNode = DataProviderNode { null }
-
-    val dataProvider: (String) -> Any? = { rootNode.getData(it) }
-
-    override fun create() = rootNode
-
-    override fun update(node: DataProviderNode) {
-        // do nothing
-    }
-
-    override fun hashCode(): Int = rootNode.hashCode()
-
-    override fun equals(other: Any?) = other === this
-}
-
-private fun DataProviderNode.getData(dataId: String): Any? {
-    val focusedNode = this.traverseDownToFocused() ?: return null
-    return focusedNode.collectData(dataId)
-}
-
-private fun DataProviderNode.collectData(dataId: String): Any? {
-    var currentNode: DataProviderNode? = this
-    while (currentNode != null) {
-        val data = currentNode.dataProvider(dataId)
-        if (data != null) {
-            return data
-        }
-        currentNode = currentNode.parent
-    }
-
-    return null
-}
-
-private fun DataProviderNode.traverseDownToFocused(): DataProviderNode? {
-    for (child in children) {
-        if (child.hasFocus) {
-            return child.traverseDownToFocused()
-        }
-    }
-
-    return this.takeIf { hasFocus }
-}
+public fun Modifier.provideData(dataProvider: DataProviderContext.() -> Unit): Modifier = this then DataProviderElement(dataProvider)

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/actionSystem/RootDataProviderModifier.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/actionSystem/RootDataProviderModifier.kt
@@ -1,0 +1,61 @@
+package org.jetbrains.jewel.bridge.actionSystem
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.node.ModifierNodeElement
+import androidx.compose.ui.node.TraversableNode
+import androidx.compose.ui.node.traverseDescendants
+import com.intellij.openapi.actionSystem.DataKey
+import com.intellij.openapi.actionSystem.DataSink
+import com.intellij.openapi.actionSystem.UiDataProvider
+import org.jetbrains.annotations.VisibleForTesting
+
+private class DataProviderDataSinkContext(
+    private val dataSink: DataSink
+): DataProviderContext {
+    override fun <TValue: Any> set(key: DataKey<TValue>, value: TValue?) {
+        if (value == null) {
+            dataSink.setNull(key)
+        }
+        dataSink[key] = value
+    }
+
+    override fun <TValue: Any> lazy(key: DataKey<TValue>, initializer: () -> TValue?) {
+        dataSink.lazy(key, initializer)
+    }
+}
+
+internal class RootDataProviderNode: Modifier.Node(), UiDataProvider {
+    override fun uiDataSnapshot(sink: DataSink) {
+        val context = DataProviderDataSinkContext(sink)
+
+        traverseDescendants(DataProviderNode.TraverseKey) { dp ->
+            if (dp is DataProviderNode) {
+                if (!dp.hasFocus) {
+                    return@traverseDescendants TraversableNode.Companion.TraverseDescendantsAction.SkipSubtreeAndContinueTraversal
+                } else {
+                    dp.dataProvider(context)
+                }
+            }
+            TraversableNode.Companion.TraverseDescendantsAction.ContinueTraversal
+        }
+    }
+}
+
+@VisibleForTesting
+internal class RootDataProviderModifier : ModifierNodeElement<RootDataProviderNode>(), UiDataProvider {
+    private val rootNode = RootDataProviderNode()
+
+    override fun uiDataSnapshot(sink: DataSink) {
+        rootNode.uiDataSnapshot(sink)
+    }
+
+    override fun create() = rootNode
+
+    override fun update(node: RootDataProviderNode) {
+        // do nothing
+    }
+
+    override fun hashCode(): Int = rootNode.hashCode()
+
+    override fun equals(other: Any?) = other === this
+}

--- a/ide-laf-bridge/src/test/kotlin/org/jetbrains/jewel/bridge/actionSystem/ProvideDataTest.kt
+++ b/ide-laf-bridge/src/test/kotlin/org/jetbrains/jewel/bridge/actionSystem/ProvideDataTest.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithTag
+import com.intellij.openapi.actionSystem.DataKey
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Rule
@@ -22,6 +23,7 @@ class ProvideDataTest {
     @Test
     fun `one component`() {
         runBlocking {
+            val sink = TestDataSink()
             val rootDataProviderModifier = RootDataProviderModifier()
             var focusManager: FocusManager? = null
             rule.setContent {
@@ -30,10 +32,7 @@ class ProvideDataTest {
                     modifier =
                         rootDataProviderModifier.testTag("provider")
                             .provideData {
-                                when (it) {
-                                    "data" -> "ok"
-                                    else -> null
-                                }
+                                set(TestDataKeys.DATA, "ok")
                             }
                             .focusable(),
                 )
@@ -43,9 +42,10 @@ class ProvideDataTest {
             rule.awaitIdle()
 
             rule.onNodeWithTag("provider").assertIsFocused()
+            rootDataProviderModifier.uiDataSnapshot(sink)
 
-            assertEquals("ok", rootDataProviderModifier.dataProvider("data"))
-            assertEquals(null, rootDataProviderModifier.dataProvider("another_data"))
+            assertEquals("ok", sink.get(TestDataKeys.DATA))
+            assertEquals(null, sink.get(TestDataKeys.ANOTHER_DATA))
         }
     }
 
@@ -60,10 +60,8 @@ class ProvideDataTest {
                     modifier =
                         rootDataProviderModifier.testTag("root_provider")
                             .provideData {
-                                when (it) {
-                                    "isRoot" -> "yes"
-                                    else -> null
-                                }
+                                set(TestDataKeys.IS_ROOT, "yes")
+                                set(TestDataKeys.DATA, "notOk")
                             }
                             .focusable(),
                 ) {
@@ -72,10 +70,8 @@ class ProvideDataTest {
                             modifier =
                                 Modifier.testTag("data_provider_item")
                                     .provideData {
-                                        when (it) {
-                                            "data" -> "ok"
-                                            else -> null
-                                        }
+                                        set(TestDataKeys.DATA, "ok")
+                                        set(TestDataKeys.ONE, "1")
                                     }
                                     .focusable(),
                         )
@@ -87,26 +83,41 @@ class ProvideDataTest {
             focusManager!!.moveFocus(FocusDirection.Next)
             rule.awaitIdle()
 
+            val sink = TestDataSink()
             rule.onNodeWithTag("root_provider").assertIsFocused()
-            assertEquals("yes", rootDataProviderModifier.dataProvider("isRoot"))
-            assertEquals(null, rootDataProviderModifier.dataProvider("data"))
+            rootDataProviderModifier.uiDataSnapshot(sink)
+            assertEquals("yes", sink.get(TestDataKeys.IS_ROOT))
+            assertEquals("notOk", sink.get(TestDataKeys.DATA))
+            assertEquals(null, sink.get(TestDataKeys.ONE))
 
             focusManager!!.moveFocus(FocusDirection.Next)
             rule.awaitIdle()
+            sink.clear()
 
             rule.onNodeWithTag("non_data_provider").assertIsFocused()
+            rootDataProviderModifier.uiDataSnapshot(sink)
             // non_data_provider still should provide isRoot == true because it should be taken from root
-            // but shouldn't provide "data" yet
-            assertEquals("yes", rootDataProviderModifier.dataProvider("isRoot"))
-            assertEquals(null, rootDataProviderModifier.dataProvider("data"))
+            // but shouldn't provide "one" yet
+            assertEquals("yes", sink.get(TestDataKeys.IS_ROOT))
+            assertEquals("notOk", sink.get(TestDataKeys.DATA))
+            assertEquals(null, sink.get(TestDataKeys.ONE))
 
             focusManager!!.moveFocus(FocusDirection.Next)
             rule.awaitIdle()
+            sink.clear()
 
             rule.onNodeWithTag("data_provider_item").assertIsFocused()
-
-            assertEquals("yes", rootDataProviderModifier.dataProvider("isRoot"))
-            assertEquals("ok", rootDataProviderModifier.dataProvider("data"))
+            rootDataProviderModifier.uiDataSnapshot(sink)
+            assertEquals("yes", sink.get(TestDataKeys.IS_ROOT))
+            assertEquals("ok", sink.get(TestDataKeys.DATA))
+            assertEquals("1", sink.get(TestDataKeys.ONE))
         }
     }
+}
+
+private object TestDataKeys {
+    val DATA = DataKey.create<String>("data")
+    val ANOTHER_DATA = DataKey.create<String>("another_data")
+    val IS_ROOT = DataKey.create<String>("isRoot")
+    val ONE = DataKey.create<String>("one")
 }

--- a/ide-laf-bridge/src/test/kotlin/org/jetbrains/jewel/bridge/actionSystem/TestDataSink.kt
+++ b/ide-laf-bridge/src/test/kotlin/org/jetbrains/jewel/bridge/actionSystem/TestDataSink.kt
@@ -1,0 +1,48 @@
+package org.jetbrains.jewel.bridge.actionSystem
+
+import com.intellij.openapi.actionSystem.DataKey
+import com.intellij.openapi.actionSystem.DataProvider
+import com.intellij.openapi.actionSystem.DataSink
+import com.intellij.openapi.actionSystem.DataSnapshotProvider
+import com.intellij.openapi.actionSystem.UiDataProvider
+
+@Suppress("OverrideOnly", "NonExtendableApiUsage")
+internal class TestDataSink: DataSink {
+    val allData = mutableMapOf<String, Any>()
+
+    fun clear() {
+        allData.clear()
+    }
+
+    inline fun <reified T> get(key: DataKey<T>): T? {
+        val data = allData[key.name] as T?
+        if (data is T) return data
+        return null
+    }
+
+    override fun dataSnapshot(provider: DataSnapshotProvider) {
+        provider.dataSnapshot(this)
+    }
+
+    override fun uiDataSnapshot(provider: DataProvider) {
+        // NOT needed in current tests
+    }
+
+    override fun uiDataSnapshot(provider: UiDataProvider) {
+        provider.uiDataSnapshot(this)
+    }
+
+    override fun <T : Any> setNull(key: DataKey<T>) {
+        allData.remove(key.name)
+    }
+
+    override fun <T : Any> set(key: DataKey<T>, data: T?) {
+        if (data != null) {
+            allData[key.name] = data
+        }
+    }
+
+    override fun <T : Any> lazy(key: DataKey<T>, data: () -> T?) {
+        set(key, data())
+    }
+}

--- a/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ActionSystemTestAction.kt
+++ b/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ActionSystemTestAction.kt
@@ -1,0 +1,18 @@
+package org.jetbrains.jewel.samples.ideplugin
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.DataKey
+import com.intellij.openapi.diagnostic.Logger
+
+class ActionSystemTestAction : AnAction() {
+    private val logger = Logger.getInstance(ActionSystemTestAction::class.java)
+
+    override fun actionPerformed(anActionEvent: AnActionEvent) {
+        logger.debug(anActionEvent.getData(COMPONENT_DATA_KEY))
+    }
+
+    companion object {
+        val COMPONENT_DATA_KEY = DataKey.create<String>("COMPONENT")
+    }
+}

--- a/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
+++ b/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
@@ -34,6 +34,7 @@ import com.intellij.ui.JBColor
 import com.intellij.util.ui.JBUI
 import icons.IdeSampleIconKeys
 import org.jetbrains.jewel.bridge.LocalComponent
+import org.jetbrains.jewel.bridge.actionSystem.provideData
 import org.jetbrains.jewel.bridge.toComposeColor
 import org.jetbrains.jewel.foundation.lazy.tree.buildTree
 import org.jetbrains.jewel.foundation.modifier.onActivated
@@ -147,7 +148,9 @@ private fun RowScope.ColumnOne() {
         val state = rememberTextFieldState("")
         TextField(
             state = state,
-            modifier = Modifier.width(200.dp),
+            modifier = Modifier.width(200.dp).provideData {
+                set(ActionSystemTestAction.COMPONENT_DATA_KEY, "TextField")
+            },
             placeholder = { Text("Write something...") },
         )
 
@@ -160,6 +163,9 @@ private fun RowScope.ColumnOne() {
                 checked = checked,
                 onCheckedChange = { checked = it },
                 outline = outline,
+                modifier = Modifier.provideData {
+                    set(ActionSystemTestAction.COMPONENT_DATA_KEY, "Checkbox")
+                }
             ) {
                 Text("Hello, I am a themed checkbox")
             }

--- a/samples/ide-plugin/src/main/resources/META-INF/plugin.xml
+++ b/samples/ide-plugin/src/main/resources/META-INF/plugin.xml
@@ -26,5 +26,8 @@ See the <a href="https://github.com/JetBrains/jewel">Jewel repository</a> for mo
         <action id="Jewel Dialog Demo" class="org.jetbrains.jewel.samples.ideplugin.dialog.JewelDemoAction"
                 text="Jewel Demo Dialog">
         </action>
+        <action id="Jewel Action System Test" class="org.jetbrains.jewel.samples.ideplugin.ActionSystemTestAction"
+                text="Jewel Action System Test">
+        </action>
     </actions>
 </idea-plugin>


### PR DESCRIPTION
The api now looks like this:
```kotlin
val state = rememberTextFieldState("")
TextField(
    state = state,
    modifier = Modifier
        .width(200.dp)
        .provideData {
            set(ActionSystemTestAction.COMPONENT_DATA_KEY, "TextField")
            lazy(ActionSystemTestAction.COMPONENT_DATA_KEY) { 
                Math.random().toString()
            }
        },
    placeholder = { Text("Write something...") },
)
```
Let me know if the api can be improved somehow. ComponentDataProviderBridge is no longer public as it requires instance of JewelComposePanel and Swing level nesting. If there is reasonable use-case for this, we can make it public again.