### PR TITLE
Add scrollbar style and behavior reactive update for Mac OS

### DIFF
--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/MacScrollbarHelper.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/MacScrollbarHelper.kt
@@ -28,6 +28,10 @@ internal object MacScrollbarHelper {
 
     val trackClickBehavior: TrackClickBehavior
         get() {
+            if (!SystemInfoRt.isMac) {
+                return TrackClickBehavior.JumpToSpot
+            }
+
             val pool = NSAutoreleasePool()
             try {
                 return readMacScrollbarBehavior()
@@ -38,6 +42,10 @@ internal object MacScrollbarHelper {
 
     val scrollbarVisibility: ScrollbarVisibility
         get() {
+            if (!SystemInfoRt.isMac) {
+                return ScrollbarVisibility.AlwaysVisible
+            }
+
             val pool = NSAutoreleasePool()
             try {
                 return readMacScrollbarStyle()

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/MacScrollbarHelper.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/MacScrollbarHelper.kt
@@ -20,36 +20,33 @@ internal object MacScrollbarHelper {
     private val _trackClickBehaviorFlow = MutableStateFlow(trackClickBehavior)
     val trackClickBehaviorFlow: StateFlow<TrackClickBehavior> = _trackClickBehaviorFlow
 
-    private val APPEARANCE_CALLBACK: Callback =
-        object : Callback {
-            @Suppress("UNUSED_PARAMETER", "unused")
-            @SuppressWarnings("UnusedDeclaration")
-            fun callback(
-                self: ID?,
-                selector: Pointer?,
-                event: ID?,
-            ) {
-                _scrollbarVisibilityStyleFlow.tryEmit(scrollbarVisibility)
-            }
-        }
-    private val BEHAVIOR_CALLBACK: Callback =
-        object : Callback {
-            @Suppress("UNUSED_PARAMETER", "unused")
-            @SuppressWarnings("UnusedDeclaration")
-            fun callback(
-                self: ID?,
-                selector: Pointer?,
-                event: ID?,
-            ) {
-                _trackClickBehaviorFlow.tryEmit(trackClickBehavior)
-            }
-        }
-
     init {
         if (SystemInfoRt.isMac) {
             initNotificationObserver()
         }
     }
+
+    val trackClickBehavior: TrackClickBehavior
+        get() {
+            val pool = NSAutoreleasePool()
+            try {
+                return readMacScrollbarBehavior()
+            } finally {
+                pool.drain()
+            }
+        }
+
+    val scrollbarVisibility: ScrollbarVisibility
+        get() {
+            val pool = NSAutoreleasePool()
+            try {
+                return readMacScrollbarStyle()
+            } catch (ignore: Throwable) {
+            } finally {
+                pool.drain()
+            }
+            return ScrollbarVisibility.AlwaysVisible
+        }
 
     private fun initNotificationObserver() {
         val pool = NSAutoreleasePool()
@@ -94,26 +91,30 @@ internal object MacScrollbarHelper {
         }
     }
 
-    val trackClickBehavior: TrackClickBehavior
-        get() {
-            val pool = NSAutoreleasePool()
-            try {
-                return readMacScrollbarBehavior()
-            } finally {
-                pool.drain()
+    private val APPEARANCE_CALLBACK: Callback =
+        object : Callback {
+            @Suppress("UNUSED_PARAMETER", "unused")
+            @SuppressWarnings("UnusedDeclaration")
+            fun callback(
+                self: ID?,
+                selector: Pointer?,
+                event: ID?,
+            ) {
+                _scrollbarVisibilityStyleFlow.tryEmit(scrollbarVisibility)
             }
         }
 
-    val scrollbarVisibility: ScrollbarVisibility
-        get() {
-            val pool = NSAutoreleasePool()
-            try {
-                return readMacScrollbarStyle()
-            } catch (ignore: Throwable) {
-            } finally {
-                pool.drain()
+    private val BEHAVIOR_CALLBACK: Callback =
+        object : Callback {
+            @Suppress("UNUSED_PARAMETER", "unused")
+            @SuppressWarnings("UnusedDeclaration")
+            fun callback(
+                self: ID?,
+                selector: Pointer?,
+                event: ID?,
+            ) {
+                _trackClickBehaviorFlow.tryEmit(trackClickBehavior)
             }
-            return ScrollbarVisibility.AlwaysVisible
         }
 
     private fun readMacScrollbarBehavior(): TrackClickBehavior {

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/MacScrollbarHelper.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/MacScrollbarHelper.kt
@@ -1,0 +1,129 @@
+package org.jetbrains.jewel.bridge
+
+import com.intellij.openapi.util.SystemInfoRt
+import com.intellij.ui.mac.foundation.Foundation
+import com.intellij.ui.mac.foundation.Foundation.NSAutoreleasePool
+import com.intellij.ui.mac.foundation.ID
+import com.sun.jna.Callback
+import com.sun.jna.Pointer
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+internal object MacScrollbarHelper {
+
+    private val _scrollbarVisibilityStyle = MutableStateFlow(scrollbarStyle)
+    val scrollbarVisibilityStyleFlow: StateFlow<ScrollbarStyle> = _scrollbarVisibilityStyle
+
+    private val _trackClickBehavior = MutableStateFlow(trackClickBehavior)
+    val trackClickBehaviorFlow: StateFlow<TrackClickBehavior> = _trackClickBehavior
+
+    private val APPEARANCE_CALLBACK: Callback = object : Callback {
+        @SuppressWarnings("UnusedDeclaration")
+        fun callback(self: ID?, selector: Pointer?, event: ID?) {
+            _scrollbarVisibilityStyle.tryEmit(scrollbarStyle)
+        }
+    }
+    private val BEHAVIOR_CALLBACK: Callback = object : Callback {
+        @SuppressWarnings("UnusedDeclaration")
+        fun callback(self: ID?, selector: Pointer?, event: ID?) {
+            _trackClickBehavior.tryEmit(trackClickBehavior)
+        }
+    }
+
+    init {
+        if (SystemInfoRt.isMac) {
+            initNotificationObserver()
+        }
+    }
+
+    private fun initNotificationObserver() {
+        val pool = NSAutoreleasePool()
+
+        val delegateClass =
+            Foundation.allocateObjcClassPair(Foundation.getObjcClass("NSObject"), "NSScrollerChangesObserver")
+        if (ID.NIL != delegateClass) {
+            // This static initializer might be called more than once (with different class loaders). In that case NSScrollerChangesObserver
+            // already exists.
+            if (!Foundation.addMethod(
+                    delegateClass,
+                    Foundation.createSelector("handleScrollerStyleChanged:"),
+                    APPEARANCE_CALLBACK,
+                    "v@"
+                )) {
+                throw RuntimeException("Cannot add observer method")
+            }
+            if (!Foundation.addMethod(
+                    delegateClass,
+                    Foundation.createSelector("handleBehaviorChanged:"),
+                    BEHAVIOR_CALLBACK,
+                    "v@"
+                )) {
+                throw RuntimeException("Cannot add observer method")
+            }
+
+            Foundation.registerObjcClassPair(delegateClass)
+        }
+        val delegate = Foundation.invoke("NSScrollerChangesObserver", "new")
+
+        try {
+            var center =
+                Foundation.invoke("NSNotificationCenter", "defaultCenter")
+            Foundation.invoke(
+                center, "addObserver:selector:name:object:",
+                delegate,
+                Foundation.createSelector("handleScrollerStyleChanged:"),
+                Foundation.nsString("NSPreferredScrollerStyleDidChangeNotification"),
+                ID.NIL
+            )
+
+            center = Foundation.invoke("NSDistributedNotificationCenter", "defaultCenter")
+            Foundation.invoke(
+                center, "addObserver:selector:name:object:",
+                delegate,
+                Foundation.createSelector("handleBehaviorChanged:"),
+                Foundation.nsString("AppleNoRedisplayAppearancePreferenceChanged"),
+                ID.NIL,
+                2 // NSNotificationSuspensionBehaviorCoalesce
+            )
+        } finally {
+            pool.drain()
+        }
+    }
+
+    val trackClickBehavior: TrackClickBehavior
+        get() {
+            val pool = NSAutoreleasePool()
+            try {
+                val defaults = Foundation.invoke("NSUserDefaults", "standardUserDefaults")
+                Foundation.invoke(defaults, "synchronize")
+                return if (Foundation.invoke(defaults, "boolForKey:", Foundation.nsString("AppleScrollerPagingBehavior")).booleanValue())
+                    TrackClickBehavior.JumpToSpot
+                else
+                    TrackClickBehavior.NextPage
+            } finally {
+                pool.drain()
+            }
+        }
+
+    val scrollbarStyle: ScrollbarStyle
+        get() {
+            val pool = NSAutoreleasePool()
+            try {
+                if (Foundation.invoke(Foundation.getObjcClass("NSScroller"), "preferredScrollerStyle").toInt() == 1) {
+                    return ScrollbarStyle.Overlay
+                }
+            } catch (ignore: Throwable) {
+            } finally {
+                pool.drain()
+            }
+            return ScrollbarStyle.Legacy
+        }
+
+    internal enum class TrackClickBehavior {
+        NextPage, JumpToSpot
+    }
+
+    internal enum class ScrollbarStyle {
+        Legacy, Overlay
+    }
+}

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/SwingBridgeService.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/SwingBridgeService.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import org.jetbrains.jewel.bridge.theme.createBridgeComponentStyling
 import org.jetbrains.jewel.bridge.theme.createBridgeThemeDefinition
@@ -20,9 +20,13 @@ import kotlin.time.Duration.Companion.milliseconds
 @Service(Level.APP)
 internal class SwingBridgeService(scope: CoroutineScope) {
     internal val currentBridgeThemeData: StateFlow<BridgeThemeData> =
-        IntelliJApplication.lookAndFeelChangedFlow(scope)
-            .mapLatest { tryGettingThemeData() }
-            .stateIn(scope, SharingStarted.Eagerly, BridgeThemeData.DEFAULT)
+        combine(
+            IntelliJApplication.lookAndFeelChangedFlow(scope),
+            MacScrollbarHelper.scrollbarVisibilityStyleFlow,
+            MacScrollbarHelper.trackClickBehaviorFlow,
+        ) { _, _, _ ->
+            tryGettingThemeData()
+        }.stateIn(scope, SharingStarted.Eagerly, BridgeThemeData.DEFAULT)
 
     private suspend fun tryGettingThemeData(): BridgeThemeData {
         var counter = 0

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/ScrollbarBridge.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/ScrollbarBridge.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.unit.dp
-import com.intellij.ui.mac.foundation.Foundation
 import org.jetbrains.jewel.bridge.MacScrollbarHelper
 import org.jetbrains.jewel.bridge.retrieveColorOrUnspecified
 import org.jetbrains.jewel.ui.component.styling.ScrollbarColors
@@ -51,7 +50,7 @@ private fun readScrollbarWinColors(isDark: Boolean): ScrollbarColors =
         thumbBackground =
             readScrollBarColorForKey(
                 isDark,
-                "ScrollBar.Transparent.thumbColor",
+                "ScrollBar.thumbColor",
                 0x33737373,
                 0x47A6A6A6,
             ),
@@ -111,9 +110,9 @@ private fun readScrollbarMacColors(isDark: Boolean): ScrollbarColors =
         thumbBackground =
             readScrollBarColorForKey(
                 isDark,
-                "ScrollBar.Mac.Transparent.thumbColor",
-                0x00000000,
-                0x00808080,
+                "ScrollBar.Mac.thumbColor",
+                0x33000000,
+                0x59808080,
             ),
         thumbBackgroundHovered =
             readScrollBarColorForKey(
@@ -153,16 +152,16 @@ private fun readScrollbarMacColors(isDark: Boolean): ScrollbarColors =
         trackBackground =
             readScrollBarColorForKey(
                 isDark,
-                "ScrollBar.Mac.Transparent.trackColor",
+                "ScrollBar.Mac.trackColor",
                 0x00808080,
                 0x00808080,
             ),
         trackBackgroundHovered =
             readScrollBarColorForKey(
                 isDark,
-                "ScrollBar.Mac.Transparent.hoverTrackColor",
-                0x1A808080,
-                0x1A808080,
+                "ScrollBar.Mac.hoverTrackColor",
+                0x00808080,
+                0x00808080,
             ),
     )
 

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/ScrollbarBridge.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/ScrollbarBridge.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.unit.dp
 import com.intellij.ui.mac.foundation.Foundation
+import org.jetbrains.jewel.bridge.MacScrollbarHelper
 import org.jetbrains.jewel.bridge.retrieveColorOrUnspecified
 import org.jetbrains.jewel.ui.component.styling.ScrollbarColors
 import org.jetbrains.jewel.ui.component.styling.ScrollbarMetrics
@@ -26,7 +27,7 @@ internal fun readScrollbarStyle(isDark: Boolean): ScrollbarStyle =
 
 private fun readScrollbarVisibility() =
     if (hostOs.isMacOS) {
-        readMacScrollbarStyle()
+        MacScrollbarHelper.scrollbarVisibility
     } else {
         ScrollbarVisibility.AlwaysVisible
     }
@@ -40,7 +41,7 @@ private fun readScrollbarColors(isDark: Boolean) =
 
 private fun readTrackClickBehavior() =
     if (hostOs.isMacOS) {
-        readMacScrollbarBehavior()
+        MacScrollbarHelper.trackClickBehavior
     } else {
         TrackClickBehavior.JumpToSpot
     }
@@ -193,28 +194,6 @@ private fun readScrollbarMetrics(): ScrollbarMetrics =
             trackPaddingExpanded = PaddingValues(),
         )
     }
-
-private fun readMacScrollbarStyle(): ScrollbarVisibility {
-    val nsScroller =
-        Foundation
-            .invoke(Foundation.getObjcClass("NSScroller"), "preferredScrollerStyle")
-
-    val visibility: ScrollbarVisibility =
-        if (1 == nsScroller.toInt()) {
-            ScrollbarVisibility.WhenScrolling.Companion.defaults()
-        } else {
-            ScrollbarVisibility.AlwaysVisible
-        }
-    return visibility
-}
-
-private fun readMacScrollbarBehavior(): TrackClickBehavior {
-    val defaults = Foundation.invoke("NSUserDefaults", "standardUserDefaults")
-    Foundation.invoke(defaults, "synchronize")
-    return Foundation
-        .invoke(defaults, "boolForKey:", Foundation.nsString("AppleScrollerPagingBehavior"))
-        .run { if (toInt() == 1) TrackClickBehavior.JumpToSpot else TrackClickBehavior.NextPage }
-}
 
 public fun ScrollbarVisibility.WhenScrolling.Companion.defaults(
     appearAnimationDuration: Duration = 125.milliseconds,

--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarStyling.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/styling/IntUiScrollbarStyling.kt
@@ -94,9 +94,9 @@ public fun ScrollbarVisibility.WhenScrolling.Companion.defaults(
     )
 
 public fun ScrollbarColors.Companion.macOsLight(
-    thumbBackground: Color = Color(0x00000000),
-    thumbBackgroundHovered: Color = Color(0x80000000),
-    thumbBackgroundPressed: Color = thumbBackgroundHovered,
+    thumbBackground: Color = Color(0xFFBBBBBA),
+    thumbBackgroundHovered: Color = Color(0xFF7D7D7C),
+    thumbBackgroundPressed: Color = Color(0xFF7D7D7C),
     thumbBorder: Color = Color(0x33000000),
     thumbBorderHovered: Color = Color(0x80000000),
     thumbBorderPressed: Color = thumbBorderHovered,

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Scrollbars.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Scrollbars.kt
@@ -148,40 +148,15 @@ private fun MyScrollbar(
     )
 
     LaunchedEffect(scrollState.isScrollInProgress, hovered, style.scrollbarVisibility) {
-        when (style.scrollbarVisibility) {
-            AlwaysVisible -> {
-                visible = true
-                trackIsVisible = true
-            }
-
-            is WhenScrolling -> {
-                when {
-                    scrollState.isScrollInProgress -> visible = true
-                    hovered -> {
-                        visible = true
-                        trackIsVisible = true
-                    }
-
-                    !hovered -> {
-                        delay(style.scrollbarVisibility.lingerDuration)
-                        trackIsVisible = false
-                        visible = false
-                    }
-
-                    !scrollState.isScrollInProgress && !hovered -> {
-                        delay(style.scrollbarVisibility.lingerDuration)
-                        visible = false
-                    }
-                }
-            }
+        if(style.scrollbarVisibility is AlwaysVisible || scrollState.isScrollInProgress || hovered) {
+            visible = true
+            trackIsVisible = true
         }
 
-        when {
-            scrollState.isScrollInProgress -> visible = true
-            hovered -> {
-                visible = true
-                trackIsVisible = true
-            }
+        if (style.scrollbarVisibility is WhenScrolling && !hovered) {
+            delay(style.scrollbarVisibility.lingerDuration)
+            trackIsVisible = false
+            visible = false
         }
     }
 

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Scrollbars.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Scrollbars.kt
@@ -140,7 +140,6 @@ private fun MyScrollbar(
     // Visibility, hover and fade out
     var visible by remember { mutableStateOf(scrollState.canScrollBackward) }
     val hovered = interactionSource.collectIsHoveredAsState().value
-    var trackIsVisible by remember { mutableStateOf(false) }
 
     val animatedAlpha by animateFloatAsState(
         targetValue = if (visible) 1.0f else 0f,
@@ -150,12 +149,10 @@ private fun MyScrollbar(
     LaunchedEffect(scrollState.isScrollInProgress, hovered, style.scrollbarVisibility) {
         if(style.scrollbarVisibility is AlwaysVisible || scrollState.isScrollInProgress || hovered) {
             visible = true
-            trackIsVisible = true
         }
 
         if (style.scrollbarVisibility is WhenScrolling && !hovered) {
             delay(style.scrollbarVisibility.lingerDuration)
-            trackIsVisible = false
             visible = false
         }
     }
@@ -169,9 +166,9 @@ private fun MyScrollbar(
             else -> error("Unsupported scroll state type: ${scrollState::class}")
         }
 
-    val thumbWidth = if (trackIsVisible) style.metrics.thumbThicknessExpanded else style.metrics.thumbThickness
-    val trackBackground = if (trackIsVisible) style.colors.trackBackground else Color.Transparent
-    val trackPadding = if (trackIsVisible) style.metrics.trackPaddingExpanded else style.metrics.trackPadding
+    val thumbWidth = if (visible) style.metrics.thumbThicknessExpanded else style.metrics.thumbThickness
+    val trackBackground = if (visible) style.colors.trackBackground else Color.Transparent
+    val trackPadding = if (visible) style.metrics.trackPaddingExpanded else style.metrics.trackPadding
     ScrollbarImpl(
         adapter = adapter,
         modifier =


### PR DESCRIPTION
## Description

This PR adds `MacScrollbarHelper`. This file is heavily inspired by IntelliJ `NSScrollerHelper`. It has been converted to Kotlin, purged of what we don't need and migrated to Kotlin Coroutines.

`MacScrollbarHelper` API provides:
* `scrollbarVisibilityStyleFlow: StateFlow<ScrollbarVisibility>`
* `trackClickBehaviorFlow: StateFlow<TrackClickBehavior>`
* `trackClickBehavior: TrackClickBehavior`
* `scrollbarVisibility: ScrollbarVisibility`

The two flows have been plugged into the `SwingBridgeService.currentBridgeThemeData: StateFlow<BridgeThemeData>`. Every time the theme, the scrollbar visibility, or the track behavior change, we get an emission and whoever is listening gets an update.

The two properties replaced the original implementations we had in `ScrollbarBridge`.

Furthermore, this PR iterate once again on scrollbars colors on macOS.

## Related Issues
#510 #445 

## Checklist

- [x] I have executed the `Pre-push` Gradle task
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

## How Has This Been Tested?
 
- [x] New and existing unit tests pass locally with my changes
- [x] I have manually tested my changes on MacOS
  - [x] With dark theme
  - [x] With light theme
- [x] I have manually tested my changes on Windows
- [x] I have manually tested my changes on Linux

## Screenshots or GIFs:
![ScreenRecording2024-08-09at16 55 24-ezgif com-video-to-gif-converter (1)](https://github.com/user-attachments/assets/7f26b91d-46d7-4abf-a77a-c855d6dbe175)
