### PR TITLE
Fix button border alignement

### DIFF
--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Button.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Button.kt
@@ -136,7 +136,7 @@ private fun ButtonImpl(
                     alignment = style.focusOutlineAlignment,
                     expand = style.metrics.focusOutlineExpand,
                 )
-                .border(Stroke.Alignment.Center, style.metrics.borderWidth, borderColor, shape),
+                .border(Stroke.Alignment.Inside, style.metrics.borderWidth, borderColor, shape),
         propagateMinConstraints = true,
     ) {
         val contentColor by colors.contentFor(buttonState)


### PR DESCRIPTION
## Description
This PR fix a border issue for OutlineButton.

## Related Issue
Reference https://github.com/JetBrains/jewel/issues/541

## Checklist

- [x] I have executed the `API dump` and `Reformat project` Gradle tasks
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## How Has This Been Tested?

I have manually tested my changes on macOS
- [x] dark
- [x] light

I have manually tested my changes on Windows
- [x] dark
- [x] light

I have manually tested my changes on Linux
- [ ] dark
- [ ] light

## Screenshots or GIFs:

| Before| After|
|--------|--------|
| ![image](https://github.com/user-attachments/assets/ddb19f07-2b83-48d7-a2af-ebbd727b39a5) | ![image](https://github.com/user-attachments/assets/751cbfd1-7c8f-4457-8921-2843f0333fba) |
| ![image](https://github.com/user-attachments/assets/ab3e14ad-bb73-40ae-bb68-546a058e7f5a) | ![image](https://github.com/user-attachments/assets/587881e1-71d0-44c3-a407-af654ccce42a) | 

### Before:

![image](https://github.com/user-attachments/assets/7c95e1f9-f346-49ea-a49f-a86191758edc)
![image](https://github.com/user-attachments/assets/e1d7968a-7537-4f38-b8d9-8dfc6213ad5b)
![image](https://github.com/user-attachments/assets/1de6f48c-8f8d-4c95-9fd3-7e4070c5610d)
![image](https://github.com/user-attachments/assets/f28fb3be-1c28-49e0-ac7f-10358e9035d4)


### After:

![image](https://github.com/user-attachments/assets/e3dce847-c4ef-4701-8906-f90d48e00dbe)
![image](https://github.com/user-attachments/assets/85907a16-c7d6-4bff-97eb-f47fb3c90f32)
![image](https://github.com/user-attachments/assets/38b137b1-faab-4d4a-b9cb-3f2fb2c10a85)
![image](https://github.com/user-attachments/assets/c0fc9e19-13b2-4d6a-a527-9b96059fd89c)


