### PR TITLE
Exclude generated files from formatKotlinMain

### DIFF
--- a/buildSrc/src/main/kotlin/jewel.gradle.kts
+++ b/buildSrc/src/main/kotlin/jewel.gradle.kts
@@ -75,7 +75,9 @@ tasks {
         }
     }
 
-    formatKotlinMain { exclude { it.file.absolutePath.contains("build/generated") } }
+    formatKotlinMain {
+        exclude { it.file.absolutePath.replace('\\', '/').contains("build/generated") }
+    }
 
     lintKotlinMain {
         exclude { it.file.absolutePath.replace('\\', '/').contains("build/generated") }


### PR DESCRIPTION
This PR iterates on the `exclude` configuration for `formatKotlinMain` to properly ignore generated files on Windows.

The following image shows the console output with the linter trying to reformat a generated file:
![image](https://github.com/user-attachments/assets/6eee80f4-319a-48b8-9162-921a5f24f950)

Although this is not an issue per itself because git ignores those files anyway, we can save time during development.

This also seems to help with the glitch I was having when running the `Pre-push` task on Windows.