### PR TITLE
Improve OverrideDarkMode kdocs

### DIFF
--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/theme/JewelTheme.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/theme/JewelTheme.kt
@@ -142,7 +142,22 @@ public val LocalConsoleTextStyle: ProvidableCompositionLocal<TextStyle> =
         error("No ConsoleTextStyle provided. Have you forgotten the theme?")
     }
 
-/** Overrides the dark mode for the current composition scope. */
+/**
+ * Overrides the [isDark] value for the [content]. It is used to inject a
+ * different dark mode style in a sub-tree.
+ *
+ * Note: this does _not_ change the theme. If you want to change the theme,
+ * you need to do it by yourself. For example, in standalone:
+ * ```kotlin
+ * IntUiTheme(isDark = false) {
+ *   Text("I am light")
+ *
+ *   IntUiTheme(isDark = true) {
+ *     Text("I am dark")
+ *   }
+ * }
+ * ```
+ */
 @Composable
 public fun OverrideDarkMode(
     isDark: Boolean,


### PR DESCRIPTION
Now it makes it clear that OverrideDarkMode does not change the theme, and provides an example on how to do that.

Closes #550 