### PR TITLE
Fix TextField placeholder going outside the bounds of the TextField

### DIFF
--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TextField.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TextField.kt
@@ -261,8 +261,13 @@ private fun TextFieldDecorationBox(
             incomingConstraints.offset(horizontal = -occupiedSpaceHorizontally).copy(minHeight = 0)
         val textFieldPlaceable = measurables.single { it.layoutId == TEXT_FIELD_ID }.measure(textFieldConstraints)
 
-        // measure placeholder
-        val placeholderConstraints = textFieldConstraints.copy(minWidth = 0)
+        // measure placeholder (can't be bigger than the text)
+        val placeholderConstraints =
+            textFieldConstraints.copy(
+                minWidth = 0,
+                maxWidth = textFieldPlaceable.width,
+                maxHeight = textFieldPlaceable.height,
+            )
         val placeholderPlaceable = measurables.find { it.layoutId == PLACEHOLDER_ID }?.measure(placeholderConstraints)
 
         val width = calculateWidth(leadingPlaceable, trailingPlaceable, textFieldPlaceable, incomingConstraints)


### PR DESCRIPTION
The problem was that we were not capping the size of the placeholder when measuring it; but the placeholder can't be larger than the space allocated to the actual text; setting the constraints accordingly fixes the issue.