### PR TITLE
Fix global border colors

### DIFF
--- a/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/theme/IntUiGlobalColors.kt
+++ b/int-ui/int-ui-standalone/src/main/kotlin/org/jetbrains/jewel/intui/standalone/theme/IntUiGlobalColors.kt
@@ -39,14 +39,14 @@ public fun GlobalColors.Companion.dark(
 
 @Composable
 public fun BorderColors.Companion.light(
-    normal: Color = IntUiLightTheme.colors.gray(9),
+    normal: Color = IntUiLightTheme.colors.gray(12),
     focused: Color = IntUiLightTheme.colors.gray(14),
     disabled: Color = IntUiLightTheme.colors.gray(11),
 ): BorderColors = BorderColors(normal, focused, disabled)
 
 @Composable
 public fun BorderColors.Companion.dark(
-    normal: Color = IntUiDarkTheme.colors.gray(5),
+    normal: Color = IntUiDarkTheme.colors.gray(1),
     focused: Color = IntUiDarkTheme.colors.gray(2),
     disabled: Color = IntUiDarkTheme.colors.gray(4),
 ): BorderColors = BorderColors(normal, focused, disabled)


### PR DESCRIPTION
Working on #273 showed that the current global colors for borders in Standalone are a bit off.

This PR brings in the right shades of gray for light and dark theme. These are the same colors you would expect to see with `Borders.color` in LaF in the IJP.