### PR TITLE
Use icon keys everywhere

### DIFF
--- a/decorated-window/api/decorated-window.api
+++ b/decorated-window/api/decorated-window.api
@@ -184,12 +184,12 @@ public final class org/jetbrains/jewel/window/styling/TitleBarColors$Companion {
 public final class org/jetbrains/jewel/window/styling/TitleBarIcons {
 	public static final field $stable I
 	public static final field Companion Lorg/jetbrains/jewel/window/styling/TitleBarIcons$Companion;
-	public fun <init> (Lorg/jetbrains/jewel/ui/painter/PainterProvider;Lorg/jetbrains/jewel/ui/painter/PainterProvider;Lorg/jetbrains/jewel/ui/painter/PainterProvider;Lorg/jetbrains/jewel/ui/painter/PainterProvider;)V
+	public fun <init> (Lorg/jetbrains/jewel/ui/icon/IconKey;Lorg/jetbrains/jewel/ui/icon/IconKey;Lorg/jetbrains/jewel/ui/icon/IconKey;Lorg/jetbrains/jewel/ui/icon/IconKey;)V
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getCloseButton ()Lorg/jetbrains/jewel/ui/painter/PainterProvider;
-	public final fun getMaximizeButton ()Lorg/jetbrains/jewel/ui/painter/PainterProvider;
-	public final fun getMinimizeButton ()Lorg/jetbrains/jewel/ui/painter/PainterProvider;
-	public final fun getRestoreButton ()Lorg/jetbrains/jewel/ui/painter/PainterProvider;
+	public final fun getCloseButton ()Lorg/jetbrains/jewel/ui/icon/IconKey;
+	public final fun getMaximizeButton ()Lorg/jetbrains/jewel/ui/icon/IconKey;
+	public final fun getMinimizeButton ()Lorg/jetbrains/jewel/ui/icon/IconKey;
+	public final fun getRestoreButton ()Lorg/jetbrains/jewel/ui/icon/IconKey;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/TitleBar.Linux.kt
+++ b/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/TitleBar.Linux.kt
@@ -21,8 +21,8 @@ import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.Icon
 import org.jetbrains.jewel.ui.component.IconButton
 import org.jetbrains.jewel.ui.component.styling.IconButtonStyle
+import org.jetbrains.jewel.ui.icon.IconKey
 import org.jetbrains.jewel.ui.painter.PainterHint
-import org.jetbrains.jewel.ui.painter.PainterProvider
 import org.jetbrains.jewel.ui.painter.PainterProviderScope
 import org.jetbrains.jewel.ui.painter.PainterSuffixHint
 import org.jetbrains.jewel.window.styling.TitleBarStyle
@@ -90,7 +90,7 @@ private fun TitleBarScope.CloseButton(
 private fun TitleBarScope.ControlButton(
     onClick: () -> Unit,
     state: DecoratedWindowState,
-    painterProvider: PainterProvider,
+    iconKey: IconKey,
     description: String,
     style: TitleBarStyle = JewelTheme.defaultTitleBarStyle,
     iconButtonStyle: IconButtonStyle = style.paneButtonStyle,
@@ -100,12 +100,10 @@ private fun TitleBarScope.ControlButton(
         Modifier.align(Alignment.End).focusable(false).size(style.metrics.titlePaneButtonSize),
         style = iconButtonStyle,
     ) {
-        Icon(painterProvider.getPainter(if (state.isActive) PainterHint else Inactive).value, description)
+        Icon(iconKey, description, hint = if (state.isActive) PainterHint else Inactive)
     }
 }
 
-private object Inactive : PainterSuffixHint() {
+private data object Inactive : PainterSuffixHint() {
     override fun PainterProviderScope.suffix(): String = "Inactive"
-
-    override fun toString(): String = "Inactive"
 }

--- a/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/styling/TitleBarStyling.kt
+++ b/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/styling/TitleBarStyling.kt
@@ -13,7 +13,7 @@ import androidx.compose.ui.unit.DpSize
 import org.jetbrains.jewel.foundation.GenerateDataFunctions
 import org.jetbrains.jewel.ui.component.styling.DropdownStyle
 import org.jetbrains.jewel.ui.component.styling.IconButtonStyle
-import org.jetbrains.jewel.ui.painter.PainterProvider
+import org.jetbrains.jewel.ui.icon.IconKey
 import org.jetbrains.jewel.window.DecoratedWindowState
 
 @Stable
@@ -79,10 +79,10 @@ public class TitleBarMetrics(
 @Immutable
 @GenerateDataFunctions
 public class TitleBarIcons(
-    public val minimizeButton: PainterProvider,
-    public val maximizeButton: PainterProvider,
-    public val restoreButton: PainterProvider,
-    public val closeButton: PainterProvider,
+    public val minimizeButton: IconKey,
+    public val maximizeButton: IconKey,
+    public val restoreButton: IconKey,
+    public val closeButton: IconKey,
 ) {
     public companion object
 }

--- a/int-ui/int-ui-decorated-window/api/int-ui-decorated-window.api
+++ b/int-ui/int-ui-decorated-window/api/int-ui-decorated-window.api
@@ -1,3 +1,12 @@
+public final class org/jetbrains/jewel/intui/window/DecoratedWindowIconKeys {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/intui/window/DecoratedWindowIconKeys;
+	public final fun getClose ()Lorg/jetbrains/jewel/ui/icon/IconKey;
+	public final fun getMaximize ()Lorg/jetbrains/jewel/ui/icon/IconKey;
+	public final fun getMinimize ()Lorg/jetbrains/jewel/ui/icon/IconKey;
+	public final fun getRestore ()Lorg/jetbrains/jewel/ui/icon/IconKey;
+}
+
 public final class org/jetbrains/jewel/intui/window/IntUiDecoratedWindowResourceResolverKt {
 	public static final fun decoratedWindowPainterProvider (Ljava/lang/String;)Lorg/jetbrains/jewel/ui/painter/ResourcePainterProvider;
 }
@@ -23,8 +32,8 @@ public final class org/jetbrains/jewel/intui/window/styling/IntUiDecoratedWindow
 public final class org/jetbrains/jewel/intui/window/styling/IntUiTitleBarStylingKt {
 	public static final fun dark (Lorg/jetbrains/jewel/window/styling/TitleBarStyle$Companion;Lorg/jetbrains/jewel/window/styling/TitleBarColors;Lorg/jetbrains/jewel/window/styling/TitleBarMetrics;Lorg/jetbrains/jewel/window/styling/TitleBarIcons;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/window/styling/TitleBarStyle;
 	public static final fun dark-a6iJyiw (Lorg/jetbrains/jewel/window/styling/TitleBarColors$Companion;JJJJJJJJJJJJJLandroidx/compose/runtime/Composer;III)Lorg/jetbrains/jewel/window/styling/TitleBarColors;
-	public static final fun defaults (Lorg/jetbrains/jewel/window/styling/TitleBarIcons$Companion;Lorg/jetbrains/jewel/ui/painter/PainterProvider;Lorg/jetbrains/jewel/ui/painter/PainterProvider;Lorg/jetbrains/jewel/ui/painter/PainterProvider;Lorg/jetbrains/jewel/ui/painter/PainterProvider;)Lorg/jetbrains/jewel/window/styling/TitleBarIcons;
-	public static synthetic fun defaults$default (Lorg/jetbrains/jewel/window/styling/TitleBarIcons$Companion;Lorg/jetbrains/jewel/ui/painter/PainterProvider;Lorg/jetbrains/jewel/ui/painter/PainterProvider;Lorg/jetbrains/jewel/ui/painter/PainterProvider;Lorg/jetbrains/jewel/ui/painter/PainterProvider;ILjava/lang/Object;)Lorg/jetbrains/jewel/window/styling/TitleBarIcons;
+	public static final fun defaults (Lorg/jetbrains/jewel/window/styling/TitleBarIcons$Companion;Lorg/jetbrains/jewel/ui/icon/IconKey;Lorg/jetbrains/jewel/ui/icon/IconKey;Lorg/jetbrains/jewel/ui/icon/IconKey;Lorg/jetbrains/jewel/ui/icon/IconKey;)Lorg/jetbrains/jewel/window/styling/TitleBarIcons;
+	public static synthetic fun defaults$default (Lorg/jetbrains/jewel/window/styling/TitleBarIcons$Companion;Lorg/jetbrains/jewel/ui/icon/IconKey;Lorg/jetbrains/jewel/ui/icon/IconKey;Lorg/jetbrains/jewel/ui/icon/IconKey;Lorg/jetbrains/jewel/ui/icon/IconKey;ILjava/lang/Object;)Lorg/jetbrains/jewel/window/styling/TitleBarIcons;
 	public static final fun defaults-LgNEgRQ (Lorg/jetbrains/jewel/window/styling/TitleBarMetrics$Companion;FFFJ)Lorg/jetbrains/jewel/window/styling/TitleBarMetrics;
 	public static synthetic fun defaults-LgNEgRQ$default (Lorg/jetbrains/jewel/window/styling/TitleBarMetrics$Companion;FFFJILjava/lang/Object;)Lorg/jetbrains/jewel/window/styling/TitleBarMetrics;
 	public static final fun light (Lorg/jetbrains/jewel/window/styling/TitleBarStyle$Companion;Lorg/jetbrains/jewel/window/styling/TitleBarColors;Lorg/jetbrains/jewel/window/styling/TitleBarMetrics;Lorg/jetbrains/jewel/window/styling/TitleBarIcons;Landroidx/compose/runtime/Composer;II)Lorg/jetbrains/jewel/window/styling/TitleBarStyle;

--- a/int-ui/int-ui-decorated-window/src/main/kotlin/org/jetbrains/jewel/intui/window/DecoratedWindowIconKeys.kt
+++ b/int-ui/int-ui-decorated-window/src/main/kotlin/org/jetbrains/jewel/intui/window/DecoratedWindowIconKeys.kt
@@ -1,0 +1,11 @@
+package org.jetbrains.jewel.intui.window
+
+import org.jetbrains.jewel.ui.icon.IconKey
+import org.jetbrains.jewel.ui.icon.PathIconKey
+
+public object DecoratedWindowIconKeys {
+    public val minimize: IconKey = PathIconKey("icons/intui/window/minimize.svg", this::class.java)
+    public val maximize: IconKey = PathIconKey("icons/intui/window/maximize.svg", this::class.java)
+    public val restore: IconKey = PathIconKey("icons/intui/window/restore.svg", this::class.java)
+    public val close: IconKey = PathIconKey("icons/intui/window/close.svg", this::class.java)
+}

--- a/int-ui/int-ui-decorated-window/src/main/kotlin/org/jetbrains/jewel/intui/window/styling/IntUiTitleBarStyling.kt
+++ b/int-ui/int-ui-decorated-window/src/main/kotlin/org/jetbrains/jewel/intui/window/styling/IntUiTitleBarStyling.kt
@@ -13,7 +13,7 @@ import org.jetbrains.jewel.intui.standalone.styling.Undecorated
 import org.jetbrains.jewel.intui.standalone.styling.defaults
 import org.jetbrains.jewel.intui.standalone.styling.light
 import org.jetbrains.jewel.intui.standalone.styling.undecorated
-import org.jetbrains.jewel.intui.window.decoratedWindowPainterProvider
+import org.jetbrains.jewel.intui.window.DecoratedWindowIconKeys
 import org.jetbrains.jewel.ui.component.styling.DropdownColors
 import org.jetbrains.jewel.ui.component.styling.DropdownMetrics
 import org.jetbrains.jewel.ui.component.styling.DropdownStyle
@@ -21,7 +21,7 @@ import org.jetbrains.jewel.ui.component.styling.IconButtonColors
 import org.jetbrains.jewel.ui.component.styling.IconButtonMetrics
 import org.jetbrains.jewel.ui.component.styling.IconButtonStyle
 import org.jetbrains.jewel.ui.component.styling.MenuStyle
-import org.jetbrains.jewel.ui.painter.PainterProvider
+import org.jetbrains.jewel.ui.icon.IconKey
 import org.jetbrains.jewel.window.styling.TitleBarColors
 import org.jetbrains.jewel.window.styling.TitleBarIcons
 import org.jetbrains.jewel.window.styling.TitleBarMetrics
@@ -319,8 +319,8 @@ public fun TitleBarMetrics.Companion.defaults(
 ): TitleBarMetrics = TitleBarMetrics(height, gradientStartX, gradientEndX, titlePaneButtonSize)
 
 public fun TitleBarIcons.Companion.defaults(
-    minimizeButton: PainterProvider = decoratedWindowPainterProvider("icons/intui/window/minimize.svg"),
-    maximizeButton: PainterProvider = decoratedWindowPainterProvider("icons/intui/window/maximize.svg"),
-    restoreButton: PainterProvider = decoratedWindowPainterProvider("icons/intui/window/restore.svg"),
-    closeButton: PainterProvider = decoratedWindowPainterProvider("icons/intui/window/close.svg"),
+    minimizeButton: IconKey = DecoratedWindowIconKeys.minimize,
+    maximizeButton: IconKey = DecoratedWindowIconKeys.maximize,
+    restoreButton: IconKey = DecoratedWindowIconKeys.restore,
+    closeButton: IconKey = DecoratedWindowIconKeys.close,
 ): TitleBarIcons = TitleBarIcons(minimizeButton, maximizeButton, restoreButton, closeButton)

--- a/markdown/extension/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertBlockRenderer.kt
+++ b/markdown/extension/gfm-alerts/src/main/kotlin/org/jetbrains/jewel/markdown/extensions/github/alerts/GitHubAlertBlockRenderer.kt
@@ -6,13 +6,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.isSpecified
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.input.pointer.pointerHoverIcon
@@ -47,7 +44,8 @@ public class GitHubAlertBlockRenderer(private val styling: AlertStyling, private
     ) {
         // Smart cast doesn't work in this case, and then the detection for redundant suppression is
         // also borked
-        @Suppress("MoveVariableDeclarationIntoWhen", "RedundantSuppression") val alert = block as? Alert
+        @Suppress("MoveVariableDeclarationIntoWhen", "RedundantSuppression") // ktfmt: break line
+        val alert = block as? Alert
 
         when (alert) {
             is Caution -> Alert(alert, styling.caution, enabled, blockRenderer, onUrlClick, onTextClick)
@@ -75,34 +73,25 @@ public class GitHubAlertBlockRenderer(private val styling: AlertStyling, private
                     val x = if (isLtr) lineWidthPx / 2 else size.width - lineWidthPx / 2
 
                     drawLine(
-                        styling.lineColor,
-                        Offset(x, 0f),
-                        Offset(x, size.height),
-                        lineWidthPx,
-                        styling.strokeCap,
-                        styling.pathEffect,
+                        color = styling.lineColor,
+                        start = Offset(x, 0f),
+                        end = Offset(x, size.height),
+                        strokeWidth = lineWidthPx,
+                        cap = styling.strokeCap,
+                        pathEffect = styling.pathEffect,
                     )
                 }
                 .padding(styling.padding),
             verticalArrangement = Arrangement.spacedBy(rootStyling.blockVerticalSpacing),
         ) {
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
-                val titleIconProvider = styling.titleIconKey
-                if (titleIconProvider != null) {
-                    val colorFilter =
-                        remember(styling.titleIconTint) {
-                            if (styling.titleIconTint.isSpecified) {
-                                ColorFilter.tint(styling.titleIconTint)
-                            } else {
-                                null
-                            }
-                        }
-
+                val titleIconKey = styling.titleIconKey
+                if (titleIconKey != null) {
                     Icon(
-                        titleIconProvider,
+                        key = titleIconKey,
                         contentDescription = null,
                         iconClass = AlertStyling::class.java,
-                        colorFilter = colorFilter,
+                        tint = styling.titleIconTint,
                     )
                 }
 

--- a/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
+++ b/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
@@ -175,7 +175,7 @@ private fun RowScope.ColumnOne() {
             Tooltip(
                 tooltip = {
                     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                        Icon(AllIconsKeys.General.ShowInfos, contentDescription = null)
+                        Icon(key = AllIconsKeys.General.ShowInfos, contentDescription = null)
                         Text("This is a tooltip")
                     }
                 }
@@ -246,7 +246,7 @@ private fun IconsShowcase() {
 
         Box(Modifier.size(24.dp), contentAlignment = Alignment.Center) {
             Icon(
-                IdeSampleIconKeys.gitHub,
+                key = IdeSampleIconKeys.gitHub,
                 iconClass = IdeSampleIconKeys::class.java,
                 modifier = Modifier.border(1.dp, Color.Magenta),
                 contentDescription = "An owned icon",

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Icon.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Icon.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import java.io.InputStream
+import org.jetbrains.annotations.ApiStatus.ScheduledForRemoval
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.icon.IconKey
 import org.jetbrains.jewel.ui.icon.newUiChecker
@@ -48,6 +49,7 @@ import org.xml.sax.InputSource
         "org.jetbrains.jewel.ui.icon.PathIconKey",
     ),
 )
+@ScheduledForRemoval(inVersion = "Before 1.0")
 @Composable
 public fun Icon(
     resource: String,
@@ -71,6 +73,7 @@ public fun Icon(
         "org.jetbrains.jewel.ui.icon.PathIconKey",
     ),
 )
+@ScheduledForRemoval(inVersion = "Before 1.0")
 @Composable
 public fun Icon(
     resource: String,
@@ -94,6 +97,7 @@ public fun Icon(
         "org.jetbrains.jewel.ui.icon.PathIconKey",
     ),
 )
+@ScheduledForRemoval(inVersion = "Before 1.0")
 @Composable
 public fun Icon(
     resource: String,
@@ -117,6 +121,7 @@ public fun Icon(
         "org.jetbrains.jewel.ui.icon.PathIconKey",
     ),
 )
+@ScheduledForRemoval(inVersion = "Before 1.0")
 @Composable
 public fun Icon(
     resource: String,


### PR DESCRIPTION
This PR moves the last usages of the old, deprecated `PainterProvider`- and `String`-based `Icon` APIs to the `IconKey`-based ones. It then marks the deprecated methods as scheduled for removal before 1.0.

Closes #433 