### PR TITLE
Upgrade Compose to 1.7.0-beta01

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 commonmark = "0.22.0"
-composeDesktop = "1.7.0-alpha03"
+composeDesktop = "1.7.0-beta01"
 detekt = "1.23.6"
 dokka = "1.9.20"
 idea = "2024.2.1"


### PR DESCRIPTION
Compose Multiplatform 1.7.0-beta01 release notes: https://github.com/JetBrains/compose-multiplatform/releases/tag/v1.7.0-beta01

Smoke tested both in standalone and IDE samples, nothing to report.