### PR TITLE
Remove Jewel usages of deprecated PlatformIcon API

### DIFF
--- a/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
+++ b/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
@@ -55,7 +55,6 @@ import org.jetbrains.jewel.ui.component.IconActionButton
 import org.jetbrains.jewel.ui.component.IconButton
 import org.jetbrains.jewel.ui.component.LazyTree
 import org.jetbrains.jewel.ui.component.OutlinedButton
-import org.jetbrains.jewel.ui.component.PlatformIcon
 import org.jetbrains.jewel.ui.component.RadioButtonRow
 import org.jetbrains.jewel.ui.component.Slider
 import org.jetbrains.jewel.ui.component.Text
@@ -202,46 +201,50 @@ private fun IconsShowcase() {
         horizontalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         Box(Modifier.size(24.dp), contentAlignment = Alignment.Center) {
-            PlatformIcon(AllIconsKeys.Nodes.ConfigFolder, "taskGroup")
+            Icon(AllIconsKeys.Nodes.ConfigFolder, "taskGroup")
         }
 
         Box(Modifier.size(24.dp), contentAlignment = Alignment.Center) {
-            PlatformIcon(AllIconsKeys.Nodes.ConfigFolder, "taskGroup", hint = Badge(Color.Red, DotBadgeShape.Default))
+            Icon(
+                key = AllIconsKeys.Nodes.ConfigFolder,
+                contentDescription = "taskGroup",
+                hint = Badge(Color.Red, DotBadgeShape.Default),
+            )
         }
 
         Box(
             Modifier.size(24.dp).background(iconBackgroundColor, shape = RoundedCornerShape(4.dp)),
             contentAlignment = Alignment.Center,
         ) {
-            PlatformIcon(AllIconsKeys.Nodes.ConfigFolder, "taskGroup", hint = Stroke(Color.White))
+            Icon(key = AllIconsKeys.Nodes.ConfigFolder, contentDescription = "taskGroup", hint = Stroke(Color.White))
         }
 
         Box(
             Modifier.size(24.dp).background(iconBackgroundColor, shape = RoundedCornerShape(4.dp)),
             contentAlignment = Alignment.Center,
         ) {
-            PlatformIcon(
-                AllIconsKeys.Nodes.ConfigFolder,
-                "taskGroup",
+            Icon(
+                key = AllIconsKeys.Nodes.ConfigFolder,
+                contentDescription = "taskGroup",
                 hints = arrayOf(Stroke(Color.White), Badge(Color.Red, DotBadgeShape.Default)),
             )
         }
 
         Box(Modifier.size(24.dp), contentAlignment = Alignment.Center) {
-            PlatformIcon(AllIconsKeys.Nodes.ConfigFolder, "taskGroup", hint = Size(20))
+            Icon(key = AllIconsKeys.Nodes.ConfigFolder, contentDescription = "taskGroup", hint = Size(20))
         }
 
         Box(Modifier.size(24.dp), contentAlignment = Alignment.Center) {
-            PlatformIcon(
-                AllIconsKeys.Actions.Close,
-                "An icon",
+            Icon(
+                key = AllIconsKeys.Actions.Close,
+                contentDescription = "An icon",
                 modifier = Modifier.border(1.dp, Color.Magenta),
                 hint = Size(20),
             )
         }
 
         Box(Modifier.size(24.dp), contentAlignment = Alignment.Center) {
-            PlatformIcon(AllIconsKeys.Nodes.ConfigFolder, "taskGroup", hint = Size(20))
+            Icon(key = AllIconsKeys.Nodes.ConfigFolder, contentDescription = "taskGroup", hint = Size(20))
         }
 
         Box(Modifier.size(24.dp), contentAlignment = Alignment.Center) {
@@ -253,7 +256,9 @@ private fun IconsShowcase() {
             )
         }
 
-        IconButton(onClick = {}, Modifier.size(24.dp)) { PlatformIcon(AllIconsKeys.Actions.Close, "Close") }
+        IconButton(onClick = {}, Modifier.size(24.dp)) {
+            Icon(key = AllIconsKeys.Actions.Close, contentDescription = "Close")
+        }
 
         IconActionButton(
             AllIconsKeys.Actions.AddList,

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/component/Buttons.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/component/Buttons.kt
@@ -15,10 +15,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import org.jetbrains.jewel.ui.component.ActionButton
 import org.jetbrains.jewel.ui.component.DefaultButton
+import org.jetbrains.jewel.ui.component.Icon
 import org.jetbrains.jewel.ui.component.IconActionButton
 import org.jetbrains.jewel.ui.component.IconButton
 import org.jetbrains.jewel.ui.component.OutlinedButton
-import org.jetbrains.jewel.ui.component.PlatformIcon
 import org.jetbrains.jewel.ui.component.SelectableIconActionButton
 import org.jetbrains.jewel.ui.component.SelectableIconButton
 import org.jetbrains.jewel.ui.component.Text
@@ -71,19 +71,19 @@ private fun IconButtons(selected: Boolean, onSelectableClick: () -> Unit) {
 
         Text("Focusable:")
 
-        IconButton(onClick = {}) { PlatformIcon(AllIconsKeys.Actions.Close, contentDescription = "IconButton") }
+        IconButton(onClick = {}) { Icon(key = AllIconsKeys.Actions.Close, contentDescription = "IconButton") }
 
         Text("Not focusable:")
 
         IconButton(onClick = {}, focusable = false) {
-            PlatformIcon(AllIconsKeys.Actions.Close, contentDescription = "IconButton")
+            Icon(key = AllIconsKeys.Actions.Close, contentDescription = "IconButton")
         }
 
         Text("Selectable:")
 
         SelectableIconButton(onClick = onSelectableClick, selected = selected) { state ->
             val tint by LocalIconButtonStyle.current.colors.selectableForegroundFor(state)
-            PlatformIcon(
+            Icon(
                 key = AllIconsKeys.Actions.MatchCase,
                 contentDescription = "SelectableIconButton",
                 hints = arrayOf(Selected(selected), Stroke(tint)),
@@ -95,7 +95,7 @@ private fun IconButtons(selected: Boolean, onSelectableClick: () -> Unit) {
         var checked by remember { mutableStateOf(false) }
         ToggleableIconButton(onValueChange = { checked = !checked }, value = checked) { state ->
             val tint by LocalIconButtonStyle.current.colors.toggleableForegroundFor(state)
-            PlatformIcon(
+            Icon(
                 key = AllIconsKeys.Actions.MatchCase,
                 contentDescription = "ToggleableIconButton",
                 hints = arrayOf(Selected(checked), Stroke(tint)),

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/component/Icons.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/component/Icons.kt
@@ -18,7 +18,6 @@ import androidx.compose.ui.unit.dp
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.samples.standalone.StandaloneSampleIcons
 import org.jetbrains.jewel.ui.component.Icon
-import org.jetbrains.jewel.ui.component.PlatformIcon
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.icons.AllIconsKeys
 import org.jetbrains.jewel.ui.painter.badge.DotBadgeShape
@@ -52,29 +51,33 @@ internal fun Icons() {
         horizontalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         Box(Modifier.size(24.dp), contentAlignment = Alignment.Center) {
-            PlatformIcon(AllIconsKeys.Nodes.ConfigFolder, "taskGroup")
+            Icon(key = AllIconsKeys.Nodes.ConfigFolder, contentDescription = "taskGroup")
         }
         Box(Modifier.size(24.dp), contentAlignment = Alignment.Center) {
-            PlatformIcon(AllIconsKeys.Nodes.ConfigFolder, "taskGroup", hint = Badge(Color.Red, DotBadgeShape.Default))
+            Icon(
+                key = AllIconsKeys.Nodes.ConfigFolder,
+                contentDescription = "taskGroup",
+                hint = Badge(Color.Red, DotBadgeShape.Default),
+            )
         }
         Box(
             Modifier.size(24.dp).background(JewelTheme.colorPalette.blue(4), shape = RoundedCornerShape(4.dp)),
             contentAlignment = Alignment.Center,
         ) {
-            PlatformIcon(AllIconsKeys.Nodes.ConfigFolder, "taskGroup", hint = Stroke(Color.White))
+            Icon(key = AllIconsKeys.Nodes.ConfigFolder, contentDescription = "taskGroup", hint = Stroke(Color.White))
         }
         Box(
             Modifier.size(24.dp).background(JewelTheme.colorPalette.blue(4), shape = RoundedCornerShape(4.dp)),
             contentAlignment = Alignment.Center,
         ) {
-            PlatformIcon(
-                AllIconsKeys.Nodes.ConfigFolder,
-                "taskGroup",
+            Icon(
+                key = AllIconsKeys.Nodes.ConfigFolder,
+                contentDescription = "taskGroup",
                 hints = arrayOf(Stroke(Color.White), Badge(Color.Red, DotBadgeShape.Default)),
             )
         }
         Box(Modifier.size(24.dp), contentAlignment = Alignment.Center) {
-            PlatformIcon(AllIconsKeys.Nodes.ConfigFolder, "taskGroup", hint = Size(20))
+            Icon(key = AllIconsKeys.Nodes.ConfigFolder, contentDescription = "taskGroup", hint = Size(20))
         }
     }
 }

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/PlatformIcon.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/PlatformIcon.kt
@@ -20,6 +20,7 @@ public fun PlatformIcon(
     tint: Color = Color.Unspecified,
     hint: PainterHint,
 ) {
+    @Suppress("DEPRECATION") // Everything is deprecated here anyway
     PlatformIcon(key, contentDescription, modifier, tint, *arrayOf(hint))
 }
 


### PR DESCRIPTION
We've deprecated it for a good reason... and we should stop using it ourselves, too. This PR removes all usages.