### PR TITLE
Add syntax highlighting to markdown preview

### DIFF
--- a/foundation/api/foundation.api
+++ b/foundation/api/foundation.api
@@ -171,6 +171,89 @@ public final class org/jetbrains/jewel/foundation/actionSystem/ProvideDataKt {
 	public static final fun provideData (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;)Landroidx/compose/ui/Modifier;
 }
 
+public final class org/jetbrains/jewel/foundation/code/MimeType {
+	public static final field ATTR_FOLDER_TYPE Ljava/lang/String;
+	public static final field ATTR_ROLE Ljava/lang/String;
+	public static final field ATTR_ROOT_TAG Ljava/lang/String;
+	public static final field VALUE_MANIFEST Ljava/lang/String;
+	public static final field VALUE_RESOURCE Ljava/lang/String;
+	public static final fun base-9EQw4cI (Ljava/lang/String;)Ljava/lang/String;
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lorg/jetbrains/jewel/foundation/code/MimeType;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public static final fun displayName-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/foundation/code/MimeType$Known {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/foundation/code/MimeType$Known;
+	public final fun fromMarkdownLanguageName-YABSuFg (Ljava/lang/String;)Ljava/lang/String;
+	public final fun getAGSL-9EQw4cI ()Ljava/lang/String;
+	public final fun getAIDL-9EQw4cI ()Ljava/lang/String;
+	public final fun getC-9EQw4cI ()Ljava/lang/String;
+	public final fun getCPP-9EQw4cI ()Ljava/lang/String;
+	public final fun getDART-9EQw4cI ()Ljava/lang/String;
+	public final fun getGO-9EQw4cI ()Ljava/lang/String;
+	public final fun getGRADLE-9EQw4cI ()Ljava/lang/String;
+	public final fun getGRADLE_KTS-9EQw4cI ()Ljava/lang/String;
+	public final fun getGROOVY-9EQw4cI ()Ljava/lang/String;
+	public final fun getJAVA-9EQw4cI ()Ljava/lang/String;
+	public final fun getJAVASCRIPT-9EQw4cI ()Ljava/lang/String;
+	public final fun getJSON-9EQw4cI ()Ljava/lang/String;
+	public final fun getKOTLIN-9EQw4cI ()Ljava/lang/String;
+	public final fun getMANIFEST-9EQw4cI ()Ljava/lang/String;
+	public final fun getPROGUARD-9EQw4cI ()Ljava/lang/String;
+	public final fun getPROPERTIES-9EQw4cI ()Ljava/lang/String;
+	public final fun getPROTO-9EQw4cI ()Ljava/lang/String;
+	public final fun getPYTHON-9EQw4cI ()Ljava/lang/String;
+	public final fun getREGEX-9EQw4cI ()Ljava/lang/String;
+	public final fun getRESOURCE-9EQw4cI ()Ljava/lang/String;
+	public final fun getRUST-9EQw4cI ()Ljava/lang/String;
+	public final fun getSHELL-9EQw4cI ()Ljava/lang/String;
+	public final fun getSQL-9EQw4cI ()Ljava/lang/String;
+	public final fun getSVG-9EQw4cI ()Ljava/lang/String;
+	public final fun getTEXT-9EQw4cI ()Ljava/lang/String;
+	public final fun getTOML-9EQw4cI ()Ljava/lang/String;
+	public final fun getTYPESCRIPT-9EQw4cI ()Ljava/lang/String;
+	public final fun getUNKNOWN-9EQw4cI ()Ljava/lang/String;
+	public final fun getVERSION_CATALOG-9EQw4cI ()Ljava/lang/String;
+	public final fun getXML-9EQw4cI ()Ljava/lang/String;
+	public final fun getYAML-9EQw4cI ()Ljava/lang/String;
+}
+
+public final class org/jetbrains/jewel/foundation/code/MimeTypeKt {
+	public static final fun isGradle-KcqRzx0 (Ljava/lang/String;)Z
+	public static final fun isJava-KcqRzx0 (Ljava/lang/String;)Z
+	public static final fun isKotlin-KcqRzx0 (Ljava/lang/String;)Z
+	public static final fun isManifest-KcqRzx0 (Ljava/lang/String;)Z
+	public static final fun isProto-KcqRzx0 (Ljava/lang/String;)Z
+	public static final fun isRegex-KcqRzx0 (Ljava/lang/String;)Z
+	public static final fun isSql-KcqRzx0 (Ljava/lang/String;)Z
+	public static final fun isVersionCatalog-KcqRzx0 (Ljava/lang/String;)Z
+	public static final fun isXml-KcqRzx0 (Ljava/lang/String;)Z
+}
+
+public abstract interface class org/jetbrains/jewel/foundation/code/highlighting/CodeHighlighter {
+	public abstract fun highlight-C7ITchA (Ljava/lang/String;Ljava/lang/String;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class org/jetbrains/jewel/foundation/code/highlighting/CodeHighlighterKt {
+	public static final fun getLocalCodeHighlighter ()Landroidx/compose/runtime/ProvidableCompositionLocal;
+}
+
+public final class org/jetbrains/jewel/foundation/code/highlighting/NoOpCodeHighlighter : org/jetbrains/jewel/foundation/code/highlighting/CodeHighlighter {
+	public static final field $stable I
+	public static final field INSTANCE Lorg/jetbrains/jewel/foundation/code/highlighting/NoOpCodeHighlighter;
+	public fun highlight-C7ITchA (Ljava/lang/String;Ljava/lang/String;)Lkotlinx/coroutines/flow/Flow;
+}
+
 public class org/jetbrains/jewel/foundation/lazy/DefaultMacOsSelectableColumnKeybindings : org/jetbrains/jewel/foundation/lazy/DefaultSelectableColumnKeybindings {
 	public static final field $stable I
 	public static final field Companion Lorg/jetbrains/jewel/foundation/lazy/DefaultMacOsSelectableColumnKeybindings$Companion;

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/code/MimeType.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/code/MimeType.kt
@@ -1,5 +1,14 @@
 package org.jetbrains.jewel.foundation.code
 
+import org.jetbrains.jewel.foundation.code.MimeType.Known.AGSL
+import org.jetbrains.jewel.foundation.code.MimeType.Known.DART
+import org.jetbrains.jewel.foundation.code.MimeType.Known.JSON
+import org.jetbrains.jewel.foundation.code.MimeType.Known.KOTLIN
+import org.jetbrains.jewel.foundation.code.MimeType.Known.PYTHON
+import org.jetbrains.jewel.foundation.code.MimeType.Known.RUST
+import org.jetbrains.jewel.foundation.code.MimeType.Known.TYPESCRIPT
+import org.jetbrains.jewel.foundation.code.MimeType.Known.YAML
+
 /**
  * Represents the language and dialect of a source snippet, as an RFC 2046 mime type.
  *
@@ -107,22 +116,22 @@ public value class MimeType(private val mimeType: String) {
 
                 "application/kotlin-source",
                 "text/x-kotlin",
-                "text/x-kotlin-source" -> Known.KOTLIN.mimeType
+                "text/x-kotlin-source" -> KOTLIN.mimeType
 
                 "application/xml" -> Known.XML.mimeType
                 "application/json",
                 "application/vnd.api+json",
                 "application/hal+json",
-                "application/ld+json" -> Known.JSON.mimeType
+                "application/ld+json" -> JSON.mimeType
 
                 "image/svg+xml" -> Known.XML.mimeType
                 "text/x-python",
-                "application/x-python-script" -> Known.PYTHON.mimeType
+                "application/x-python-script" -> PYTHON.mimeType
 
                 "text/dart",
                 "text/x-dart",
                 "application/dart",
-                "application/x-dart" -> Known.DART.mimeType
+                "application/x-dart" -> DART.mimeType
 
                 "application/javascript",
                 "application/x-javascript",
@@ -130,14 +139,14 @@ public value class MimeType(private val mimeType: String) {
                 "application/ecmascript",
                 "application/x-ecmascript" -> Known.JAVASCRIPT.mimeType
 
-                "application/typescript" + "application/x-typescript" -> Known.TYPESCRIPT.mimeType
+                "application/typescript" + "application/x-typescript" -> TYPESCRIPT.mimeType
                 "text/x-rust",
-                "application/x-rust" -> Known.RUST.mimeType
+                "application/x-rust" -> RUST.mimeType
 
-                "text/x-sksl" -> Known.AGSL.mimeType
+                "text/x-sksl" -> AGSL.mimeType
                 "application/yaml",
                 "text/x-yaml",
-                "application/x-yaml" -> Known.YAML.mimeType
+                "application/x-yaml" -> YAML.mimeType
 
                 else -> base
             }

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/code/MimeType.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/code/MimeType.kt
@@ -1,13 +1,4 @@
-package org.jetbrains.jewel.markdown
-
-import org.jetbrains.jewel.markdown.MimeType.Known.AGSL
-import org.jetbrains.jewel.markdown.MimeType.Known.DART
-import org.jetbrains.jewel.markdown.MimeType.Known.JSON
-import org.jetbrains.jewel.markdown.MimeType.Known.KOTLIN
-import org.jetbrains.jewel.markdown.MimeType.Known.PYTHON
-import org.jetbrains.jewel.markdown.MimeType.Known.RUST
-import org.jetbrains.jewel.markdown.MimeType.Known.TYPESCRIPT
-import org.jetbrains.jewel.markdown.MimeType.Known.YAML
+package org.jetbrains.jewel.foundation.code
 
 /**
  * Represents the language and dialect of a source snippet, as an RFC 2046 mime type.
@@ -116,22 +107,22 @@ public value class MimeType(private val mimeType: String) {
 
                 "application/kotlin-source",
                 "text/x-kotlin",
-                "text/x-kotlin-source" -> KOTLIN.mimeType
+                "text/x-kotlin-source" -> Known.KOTLIN.mimeType
 
                 "application/xml" -> Known.XML.mimeType
                 "application/json",
                 "application/vnd.api+json",
                 "application/hal+json",
-                "application/ld+json" -> JSON.mimeType
+                "application/ld+json" -> Known.JSON.mimeType
 
                 "image/svg+xml" -> Known.XML.mimeType
                 "text/x-python",
-                "application/x-python-script" -> PYTHON.mimeType
+                "application/x-python-script" -> Known.PYTHON.mimeType
 
                 "text/dart",
                 "text/x-dart",
                 "application/dart",
-                "application/x-dart" -> DART.mimeType
+                "application/x-dart" -> Known.DART.mimeType
 
                 "application/javascript",
                 "application/x-javascript",
@@ -139,14 +130,14 @@ public value class MimeType(private val mimeType: String) {
                 "application/ecmascript",
                 "application/x-ecmascript" -> Known.JAVASCRIPT.mimeType
 
-                "application/typescript" + "application/x-typescript" -> TYPESCRIPT.mimeType
+                "application/typescript" + "application/x-typescript" -> Known.TYPESCRIPT.mimeType
                 "text/x-rust",
-                "application/x-rust" -> RUST.mimeType
+                "application/x-rust" -> Known.RUST.mimeType
 
-                "text/x-sksl" -> AGSL.mimeType
+                "text/x-sksl" -> Known.AGSL.mimeType
                 "application/yaml",
                 "text/x-yaml",
-                "application/x-yaml" -> YAML.mimeType
+                "application/x-yaml" -> Known.YAML.mimeType
 
                 else -> base
             }

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/code/highlighting/CodeHighlighter.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/code/highlighting/CodeHighlighter.kt
@@ -1,0 +1,32 @@
+package org.jetbrains.jewel.foundation.code.highlighting
+
+import androidx.compose.runtime.ProvidableCompositionLocal
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.text.AnnotatedString
+import kotlinx.coroutines.flow.Flow
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
+import org.jetbrains.jewel.foundation.code.MimeType
+
+@ExperimentalJewelApi
+public interface CodeHighlighter {
+    /**
+     * Highlights [code] according to rules for the language specified by [mimeType], and returns flow of styled
+     * strings. For basic highlighters with rigid color schemes it is enough to return a flow of one element:
+     * ```
+     * return flowOf(highlightedString(code, mimeType))
+     * ```
+     *
+     * However, some implementations might want gradual highlighting (for example, apply something simple while waiting
+     * for the extensive info from server), or they might rely upon a color scheme that can change at any time.
+     *
+     * In such cases, they need to produce more than one styled string for the same piece of code, and that's when flows
+     * come in handy.
+     *
+     * @see [NoOpCodeHighlighter]
+     */
+    public fun highlight(code: String, mimeType: MimeType): Flow<AnnotatedString>
+}
+
+public val LocalCodeHighlighter: ProvidableCompositionLocal<CodeHighlighter> = staticCompositionLocalOf {
+    NoOpCodeHighlighter
+}

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/code/highlighting/NoOpCodeHighlighter.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/code/highlighting/NoOpCodeHighlighter.kt
@@ -1,0 +1,14 @@
+package org.jetbrains.jewel.foundation.code.highlighting
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import org.jetbrains.jewel.foundation.code.MimeType
+
+public object NoOpCodeHighlighter : CodeHighlighter {
+    override fun highlight(code: String, mimeType: MimeType): Flow<AnnotatedString> =
+        flowOf(buildAnnotatedString { withStyle(TextStyle.Default.toSpanStyle()) { append(code) } })
+}

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/code/highlighting/NoOpCodeHighlighter.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/code/highlighting/NoOpCodeHighlighter.kt
@@ -1,14 +1,10 @@
 package org.jetbrains.jewel.foundation.code.highlighting
 
 import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.withStyle
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import org.jetbrains.jewel.foundation.code.MimeType
 
 public object NoOpCodeHighlighter : CodeHighlighter {
-    override fun highlight(code: String, mimeType: MimeType): Flow<AnnotatedString> =
-        flowOf(buildAnnotatedString { withStyle(TextStyle.Default.toSpanStyle()) { append(code) } })
+    override fun highlight(code: String, mimeType: MimeType): Flow<AnnotatedString> = flowOf(AnnotatedString(code))
 }

--- a/ide-laf-bridge/api/ide-laf-bridge.api
+++ b/ide-laf-bridge/api/ide-laf-bridge.api
@@ -105,15 +105,15 @@ public final class org/jetbrains/jewel/bridge/actionSystem/RootDataProviderNode 
 	public fun uiDataSnapshot (Lcom/intellij/openapi/actionSystem/DataSink;)V
 }
 
-public final class org/jetbrains/jewel/bridge/code/highlighting/LexerBasedCodeHighlighter : org/jetbrains/jewel/foundation/code/highlighting/CodeHighlighter {
+public final class org/jetbrains/jewel/bridge/code/highlighting/CodeHighlighterFactory {
 	public static final field $stable I
-	public static final field Companion Lorg/jetbrains/jewel/bridge/code/highlighting/LexerBasedCodeHighlighter$Companion;
+	public static final field Companion Lorg/jetbrains/jewel/bridge/code/highlighting/CodeHighlighterFactory$Companion;
 	public fun <init> (Lcom/intellij/openapi/project/Project;Lkotlinx/coroutines/CoroutineScope;)V
-	public fun highlight-C7ITchA (Ljava/lang/String;Ljava/lang/String;)Lkotlinx/coroutines/flow/Flow;
+	public final fun createHighlighter ()Lorg/jetbrains/jewel/foundation/code/highlighting/CodeHighlighter;
 }
 
-public final class org/jetbrains/jewel/bridge/code/highlighting/LexerBasedCodeHighlighter$Companion {
-	public final fun getInstance (Lcom/intellij/openapi/project/Project;)Lorg/jetbrains/jewel/bridge/code/highlighting/LexerBasedCodeHighlighter;
+public final class org/jetbrains/jewel/bridge/code/highlighting/CodeHighlighterFactory$Companion {
+	public final fun getInstance (Lcom/intellij/openapi/project/Project;)Lorg/jetbrains/jewel/bridge/code/highlighting/CodeHighlighterFactory;
 }
 
 public final class org/jetbrains/jewel/bridge/icon/IntelliJIconKeyKt {

--- a/ide-laf-bridge/api/ide-laf-bridge.api
+++ b/ide-laf-bridge/api/ide-laf-bridge.api
@@ -105,6 +105,17 @@ public final class org/jetbrains/jewel/bridge/actionSystem/RootDataProviderNode 
 	public fun uiDataSnapshot (Lcom/intellij/openapi/actionSystem/DataSink;)V
 }
 
+public final class org/jetbrains/jewel/bridge/code/highlighting/LexerBasedCodeHighlighter : org/jetbrains/jewel/foundation/code/highlighting/CodeHighlighter {
+	public static final field $stable I
+	public static final field Companion Lorg/jetbrains/jewel/bridge/code/highlighting/LexerBasedCodeHighlighter$Companion;
+	public fun <init> (Lcom/intellij/openapi/project/Project;Lkotlinx/coroutines/CoroutineScope;)V
+	public fun highlight-C7ITchA (Ljava/lang/String;Ljava/lang/String;)Lkotlinx/coroutines/flow/Flow;
+}
+
+public final class org/jetbrains/jewel/bridge/code/highlighting/LexerBasedCodeHighlighter$Companion {
+	public final fun getInstance (Lcom/intellij/openapi/project/Project;)Lorg/jetbrains/jewel/bridge/code/highlighting/LexerBasedCodeHighlighter;
+}
+
 public final class org/jetbrains/jewel/bridge/icon/IntelliJIconKeyKt {
 	public static final fun fromPlatformIcon (Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey$Companion;Ljavax/swing/Icon;Ljava/lang/Class;)Lorg/jetbrains/jewel/ui/icon/IconKey;
 	public static synthetic fun fromPlatformIcon$default (Lorg/jetbrains/jewel/ui/icon/IntelliJIconKey$Companion;Ljavax/swing/Icon;Ljava/lang/Class;ILjava/lang/Object;)Lorg/jetbrains/jewel/ui/icon/IconKey;

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/code/highlighting/CodeHighlighterFactory.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/code/highlighting/CodeHighlighterFactory.kt
@@ -1,0 +1,31 @@
+package org.jetbrains.jewel.bridge.code.highlighting
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.editor.colors.EditorColorsListener
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.project.Project
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import org.jetbrains.jewel.foundation.code.highlighting.CodeHighlighter
+
+@Service(Service.Level.PROJECT)
+public class CodeHighlighterFactory(private val project: Project, private val coroutineScope: CoroutineScope) {
+    private val reHighlightingRequests = MutableSharedFlow<Unit>(replay = 0)
+
+    init {
+        project.messageBus
+            .connect(coroutineScope)
+            .subscribe(
+                EditorColorsManager.TOPIC,
+                EditorColorsListener { coroutineScope.launch { reHighlightingRequests.emit(Unit) } },
+            )
+    }
+
+    public fun createHighlighter(): CodeHighlighter = LexerBasedCodeHighlighter(project, reHighlightingRequests)
+
+    public companion object {
+        public fun getInstance(project: Project): CodeHighlighterFactory = project.service()
+    }
+}

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/code/highlighting/LexerBasedCodeHighlighter.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/code/highlighting/LexerBasedCodeHighlighter.kt
@@ -5,11 +5,13 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import com.intellij.lang.Language
 import com.intellij.lang.LanguageUtil
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.colors.EditorColorsScheme
+import com.intellij.openapi.editor.markup.EffectType
 import com.intellij.openapi.editor.markup.TextAttributes
 import com.intellij.openapi.fileTypes.SyntaxHighlighter
 import com.intellij.openapi.fileTypes.SyntaxHighlighterFactory
@@ -91,5 +93,12 @@ internal class LexerBasedCodeHighlighter(
             color = foregroundColor.toComposeColorOrUnspecified(),
             fontWeight = if (fontType and Font.BOLD != 0) FontWeight.Bold else null,
             fontStyle = if (fontType and Font.ITALIC != 0) FontStyle.Italic else null,
+            background = backgroundColor.toComposeColorOrUnspecified(),
+            textDecoration =
+                when (effectType) {
+                    EffectType.LINE_UNDERSCORE -> TextDecoration.Underline
+                    EffectType.STRIKEOUT -> TextDecoration.LineThrough
+                    else -> null
+                },
         )
 }

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/code/highlighting/LexerBasedCodeHighlighter.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/code/highlighting/LexerBasedCodeHighlighter.kt
@@ -1,0 +1,81 @@
+package org.jetbrains.jewel.bridge.code.highlighting
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import com.intellij.lang.Language
+import com.intellij.lang.LanguageUtil
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.editor.markup.TextAttributes
+import com.intellij.openapi.fileTypes.SyntaxHighlighterFactory
+import com.intellij.openapi.project.Project
+import com.intellij.testFramework.LightVirtualFile
+import java.awt.Font
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import org.jetbrains.jewel.bridge.toComposeColorOrUnspecified
+import org.jetbrains.jewel.foundation.code.MimeType
+import org.jetbrains.jewel.foundation.code.highlighting.CodeHighlighter
+
+@Service(Service.Level.PROJECT)
+public class LexerBasedCodeHighlighter(private val project: Project) : CodeHighlighter {
+
+    override fun highlight(code: String, mimeType: MimeType): Flow<AnnotatedString> {
+        val language = mimeType.toLanguageOrNull() ?: return flowOf(AnnotatedString(code))
+        val virtualFile =
+            LightVirtualFile(
+                "markdown_code_block_${code.hashCode()}.${language.associatedFileType?.defaultExtension ?: "txt"}",
+                language,
+                code,
+            )
+        val colorScheme = EditorColorsManager.getInstance().globalScheme
+        val highlighter = SyntaxHighlighterFactory.getSyntaxHighlighter(language, project, virtualFile)
+
+        return flowOf(
+            buildAnnotatedString {
+                with(highlighter.highlightingLexer) {
+                    start(code)
+
+                    while (tokenType != null) {
+                        val attributes: TextAttributes? = run {
+                            val attrKey = highlighter.getTokenHighlights(tokenType).lastOrNull() ?: return@run null
+                            colorScheme.getAttributes(attrKey) ?: attrKey.defaultAttributes
+                        }
+                        withTextAttributes(attributes) { append(tokenText) }
+                        advance()
+                    }
+                }
+            }
+        )
+    }
+
+    private fun MimeType.toLanguageOrNull(): Language? {
+        return LanguageUtil.findRegisteredLanguage(displayName().lowercase())
+    }
+
+    private fun AnnotatedString.Builder.withTextAttributes(
+        textAttributes: TextAttributes?,
+        block: AnnotatedString.Builder.() -> Unit,
+    ) {
+        if (textAttributes == null) {
+            return block()
+        }
+        withStyle(textAttributes.toSpanStyle(), block)
+    }
+
+    private fun TextAttributes.toSpanStyle() =
+        SpanStyle(
+            color = foregroundColor.toComposeColorOrUnspecified(),
+            fontWeight = if (fontType and Font.BOLD != 0) FontWeight.Bold else null,
+            fontStyle = if (fontType and Font.ITALIC != 0) FontStyle.Italic else null,
+        )
+
+    public companion object {
+        public fun getInstance(project: Project): LexerBasedCodeHighlighter = project.service()
+    }
+}

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/code/highlighting/LexerBasedCodeHighlighter.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/code/highlighting/LexerBasedCodeHighlighter.kt
@@ -10,20 +10,42 @@ import com.intellij.lang.Language
 import com.intellij.lang.LanguageUtil
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
+import com.intellij.openapi.editor.colors.EditorColorsListener
 import com.intellij.openapi.editor.colors.EditorColorsManager
+import com.intellij.openapi.editor.colors.EditorColorsScheme
 import com.intellij.openapi.editor.markup.TextAttributes
+import com.intellij.openapi.fileTypes.SyntaxHighlighter
 import com.intellij.openapi.fileTypes.SyntaxHighlighterFactory
 import com.intellij.openapi.project.Project
 import com.intellij.testFramework.LightVirtualFile
 import java.awt.Font
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.jetbrains.jewel.bridge.toComposeColorOrUnspecified
 import org.jetbrains.jewel.foundation.code.MimeType
 import org.jetbrains.jewel.foundation.code.highlighting.CodeHighlighter
 
 @Service(Service.Level.PROJECT)
-public class LexerBasedCodeHighlighter(private val project: Project) : CodeHighlighter {
+public class LexerBasedCodeHighlighter(private val project: Project, private val coroutineScope: CoroutineScope) :
+    CodeHighlighter {
+    private val reHighlightingRequests = MutableSharedFlow<Unit>(replay = 0)
+
+    init {
+        project.messageBus
+            .connect(coroutineScope)
+            .subscribe(
+                EditorColorsManager.TOPIC,
+                EditorColorsListener { coroutineScope.launch { reHighlightingRequests.emit(Unit) } },
+            )
+    }
 
     override fun highlight(code: String, mimeType: MimeType): Flow<AnnotatedString> {
         val language = mimeType.toLanguageOrNull() ?: return flowOf(AnnotatedString(code))
@@ -34,29 +56,45 @@ public class LexerBasedCodeHighlighter(private val project: Project) : CodeHighl
                 code,
             )
         val colorScheme = EditorColorsManager.getInstance().globalScheme
-        val highlighter = SyntaxHighlighterFactory.getSyntaxHighlighter(language, project, virtualFile)
+        val highlighter =
+            SyntaxHighlighterFactory.getSyntaxHighlighter(language, project, virtualFile)
+                ?: return flowOf(AnnotatedString(code))
 
-        return flowOf(
-            buildAnnotatedString {
-                with(highlighter.highlightingLexer) {
-                    start(code)
+        return flow {
+            highlightAndEmit(highlighter, code, colorScheme)
+            reHighlightingRequests.collect { highlightAndEmit(highlighter, code, colorScheme) }
+        }
+    }
 
-                    while (tokenType != null) {
-                        val attributes: TextAttributes? = run {
-                            val attrKey = highlighter.getTokenHighlights(tokenType).lastOrNull() ?: return@run null
-                            colorScheme.getAttributes(attrKey) ?: attrKey.defaultAttributes
-                        }
-                        withTextAttributes(attributes) { append(tokenText) }
-                        advance()
-                    }
+    private suspend fun FlowCollector<AnnotatedString>.highlightAndEmit(
+        highlighter: SyntaxHighlighter,
+        code: String,
+        colorScheme: EditorColorsScheme,
+        highlightDispatcher: CoroutineContext = Dispatchers.Default,
+    ) {
+        emit(withContext(highlightDispatcher) { doHighlight(highlighter, code, colorScheme) })
+    }
+
+    private fun doHighlight(
+        highlighter: SyntaxHighlighter,
+        code: String,
+        colorScheme: EditorColorsScheme,
+    ): AnnotatedString = buildAnnotatedString {
+        with(highlighter.highlightingLexer) {
+            start(code)
+
+            while (tokenType != null) {
+                val attributes: TextAttributes? = run {
+                    val attrKey = highlighter.getTokenHighlights(tokenType).lastOrNull() ?: return@run null
+                    colorScheme.getAttributes(attrKey) ?: attrKey.defaultAttributes
                 }
+                withTextAttributes(attributes) { append(tokenText) }
+                advance()
             }
-        )
+        }
     }
 
-    private fun MimeType.toLanguageOrNull(): Language? {
-        return LanguageUtil.findRegisteredLanguage(displayName().lowercase())
-    }
+    private fun MimeType.toLanguageOrNull(): Language? = LanguageUtil.findRegisteredLanguage(displayName().lowercase())
 
     private fun AnnotatedString.Builder.withTextAttributes(
         textAttributes: TextAttributes?,

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/code/highlighting/LexerBasedCodeHighlighter.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/code/highlighting/LexerBasedCodeHighlighter.kt
@@ -34,12 +34,8 @@ internal class LexerBasedCodeHighlighter(
 ) : CodeHighlighter {
     override fun highlight(code: String, mimeType: MimeType): Flow<AnnotatedString> {
         val language = mimeType.toLanguageOrNull() ?: return flowOf(AnnotatedString(code))
-        val virtualFile =
-            LightVirtualFile(
-                "markdown_code_block_${code.hashCode()}.${language.associatedFileType?.defaultExtension ?: "txt"}",
-                language,
-                code,
-            )
+        val fileExtension = language.associatedFileType?.defaultExtension ?: return flowOf(AnnotatedString(code))
+        val virtualFile = LightVirtualFile("markdown_code_block_${code.hashCode()}.$fileExtension", language, code)
         val colorScheme = EditorColorsManager.getInstance().globalScheme
         val highlighter =
             SyntaxHighlighterFactory.getSyntaxHighlighter(language, project, virtualFile)

--- a/markdown/core/api/core.api
+++ b/markdown/core/api/core.api
@@ -121,7 +121,7 @@ public final class org/jetbrains/jewel/markdown/MarkdownBlock$CodeBlock$FencedCo
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getContent ()Ljava/lang/String;
-	public final fun getMimeType-EIRQHX8 ()Ljava/lang/String;
+	public final fun getMimeType-VwCp3SY ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -220,75 +220,6 @@ public final class org/jetbrains/jewel/markdown/MarkdownKt {
 	public static final fun LazyMarkdown (Ljava/util/List;Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/layout/PaddingValues;Landroidx/compose/foundation/lazy/LazyListState;ZZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Markdown (Ljava/lang/String;Landroidx/compose/ui/Modifier;ZZLkotlinx/coroutines/CoroutineDispatcher;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;Lorg/jetbrains/jewel/markdown/processing/MarkdownProcessor;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Landroidx/compose/runtime/Composer;II)V
 	public static final fun Markdown (Ljava/util/List;Ljava/lang/String;Landroidx/compose/ui/Modifier;ZZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Landroidx/compose/runtime/Composer;II)V
-}
-
-public final class org/jetbrains/jewel/markdown/MimeType {
-	public static final field ATTR_FOLDER_TYPE Ljava/lang/String;
-	public static final field ATTR_ROLE Ljava/lang/String;
-	public static final field ATTR_ROOT_TAG Ljava/lang/String;
-	public static final field VALUE_MANIFEST Ljava/lang/String;
-	public static final field VALUE_RESOURCE Ljava/lang/String;
-	public static final fun base-ip6yS68 (Ljava/lang/String;)Ljava/lang/String;
-	public static final synthetic fun box-impl (Ljava/lang/String;)Lorg/jetbrains/jewel/markdown/MimeType;
-	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
-	public static final fun displayName-impl (Ljava/lang/String;)Ljava/lang/String;
-	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
-	public fun hashCode ()I
-	public static fun hashCode-impl (Ljava/lang/String;)I
-	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Ljava/lang/String;
-}
-
-public final class org/jetbrains/jewel/markdown/MimeType$Known {
-	public static final field $stable I
-	public static final field INSTANCE Lorg/jetbrains/jewel/markdown/MimeType$Known;
-	public final fun fromMarkdownLanguageName-HxXrbs8 (Ljava/lang/String;)Ljava/lang/String;
-	public final fun getAGSL-ip6yS68 ()Ljava/lang/String;
-	public final fun getAIDL-ip6yS68 ()Ljava/lang/String;
-	public final fun getC-ip6yS68 ()Ljava/lang/String;
-	public final fun getCPP-ip6yS68 ()Ljava/lang/String;
-	public final fun getDART-ip6yS68 ()Ljava/lang/String;
-	public final fun getGO-ip6yS68 ()Ljava/lang/String;
-	public final fun getGRADLE-ip6yS68 ()Ljava/lang/String;
-	public final fun getGRADLE_KTS-ip6yS68 ()Ljava/lang/String;
-	public final fun getGROOVY-ip6yS68 ()Ljava/lang/String;
-	public final fun getJAVA-ip6yS68 ()Ljava/lang/String;
-	public final fun getJAVASCRIPT-ip6yS68 ()Ljava/lang/String;
-	public final fun getJSON-ip6yS68 ()Ljava/lang/String;
-	public final fun getKOTLIN-ip6yS68 ()Ljava/lang/String;
-	public final fun getMANIFEST-ip6yS68 ()Ljava/lang/String;
-	public final fun getPROGUARD-ip6yS68 ()Ljava/lang/String;
-	public final fun getPROPERTIES-ip6yS68 ()Ljava/lang/String;
-	public final fun getPROTO-ip6yS68 ()Ljava/lang/String;
-	public final fun getPYTHON-ip6yS68 ()Ljava/lang/String;
-	public final fun getREGEX-ip6yS68 ()Ljava/lang/String;
-	public final fun getRESOURCE-ip6yS68 ()Ljava/lang/String;
-	public final fun getRUST-ip6yS68 ()Ljava/lang/String;
-	public final fun getSHELL-ip6yS68 ()Ljava/lang/String;
-	public final fun getSQL-ip6yS68 ()Ljava/lang/String;
-	public final fun getSVG-ip6yS68 ()Ljava/lang/String;
-	public final fun getTEXT-ip6yS68 ()Ljava/lang/String;
-	public final fun getTOML-ip6yS68 ()Ljava/lang/String;
-	public final fun getTYPESCRIPT-ip6yS68 ()Ljava/lang/String;
-	public final fun getUNKNOWN-ip6yS68 ()Ljava/lang/String;
-	public final fun getVERSION_CATALOG-ip6yS68 ()Ljava/lang/String;
-	public final fun getXML-ip6yS68 ()Ljava/lang/String;
-	public final fun getYAML-ip6yS68 ()Ljava/lang/String;
-}
-
-public final class org/jetbrains/jewel/markdown/MimeTypeKt {
-	public static final fun isGradle-K9GpHcc (Ljava/lang/String;)Z
-	public static final fun isJava-K9GpHcc (Ljava/lang/String;)Z
-	public static final fun isKotlin-K9GpHcc (Ljava/lang/String;)Z
-	public static final fun isManifest-K9GpHcc (Ljava/lang/String;)Z
-	public static final fun isProto-K9GpHcc (Ljava/lang/String;)Z
-	public static final fun isRegex-K9GpHcc (Ljava/lang/String;)Z
-	public static final fun isSql-K9GpHcc (Ljava/lang/String;)Z
-	public static final fun isVersionCatalog-K9GpHcc (Ljava/lang/String;)Z
-	public static final fun isXml-K9GpHcc (Ljava/lang/String;)Z
 }
 
 public final class org/jetbrains/jewel/markdown/SemanticsKt {

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/MarkdownBlock.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/MarkdownBlock.kt
@@ -1,6 +1,7 @@
 package org.jetbrains.jewel.markdown
 
 import org.jetbrains.jewel.foundation.GenerateDataFunctions
+import org.jetbrains.jewel.foundation.code.MimeType
 
 public sealed interface MarkdownBlock {
     @GenerateDataFunctions

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/processing/MarkdownProcessor.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/processing/MarkdownProcessor.kt
@@ -21,11 +21,11 @@ import org.jetbrains.annotations.TestOnly
 import org.jetbrains.annotations.VisibleForTesting
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.foundation.InternalJewelApi
+import org.jetbrains.jewel.foundation.code.MimeType
 import org.jetbrains.jewel.markdown.InlineMarkdown
 import org.jetbrains.jewel.markdown.MarkdownBlock
 import org.jetbrains.jewel.markdown.MarkdownBlock.CodeBlock
 import org.jetbrains.jewel.markdown.MarkdownBlock.ListBlock
-import org.jetbrains.jewel.markdown.MimeType
 import org.jetbrains.jewel.markdown.extensions.MarkdownProcessorExtension
 import org.jetbrains.jewel.markdown.rendering.DefaultInlineMarkdownRenderer
 

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
@@ -18,6 +18,8 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.text.selection.DisableSelection
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -35,6 +37,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.LayoutDirection.Ltr
 import androidx.compose.ui.unit.dp
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
+import org.jetbrains.jewel.foundation.code.MimeType
+import org.jetbrains.jewel.foundation.code.highlighting.LocalCodeHighlighter
 import org.jetbrains.jewel.foundation.theme.LocalContentColor
 import org.jetbrains.jewel.markdown.MarkdownBlock
 import org.jetbrains.jewel.markdown.MarkdownBlock.BlockQuote
@@ -339,6 +343,7 @@ public open class DefaultMarkdownBlockRenderer(
 
     @Composable
     override fun render(block: FencedCodeBlock, styling: MarkdownStyling.Code.Fenced) {
+        val mimeType = block.mimeType ?: MimeType.Known.UNKNOWN
         MaybeScrollingContainer(
             isScrollable = styling.scrollsHorizontally,
             Modifier.background(styling.background, styling.shape)
@@ -346,9 +351,9 @@ public open class DefaultMarkdownBlockRenderer(
                 .then(if (styling.fillWidth) Modifier.fillMaxWidth() else Modifier),
         ) {
             Column(Modifier.padding(styling.padding)) {
-                if (block.mimeType != null && styling.infoPosition.verticalAlignment == Alignment.Top) {
+                if (styling.infoPosition.verticalAlignment == Alignment.Top) {
                     FencedBlockInfo(
-                        block.mimeType.displayName(),
+                        mimeType.displayName(),
                         styling.infoPosition.horizontalAlignment
                             ?: error("No horizontal alignment for position ${styling.infoPosition.name}"),
                         styling.infoTextStyle,
@@ -356,18 +361,11 @@ public open class DefaultMarkdownBlockRenderer(
                     )
                 }
 
-                Text(
-                    text = block.content,
-                    style = styling.editorTextStyle,
-                    color = styling.editorTextStyle.color.takeOrElse { LocalContentColor.current },
-                    modifier =
-                        Modifier.focusProperties { canFocus = false }
-                            .pointerHoverIcon(PointerIcon.Default, overrideDescendants = true),
-                )
+                Code(block.content, mimeType, styling)
 
-                if (block.mimeType != null && styling.infoPosition.verticalAlignment == Alignment.Bottom) {
+                if (styling.infoPosition.verticalAlignment == Alignment.Bottom) {
                     FencedBlockInfo(
-                        block.mimeType.displayName(),
+                        mimeType.displayName(),
                         styling.infoPosition.horizontalAlignment
                             ?: error("No horizontal alignment for position ${styling.infoPosition.name}"),
                         styling.infoTextStyle,
@@ -376,6 +374,25 @@ public open class DefaultMarkdownBlockRenderer(
                 }
             }
         }
+    }
+
+    @Composable
+    private fun Code(content: String, mimeType: MimeType, styling: MarkdownStyling.Code.Fenced) {
+        val annotatedCode by
+            LocalCodeHighlighter.current.highlight(content, mimeType).collectAsState(AnnotatedString(content))
+        CodeText(annotatedCode, styling)
+    }
+
+    @Composable
+    private fun CodeText(annotatedCode: AnnotatedString, styling: MarkdownStyling.Code.Fenced) {
+        Text(
+            text = annotatedCode,
+            style = styling.editorTextStyle,
+            color = styling.editorTextStyle.color.takeOrElse { LocalContentColor.current },
+            modifier =
+                Modifier.focusProperties { canFocus = false }
+                    .pointerHoverIcon(PointerIcon.Default, overrideDescendants = true),
+        )
     }
 
     @Composable

--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultMarkdownBlockRenderer.kt
@@ -388,7 +388,6 @@ public open class DefaultMarkdownBlockRenderer(
         Text(
             text = annotatedCode,
             style = styling.editorTextStyle,
-            color = styling.editorTextStyle.color.takeOrElse { LocalContentColor.current },
             modifier =
                 Modifier.focusProperties { canFocus = false }
                     .pointerHoverIcon(PointerIcon.Default, overrideDescendants = true),

--- a/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/MarkdownProcessorDocumentParsingTest.kt
+++ b/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/MarkdownProcessorDocumentParsingTest.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.jewel.markdown
 
+import org.jetbrains.jewel.foundation.code.MimeType
 import org.jetbrains.jewel.markdown.InlineMarkdown.Code
 import org.jetbrains.jewel.markdown.InlineMarkdown.Emphasis
 import org.jetbrains.jewel.markdown.InlineMarkdown.HardLineBreak

--- a/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/TestUtils.kt
+++ b/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/TestUtils.kt
@@ -1,5 +1,6 @@
 package org.jetbrains.jewel.markdown
 
+import org.jetbrains.jewel.foundation.code.MimeType
 import org.jetbrains.jewel.markdown.MarkdownBlock.BlockQuote
 import org.jetbrains.jewel.markdown.MarkdownBlock.CodeBlock
 import org.jetbrains.jewel.markdown.MarkdownBlock.CodeBlock.FencedCodeBlock

--- a/markdown/ide-laf-bridge-styling/api/ide-laf-bridge-styling.api
+++ b/markdown/ide-laf-bridge-styling/api/ide-laf-bridge-styling.api
@@ -4,6 +4,7 @@ public final class org/jetbrains/jewel/intui/markdown/bridge/BridgeMarkdownBlock
 }
 
 public final class org/jetbrains/jewel/intui/markdown/bridge/BridgeProvideMarkdownStylingKt {
+	public static final fun ProvideMarkdownStyling (Lcom/intellij/openapi/project/Project;Ljava/lang/String;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;Lorg/jetbrains/jewel/markdown/processing/MarkdownProcessor;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 	public static final fun ProvideMarkdownStyling (Ljava/lang/String;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;Lorg/jetbrains/jewel/markdown/processing/MarkdownProcessor;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Lorg/jetbrains/jewel/foundation/code/highlighting/CodeHighlighter;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
 

--- a/markdown/ide-laf-bridge-styling/api/ide-laf-bridge-styling.api
+++ b/markdown/ide-laf-bridge-styling/api/ide-laf-bridge-styling.api
@@ -4,7 +4,7 @@ public final class org/jetbrains/jewel/intui/markdown/bridge/BridgeMarkdownBlock
 }
 
 public final class org/jetbrains/jewel/intui/markdown/bridge/BridgeProvideMarkdownStylingKt {
-	public static final fun ProvideMarkdownStyling (Ljava/lang/String;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;Lorg/jetbrains/jewel/markdown/processing/MarkdownProcessor;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun ProvideMarkdownStyling (Ljava/lang/String;Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;Lorg/jetbrains/jewel/markdown/processing/MarkdownProcessor;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Lorg/jetbrains/jewel/foundation/code/highlighting/CodeHighlighter;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class org/jetbrains/jewel/intui/markdown/bridge/styling/BridgeMarkdownStylingKt {

--- a/markdown/ide-laf-bridge-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/bridge/BridgeProvideMarkdownStyling.kt
+++ b/markdown/ide-laf-bridge-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/bridge/BridgeProvideMarkdownStyling.kt
@@ -4,6 +4,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
+import org.jetbrains.jewel.foundation.code.highlighting.CodeHighlighter
+import org.jetbrains.jewel.foundation.code.highlighting.LocalCodeHighlighter
+import org.jetbrains.jewel.foundation.code.highlighting.NoOpCodeHighlighter
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.intui.markdown.bridge.styling.create
 import org.jetbrains.jewel.markdown.extensions.LocalMarkdownBlockRenderer
@@ -21,12 +24,14 @@ public fun ProvideMarkdownStyling(
     markdownProcessor: MarkdownProcessor = remember { MarkdownProcessor() },
     markdownBlockRenderer: MarkdownBlockRenderer =
         remember(markdownStyling) { MarkdownBlockRenderer.create(markdownStyling) },
+    codeHighlighter: CodeHighlighter = remember { NoOpCodeHighlighter },
     content: @Composable () -> Unit,
 ) {
     CompositionLocalProvider(
         LocalMarkdownStyling provides markdownStyling,
         LocalMarkdownProcessor provides markdownProcessor,
         LocalMarkdownBlockRenderer provides markdownBlockRenderer,
+        LocalCodeHighlighter provides codeHighlighter,
     ) {
         content()
     }

--- a/markdown/ide-laf-bridge-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/bridge/BridgeProvideMarkdownStyling.kt
+++ b/markdown/ide-laf-bridge-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/bridge/BridgeProvideMarkdownStyling.kt
@@ -3,6 +3,9 @@ package org.jetbrains.jewel.intui.markdown.bridge
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+import org.jetbrains.jewel.bridge.code.highlighting.CodeHighlighterFactory
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.foundation.code.highlighting.CodeHighlighter
 import org.jetbrains.jewel.foundation.code.highlighting.LocalCodeHighlighter
@@ -35,4 +38,27 @@ public fun ProvideMarkdownStyling(
     ) {
         content()
     }
+}
+
+@ExperimentalJewelApi
+@Composable
+public fun ProvideMarkdownStyling(
+    project: Project,
+    themeName: String = JewelTheme.name,
+    markdownStyling: MarkdownStyling = remember(themeName) { MarkdownStyling.create() },
+    markdownProcessor: MarkdownProcessor = remember { MarkdownProcessor() },
+    markdownBlockRenderer: MarkdownBlockRenderer =
+        remember(markdownStyling) { MarkdownBlockRenderer.create(markdownStyling) },
+    content: @Composable () -> Unit,
+) {
+    val codeHighlighter = remember { project.service<CodeHighlighterFactory>().createHighlighter() }
+
+    ProvideMarkdownStyling(
+        themeName = themeName,
+        markdownStyling = markdownStyling,
+        markdownProcessor = markdownProcessor,
+        markdownBlockRenderer = markdownBlockRenderer,
+        codeHighlighter = codeHighlighter,
+        content = content,
+    )
 }

--- a/markdown/int-ui-standalone-styling/api/int-ui-standalone-styling.api
+++ b/markdown/int-ui-standalone-styling/api/int-ui-standalone-styling.api
@@ -6,8 +6,8 @@ public final class org/jetbrains/jewel/intui/markdown/standalone/IntUiMarkdownBl
 }
 
 public final class org/jetbrains/jewel/intui/markdown/standalone/IntUiProvideMarkdownStylingKt {
-	public static final fun ProvideMarkdownStyling (Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Lorg/jetbrains/jewel/markdown/processing/MarkdownProcessor;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
-	public static final fun ProvideMarkdownStyling (ZLorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;Lorg/jetbrains/jewel/markdown/processing/MarkdownProcessor;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun ProvideMarkdownStyling (Lorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Lorg/jetbrains/jewel/foundation/code/highlighting/CodeHighlighter;Lorg/jetbrains/jewel/markdown/processing/MarkdownProcessor;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun ProvideMarkdownStyling (ZLorg/jetbrains/jewel/markdown/rendering/MarkdownStyling;Lorg/jetbrains/jewel/markdown/processing/MarkdownProcessor;Lorg/jetbrains/jewel/markdown/rendering/MarkdownBlockRenderer;Lorg/jetbrains/jewel/foundation/code/highlighting/CodeHighlighter;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class org/jetbrains/jewel/intui/markdown/standalone/styling/IntUiMarkdownStylingKt {

--- a/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/IntUiProvideMarkdownStyling.kt
+++ b/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/IntUiProvideMarkdownStyling.kt
@@ -4,6 +4,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
+import org.jetbrains.jewel.foundation.code.highlighting.CodeHighlighter
+import org.jetbrains.jewel.foundation.code.highlighting.LocalCodeHighlighter
+import org.jetbrains.jewel.foundation.code.highlighting.NoOpCodeHighlighter
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.intui.markdown.standalone.styling.dark
 import org.jetbrains.jewel.intui.markdown.standalone.styling.light
@@ -35,12 +38,14 @@ public fun ProvideMarkdownStyling(
                 MarkdownBlockRenderer.light(markdownStyling)
             }
         },
+    codeHighlighter: CodeHighlighter = remember { NoOpCodeHighlighter },
     content: @Composable () -> Unit,
 ) {
     CompositionLocalProvider(
         LocalMarkdownStyling provides markdownStyling,
         LocalMarkdownProcessor provides markdownProcessor,
         LocalMarkdownBlockRenderer provides markdownBlockRenderer,
+        LocalCodeHighlighter provides codeHighlighter,
     ) {
         content()
     }
@@ -51,6 +56,7 @@ public fun ProvideMarkdownStyling(
 public fun ProvideMarkdownStyling(
     markdownStyling: MarkdownStyling,
     markdownBlockRenderer: MarkdownBlockRenderer,
+    codeHighlighter: CodeHighlighter,
     markdownProcessor: MarkdownProcessor = remember { MarkdownProcessor() },
     content: @Composable () -> Unit,
 ) {
@@ -58,6 +64,7 @@ public fun ProvideMarkdownStyling(
         LocalMarkdownStyling provides markdownStyling,
         LocalMarkdownProcessor provides markdownProcessor,
         LocalMarkdownBlockRenderer provides markdownBlockRenderer,
+        LocalCodeHighlighter provides codeHighlighter,
     ) {
         content()
     }

--- a/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
+++ b/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
@@ -28,10 +28,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.intellij.ide.BrowserUtil
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
 import com.intellij.ui.JBColor
 import com.intellij.util.ui.JBUI
 import icons.IdeSampleIconKeys
 import org.jetbrains.jewel.bridge.LocalComponent
+import org.jetbrains.jewel.bridge.code.highlighting.LexerBasedCodeHighlighter
 import org.jetbrains.jewel.bridge.toComposeColor
 import org.jetbrains.jewel.foundation.actionSystem.provideData
 import org.jetbrains.jewel.foundation.lazy.tree.buildTree
@@ -71,7 +74,7 @@ import org.jetbrains.jewel.ui.painter.hints.Stroke
 import org.jetbrains.jewel.ui.theme.colorPalette
 
 @Composable
-internal fun ComponentShowcaseTab() {
+internal fun ComponentShowcaseTab(project: Project) {
     val bgColor by remember(JBColor.PanelBackground.rgb) { mutableStateOf(JBColor.PanelBackground.toComposeColor()) }
 
     VerticallyScrollableContainer {
@@ -84,7 +87,7 @@ internal fun ComponentShowcaseTab() {
             horizontalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             ColumnOne()
-            ColumnTwo()
+            ColumnTwo(project)
         }
     }
 }
@@ -272,9 +275,9 @@ private fun IconsShowcase() {
 }
 
 @Composable
-private fun RowScope.ColumnTwo() {
+private fun RowScope.ColumnTwo(project: Project) {
     Column(Modifier.trackActivation().weight(1f), verticalArrangement = Arrangement.spacedBy(16.dp)) {
-        MarkdownExample()
+        MarkdownExample(project)
 
         Divider(Orientation.Horizontal)
 
@@ -312,13 +315,13 @@ private fun RowScope.ColumnTwo() {
 }
 
 @Composable
-private fun MarkdownExample() {
+private fun MarkdownExample(project: Project) {
     var enabled by remember { mutableStateOf(true) }
     CheckboxRow("Enabled", enabled, { enabled = it })
 
     val contentColor = if (enabled) JewelTheme.globalColors.text.normal else JewelTheme.globalColors.text.disabled
     CompositionLocalProvider(LocalContentColor provides contentColor) {
-        ProvideMarkdownStyling {
+        ProvideMarkdownStyling(codeHighlighter = remember(project) { project.service<LexerBasedCodeHighlighter>() }) {
             Markdown(
                 """
                 |Hi! This is an example of **Markdown** rendering. We support the [CommonMark specs](https://commonmark.org/)

--- a/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
+++ b/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
@@ -28,13 +28,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.intellij.ide.BrowserUtil
-import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.ui.JBColor
 import com.intellij.util.ui.JBUI
 import icons.IdeSampleIconKeys
 import org.jetbrains.jewel.bridge.LocalComponent
-import org.jetbrains.jewel.bridge.code.highlighting.CodeHighlighterFactory
 import org.jetbrains.jewel.bridge.toComposeColor
 import org.jetbrains.jewel.foundation.actionSystem.provideData
 import org.jetbrains.jewel.foundation.lazy.tree.buildTree
@@ -321,9 +319,7 @@ private fun MarkdownExample(project: Project) {
 
     val contentColor = if (enabled) JewelTheme.globalColors.text.normal else JewelTheme.globalColors.text.disabled
     CompositionLocalProvider(LocalContentColor provides contentColor) {
-        ProvideMarkdownStyling(
-            codeHighlighter = remember(project) { project.service<CodeHighlighterFactory>().createHighlighter() }
-        ) {
+        ProvideMarkdownStyling(project) {
             Markdown(
                 """
                 |Hi! This is an example of **Markdown** rendering. We support the [CommonMark specs](https://commonmark.org/)

--- a/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
+++ b/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
@@ -34,7 +34,7 @@ import com.intellij.ui.JBColor
 import com.intellij.util.ui.JBUI
 import icons.IdeSampleIconKeys
 import org.jetbrains.jewel.bridge.LocalComponent
-import org.jetbrains.jewel.bridge.code.highlighting.LexerBasedCodeHighlighter
+import org.jetbrains.jewel.bridge.code.highlighting.CodeHighlighterFactory
 import org.jetbrains.jewel.bridge.toComposeColor
 import org.jetbrains.jewel.foundation.actionSystem.provideData
 import org.jetbrains.jewel.foundation.lazy.tree.buildTree
@@ -321,7 +321,9 @@ private fun MarkdownExample(project: Project) {
 
     val contentColor = if (enabled) JewelTheme.globalColors.text.normal else JewelTheme.globalColors.text.disabled
     CompositionLocalProvider(LocalContentColor provides contentColor) {
-        ProvideMarkdownStyling(codeHighlighter = remember(project) { project.service<LexerBasedCodeHighlighter>() }) {
+        ProvideMarkdownStyling(
+            codeHighlighter = remember(project) { project.service<CodeHighlighterFactory>().createHighlighter() }
+        ) {
             Markdown(
                 """
                 |Hi! This is an example of **Markdown** rendering. We support the [CommonMark specs](https://commonmark.org/)

--- a/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/JewelDemoToolWindowFactory.kt
+++ b/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/JewelDemoToolWindowFactory.kt
@@ -20,7 +20,7 @@ import org.jetbrains.jewel.samples.ideplugin.releasessample.ReleasesSampleCompos
 @ExperimentalCoroutinesApi
 internal class JewelDemoToolWindowFactory : ToolWindowFactory, DumbAware {
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
-        toolWindow.addComposeTab("Components") { ComponentShowcaseTab() }
+        toolWindow.addComposeTab("Components") { ComponentShowcaseTab(project) }
 
         toolWindow.addComposeTab("Releases Demo") { ReleasesSampleCompose(project) }
 

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/markdown/MarkdownPreview.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/markdown/MarkdownPreview.kt
@@ -16,6 +16,7 @@ import java.awt.Desktop
 import java.net.URI
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.jetbrains.jewel.foundation.code.highlighting.NoOpCodeHighlighter
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.intui.markdown.standalone.ProvideMarkdownStyling
 import org.jetbrains.jewel.intui.markdown.standalone.dark
@@ -76,7 +77,7 @@ internal fun MarkdownPreview(modifier: Modifier = Modifier, rawMarkdown: CharSeq
     // Using the values from the GitHub rendering to ensure contrast
     val background = remember(isDark) { if (isDark) Color(0xff0d1117) else Color.White }
 
-    ProvideMarkdownStyling(markdownStyling, blockRenderer) {
+    ProvideMarkdownStyling(markdownStyling, blockRenderer, NoOpCodeHighlighter) {
         val lazyListState = rememberLazyListState()
         VerticallyScrollableContainer(lazyListState, modifier.background(background)) {
             LazyMarkdown(


### PR DESCRIPTION
I decided to go with the `Flow` in highlighter API so that implementations might be able to react to their internal alterations of a color scheme and provide new styled strings accordingly. Another approach that was in my mind is `highlight` returning a single `AnnotatedString` and a separate flow in the API acting as a trigger to re-`highlight` the code. It would make implementations of `highlight` simpler but at the cost of leaking into the foundation (and not every implementation would need that). If you know how it can be done better with compose, please tell, I'm still new to this and would love to learn good practices :)

For standalone, there are no working highlighters beside no-op one that just wraps a string without applying any styles. 

Indented code blocks aren't supported as well, mainly because they aren't supported in JCEF 🙂 but also because it requires  using some language guesser (and it seems a point for a futher discussion).