### PR TITLE
Update Compose to 1.7.0-beta02

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 commonmark = "0.22.0"
-composeDesktop = "1.7.0-beta01"
+composeDesktop = "1.7.0-beta02"
 detekt = "1.23.6"
 dokka = "1.9.20"
 idea = "2024.2.1"

--- a/samples/standalone/build.gradle.kts
+++ b/samples/standalone/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation(projects.markdown.extension.gfmAlerts)
     implementation(projects.markdown.extension.autolink)
     implementation(compose.desktop.currentOs) { exclude(group = "org.jetbrains.compose.material") }
+    implementation(compose.components.resources)
     implementation(libs.intellijPlatform.icons)
 }
 

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/Main.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/Main.kt
@@ -7,12 +7,11 @@ import androidx.compose.ui.input.key.KeyEventType
 import androidx.compose.ui.input.key.isAltPressed
 import androidx.compose.ui.input.key.key
 import androidx.compose.ui.input.key.type
-import androidx.compose.ui.res.ResourceLoader
-import androidx.compose.ui.res.loadSvgPainter
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.window.application
-import java.io.InputStream
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.decodeToSvgPainter
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.foundation.util.JewelLogger
 import org.jetbrains.jewel.intui.standalone.Inter
@@ -113,5 +112,13 @@ private fun processKeyShortcuts(keyEvent: KeyEvent, onNavigateTo: (String) -> Un
     }
 }
 
-private fun svgResource(resourcePath: String, loader: ResourceLoader = ResourceLoader.Default): Painter =
-    loader.load(resourcePath).use { stream: InputStream -> loadSvgPainter(stream, Density(1f)) }
+@Suppress("SameParameterValue")
+@OptIn(ExperimentalResourceApi::class)
+private fun svgResource(resourcePath: String): Painter =
+    checkNotNull(ResourceLoader.javaClass.classLoader.getResourceAsStream(resourcePath)) {
+            "Could not load resource $resourcePath: it does not exist or can't be read."
+        }
+        .readAllBytes()
+        .decodeToSvgPainter(Density(1f))
+
+private object ResourceLoader

--- a/ui/api/ui.api
+++ b/ui/api/ui.api
@@ -370,7 +370,7 @@ public final class org/jetbrains/jewel/ui/component/IconKt {
 	public static final fun Icon-ww6aTOc (Landroidx/compose/ui/graphics/ImageBitmap;Ljava/lang/String;Landroidx/compose/ui/Modifier;JLandroidx/compose/runtime/Composer;II)V
 	public static final fun Icon-ww6aTOc (Landroidx/compose/ui/graphics/painter/Painter;Ljava/lang/String;Landroidx/compose/ui/Modifier;JLandroidx/compose/runtime/Composer;II)V
 	public static final fun Icon-ww6aTOc (Landroidx/compose/ui/graphics/vector/ImageVector;Ljava/lang/String;Landroidx/compose/ui/Modifier;JLandroidx/compose/runtime/Composer;II)V
-	public static final fun painterResource (Ljava/lang/String;Landroidx/compose/ui/res/ResourceLoader;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/graphics/painter/Painter;
+	public static final fun painterResource (Ljava/lang/String;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/graphics/painter/Painter;
 }
 
 public final class org/jetbrains/jewel/ui/component/InputFieldState : org/jetbrains/jewel/foundation/state/FocusableComponentState {

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -16,6 +16,7 @@ private val composeVersion
 
 dependencies {
     api(projects.foundation)
+    implementation(compose.components.resources)
     iconGeneration(libs.intellijPlatform.util.ui)
     iconGeneration(libs.intellijPlatform.icons)
     testImplementation(compose.desktop.uiTestJUnit4)

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/CircularProgressIndicator.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/CircularProgressIndicator.kt
@@ -16,12 +16,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.takeOrElse
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.res.loadSvgPainter
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.decodeToSvgPainter
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.styling.CircularProgressStyle
 import org.jetbrains.jewel.ui.theme.circularProgressStyle
@@ -57,6 +58,7 @@ public fun CircularProgressIndicatorBig(
     )
 }
 
+@OptIn(ExperimentalResourceApi::class)
 @Composable
 private fun CircularProgressIndicatorImpl(
     modifier: Modifier = Modifier,
@@ -73,7 +75,7 @@ private fun CircularProgressIndicatorImpl(
             value =
                 withContext(dispatcher) {
                     frameRetriever(style.color.takeOrElse { defaultColor }).map {
-                        loadSvgPainter(it.byteInputStream(), density)
+                        it.toByteArray().decodeToSvgPainter(density)
                     }
                 }
         }


### PR DESCRIPTION
This version of Compose deprecates the resource loading APIs we've been using, and brutally removes ResourceLoader, so we need to migrate to the new (experimental) CMP Resources API.

Things seem to work fine after upgrading and migrating. Would appreciate further testing on platforms other than macOS before merging.