### PR TITLE
Fixed Text Component order for color

### DIFF
--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Text.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Text.kt
@@ -79,7 +79,7 @@ public fun Text(
     onTextLayout: (TextLayoutResult) -> Unit = {},
     style: TextStyle = JewelTheme.defaultTextStyle,
 ) {
-    val textColor = color.takeOrElse { LocalContentColor.current.takeOrElse { style.color } }
+    val textColor = color.takeOrElse { style.color.takeOrElse { LocalContentColor.current } }
 
     val mergedStyle =
         style.merge(

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Tooltip.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Tooltip.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.window.PopupPositionProviderAtPosition
 import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.foundation.theme.LocalContentColor
+import org.jetbrains.jewel.foundation.theme.LocalTextStyle
 import org.jetbrains.jewel.foundation.theme.OverrideDarkMode
 import org.jetbrains.jewel.ui.component.styling.TooltipStyle
 import org.jetbrains.jewel.ui.theme.tooltipStyle
@@ -39,7 +40,10 @@ public fun Tooltip(
 ) {
     TooltipArea(
         tooltip = {
-            CompositionLocalProvider(LocalContentColor provides style.colors.content) {
+            CompositionLocalProvider(
+                LocalContentColor provides style.colors.content,
+                LocalTextStyle provides LocalTextStyle.current.copy(color = style.colors.content),
+            ) {
                 Box(
                     modifier =
                         Modifier.shadow(


### PR DESCRIPTION
Addressing https://github.com/JetBrains/jewel/issues/591

Reverts Text component logic for getting the color to one that matches Material, which is one that respects the caller's  passed in parameters first (color, then the color in the textStyle), and then falls back to localContentColor.

The code originally used what I propose here, but was later swapped to solve a bug with Tooltip + LightTheme: https://github.com/JetBrains/jewel/pull/180/files#r1361761781, but I believe this is the correct fix.

I tested that tooltip still works on ide + standalone, on light and dark