### PR TITLE
Remove underline on unhovered Links

### DIFF
--- a/markdown/ide-laf-bridge-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/bridge/styling/BridgeMarkdownStyling.kt
+++ b/markdown/ide-laf-bridge-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/bridge/styling/BridgeMarkdownStyling.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.graphics.PathEffect
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
@@ -339,19 +340,19 @@ public fun InlinesStyling.Companion.create(
         defaultEditorTextStyle
             .copy(fontSize = textStyle.fontSize * .85, background = inlineCodeBackgroundColor)
             .toSpanStyle(),
-    link: SpanStyle =
-        textStyle
-            .copy(
-                color = JBUI.CurrentTheme.Link.Foreground.ENABLED.toComposeColor(),
-                textDecoration = TextDecoration.Underline,
-            )
-            .toSpanStyle(),
+    link: SpanStyle = textStyle.copy(color = JBUI.CurrentTheme.Link.Foreground.ENABLED.toComposeColor()).toSpanStyle(),
     linkDisabled: SpanStyle = link.copy(color = JBUI.CurrentTheme.Link.Foreground.DISABLED.toComposeColor()),
-    linkHovered: SpanStyle = link.copy(color = JBUI.CurrentTheme.Link.Foreground.HOVERED.toComposeColor()),
+    linkHovered: SpanStyle =
+        link.copy(
+            color = JBUI.CurrentTheme.Link.Foreground.HOVERED.toComposeColor(),
+            textDecoration = TextDecoration.Underline,
+        ),
     linkFocused: SpanStyle =
         link.copy(
+            drawStyle = Stroke(width = 2f),
             color = JBUI.CurrentTheme.Link.Foreground.ENABLED.toComposeColor(),
             background = JBUI.CurrentTheme.ActionButton.hoverBackground().toComposeColor(),
+            textDecoration = TextDecoration.Underline,
         ),
     linkPressed: SpanStyle =
         link.copy(

--- a/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/styling/IntUiMarkdownStyling.kt
+++ b/markdown/int-ui-standalone-styling/src/main/kotlin/org/jetbrains/jewel/intui/markdown/standalone/styling/IntUiMarkdownStyling.kt
@@ -597,11 +597,10 @@ public fun InlinesStyling.Companion.light(
         defaultEditorTextStyle
             .copy(fontSize = textStyle.fontSize * .85, background = inlineCodeBackgroundColorLight)
             .toSpanStyle(),
-    link: SpanStyle =
-        textStyle.copy(color = IntUiLightTheme.colors.blue(2), textDecoration = TextDecoration.Underline).toSpanStyle(),
+    link: SpanStyle = textStyle.copy(color = IntUiLightTheme.colors.blue(2)).toSpanStyle(),
     linkDisabled: SpanStyle = link.copy(color = IntUiLightTheme.colors.gray(8)),
-    linkHovered: SpanStyle = link,
-    linkFocused: SpanStyle = link.copy(background = Color(0x12000000)),
+    linkHovered: SpanStyle = link.copy(textDecoration = TextDecoration.Underline),
+    linkFocused: SpanStyle = link.copy(background = Color(0x12000000), textDecoration = TextDecoration.Underline),
     linkPressed: SpanStyle = link.copy(background = Color(0x1D000000)),
     linkVisited: SpanStyle = link,
     emphasis: SpanStyle = textStyle.copy(fontStyle = FontStyle.Italic).toSpanStyle(),
@@ -630,11 +629,10 @@ public fun InlinesStyling.Companion.dark(
         defaultEditorTextStyle
             .copy(fontSize = textStyle.fontSize * .85, background = inlineCodeBackgroundColorDark)
             .toSpanStyle(),
-    link: SpanStyle =
-        textStyle.copy(color = IntUiDarkTheme.colors.blue(9), textDecoration = TextDecoration.Underline).toSpanStyle(),
+    link: SpanStyle = textStyle.copy(color = IntUiDarkTheme.colors.blue(9)).toSpanStyle(),
     linkDisabled: SpanStyle = link.copy(color = IntUiDarkTheme.colors.gray(8)),
-    linkHovered: SpanStyle = link,
-    linkFocused: SpanStyle = link.copy(background = Color(0x16FFFFFF)),
+    linkHovered: SpanStyle = link.copy(textDecoration = TextDecoration.Underline),
+    linkFocused: SpanStyle = link.copy(background = Color(0x16FFFFFF), textDecoration = TextDecoration.Underline),
     linkPressed: SpanStyle = link.copy(background = Color(0x26FFFFFF)),
     linkVisited: SpanStyle = link,
     emphasis: SpanStyle = textStyle.copy(fontStyle = FontStyle.Italic).toSpanStyle(),


### PR DESCRIPTION
IJ's default markdown does *not* show underline on links when they are not hovered, it only shows them on hovered.  This matches that. 

Since we currently don't support the more advance rounded border span for Focused state, I also included the underline for Focus.


https://github.com/user-attachments/assets/66c188b8-4c7c-4f1b-afbf-55729c411e06


https://github.com/user-attachments/assets/d974f118-5897-4390-b49f-06836d183294


cc: @rock3r 

