### PR TITLE
Changed grey to gray in readPaletteColor

### DIFF
--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/BridgeThemeColorPalette.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/BridgeThemeColorPalette.kt
@@ -13,7 +13,7 @@ public val ThemeColorPalette.windowsPopupBorder: Color?
     get() = lookup("windowsPopupBorder")
 
 public fun ThemeColorPalette.Companion.readFromLaF(): ThemeColorPalette {
-    val gray = readPaletteColors("Grey")
+    val gray = readPaletteColors("Gray")
     val blue = readPaletteColors("Blue")
     val green = readPaletteColors("Green")
     val red = readPaletteColors("Red")


### PR DESCRIPTION
It seems that from 242 and onward, the system color name for the gray palette changed from `grey` to `gray`. We had previously changed the name of the variables but not the name of the value.

`Grey` works fine on 233 and 241 though, so I think this needs a new release to be setup so that the change only affects 242+

This fixes https://github.com/JetBrains/jewel/issues/603