### PR TITLE
Fix z-order for text field/area placeholder

### DIFF
--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TextArea.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TextArea.kt
@@ -339,11 +339,11 @@ private fun TextAreaDecorationBox(
         val height = calculateHeight(textAreaPlaceable, placeholderPlaceable, incomingConstraints)
 
         layout(width, height) {
+            // Placed similar to the input text below
+            placeholderPlaceable?.placeRelative(0, 0)
+
             // Placed top-start
             textAreaPlaceable.placeRelative(0, 0)
-
-            // Placed similar to the input text above
-            placeholderPlaceable?.placeRelative(0, 0)
         }
     }
 }

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TextField.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TextField.kt
@@ -325,16 +325,16 @@ private fun Placeable.PlacementScope.place(
         Alignment.CenterVertically.align(trailingPlaceable.height, height),
     )
 
+    // placed similar to the input text below
+    placeholderPlaceable?.placeRelative(
+        leadingPlaceable?.width ?: 0,
+        Alignment.CenterVertically.align(placeholderPlaceable.height, height),
+    )
+
     // placed center vertically
     textFieldPlaceable.placeRelative(
         leadingPlaceable?.width ?: 0,
         Alignment.CenterVertically.align(textFieldPlaceable.height, height),
-    )
-
-    // placed similar to the input text above
-    placeholderPlaceable?.placeRelative(
-        leadingPlaceable?.width ?: 0,
-        Alignment.CenterVertically.align(placeholderPlaceable.height, height),
     )
 }
 


### PR DESCRIPTION
This changes the order in which the placeholder and actual text field are laid out in the TextField and TextArea code. Since the two have the same zIndex (the default value, 0f) their placement order is reflected in the drawing order: the last placed is drawn last, on top of the rest.

This fixes a minor cosmetic issue, where the placeholder would be drawn on top of the cursor when the TextArea/TextField is empty.

Fixes #610 