### PR TITLE
Fix TextArea placeholder layout

### DIFF
--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TextArea.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TextArea.kt
@@ -153,10 +153,11 @@ private fun TextAreaDecorator(
                 Box(Modifier.padding(contentPadding)) { innerTextField() }
             }
         },
-        placeholderTextColor = style.colors.placeholder,
-        placeholder = if (state.text.isEmpty()) placeholder else null,
         textStyle = textStyle,
         modifier = decorationBoxModifier.defaultMinSize(minWidth = minSize.width, minHeight = minSize.height),
+        placeholder = if (state.text.isEmpty()) placeholder else null,
+        placeholderTextColor = style.colors.placeholder,
+        placeholderModifier = Modifier.padding(contentPadding).padding(style.metrics.borderWidth),
     )
 }
 
@@ -268,6 +269,8 @@ public fun TextArea(
     decorationBoxModifier: Modifier = Modifier,
 ) {
     val minSize = style.metrics.minSize
+    val contentPadding = style.metrics.contentPadding
+
     @Suppress("DEPRECATION")
     InputField(
         value = value,
@@ -289,10 +292,11 @@ public fun TextArea(
     ) { innerTextField, _ ->
         TextAreaDecorationBox(
             innerTextField = innerTextField,
-            placeholderTextColor = style.colors.placeholder,
-            placeholder = if (value.text.isEmpty()) placeholder else null,
             textStyle = textStyle,
             modifier = decorationBoxModifier,
+            placeholder = if (value.text.isEmpty()) placeholder else null,
+            placeholderTextColor = style.colors.placeholder,
+            placeholderModifier = Modifier.padding(contentPadding).padding(style.metrics.borderWidth),
         )
     }
 }
@@ -302,13 +306,14 @@ private fun TextAreaDecorationBox(
     innerTextField: @Composable () -> Unit,
     textStyle: TextStyle,
     modifier: Modifier,
-    placeholderTextColor: Color,
     placeholder: @Composable (() -> Unit)?,
+    placeholderTextColor: Color,
+    placeholderModifier: Modifier,
 ) {
     Layout(
         content = {
             if (placeholder != null) {
-                Box(modifier = Modifier.layoutId(PLACEHOLDER_ID), contentAlignment = Alignment.TopStart) {
+                Box(modifier = placeholderModifier.layoutId(PLACEHOLDER_ID), contentAlignment = Alignment.TopStart) {
                     CompositionLocalProvider(
                         LocalTextStyle provides textStyle.copy(color = placeholderTextColor),
                         LocalContentColor provides placeholderTextColor,

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TextArea.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TextArea.kt
@@ -339,11 +339,11 @@ private fun TextAreaDecorationBox(
         val height = calculateHeight(textAreaPlaceable, placeholderPlaceable, incomingConstraints)
 
         layout(width, height) {
+            // Placed similar to the input text below
+            placeholderPlaceable?.placeRelative(0, 0)
+
             // Placed top-start
             textAreaPlaceable.placeRelative(0, 0)
-
-            // Placed similar to the input text above
-            placeholderPlaceable?.placeRelative(0, 0)
         }
     }
 }

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TextField.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/TextField.kt
@@ -325,16 +325,16 @@ private fun Placeable.PlacementScope.place(
         Alignment.CenterVertically.align(trailingPlaceable.height, height),
     )
 
+    // placed similar to the input text below
+    placeholderPlaceable?.placeRelative(
+        leadingPlaceable?.width ?: 0,
+        Alignment.CenterVertically.align(placeholderPlaceable.height, height),
+    )
+
     // placed center vertically
     textFieldPlaceable.placeRelative(
         leadingPlaceable?.width ?: 0,
         Alignment.CenterVertically.align(textFieldPlaceable.height, height),
-    )
-
-    // placed similar to the input text above
-    placeholderPlaceable?.placeRelative(
-        leadingPlaceable?.width ?: 0,
-        Alignment.CenterVertically.align(placeholderPlaceable.height, height),
     )
 }
 


### PR DESCRIPTION
When we added scrollbars and tweaked the TextArea paddings, we did not do the same for the placeholder. As a result, the placeholders were laid out incorrectly, up against the component's border. This fixes that issue by passing down the modifier to the TextArea decoration box.

Fixes #613

> [!IMPORTANT]
> Please merge #615 first.