### PR TITLE
Refactor KeyActions and BasicSelectableLazyColumn

### DIFF
--- a/foundation/api/foundation.api
+++ b/foundation/api/foundation.api
@@ -580,10 +580,11 @@ public class org/jetbrains/jewel/foundation/lazy/tree/DefaultTreeViewOnKeyEvent 
 	public fun onSelectPreviousItem (Ljava/util/List;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;)V
 }
 
-public final class org/jetbrains/jewel/foundation/lazy/tree/DefaultTreeViewPointerEventAction : org/jetbrains/jewel/foundation/lazy/tree/DefaultSelectableLazyColumnEventAction {
+public class org/jetbrains/jewel/foundation/lazy/tree/DefaultTreeViewPointerEventAction : org/jetbrains/jewel/foundation/lazy/tree/DefaultSelectableLazyColumnEventAction {
 	public static final field $stable I
 	public fun <init> (Lorg/jetbrains/jewel/foundation/lazy/tree/TreeState;)V
 	public fun handlePointerEventPress (Landroidx/compose/ui/input/pointer/PointerEvent;Lorg/jetbrains/jewel/foundation/lazy/SelectableColumnKeybindings;Lorg/jetbrains/jewel/foundation/lazy/SelectableLazyListState;Lorg/jetbrains/jewel/foundation/lazy/SelectionMode;Ljava/util/List;Ljava/lang/Object;)V
+	public final fun notifyItemClicked (Lorg/jetbrains/jewel/foundation/lazy/tree/Tree$Element;Lkotlinx/coroutines/CoroutineScope;JLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 }
 
 public abstract interface class org/jetbrains/jewel/foundation/lazy/tree/KeyActions {

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/tree/KeyActions.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/tree/KeyActions.kt
@@ -8,6 +8,7 @@ import androidx.compose.ui.input.pointer.isCtrlPressed
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import org.jetbrains.jewel.foundation.InternalJewelApi
 import org.jetbrains.jewel.foundation.lazy.DefaultMacOsSelectableColumnKeybindings
 import org.jetbrains.jewel.foundation.lazy.DefaultSelectableColumnKeybindings
 import org.jetbrains.jewel.foundation.lazy.DefaultSelectableOnKeyEvent
@@ -141,7 +142,7 @@ public open class DefaultSelectableLazyColumnEventAction : PointerEventActions {
     }
 }
 
-public class DefaultTreeViewPointerEventAction(private val treeState: TreeState) :
+public open class DefaultTreeViewPointerEventAction(private val treeState: TreeState) :
     DefaultSelectableLazyColumnEventAction() {
     override fun handlePointerEventPress(
         pointerEvent: PointerEvent,
@@ -176,7 +177,8 @@ public class DefaultTreeViewPointerEventAction(private val treeState: TreeState)
     // for item click that lose focus and fail to match if a operation is a double-click
     private var elementClickedTmpHolder: Any? = null
 
-    internal fun <T> notifyItemClicked(
+    @InternalJewelApi
+    public fun <T> notifyItemClicked(
         item: Tree.Element<T>,
         scope: CoroutineScope,
         doubleClickTimeDelayMillis: Long,


### PR DESCRIPTION
Make DefaultTreeViewPointerEventAction open and annotate notifyItemClicked with @InternalJewelApi. Additionally, adjust the key event handling in BasicSelectableLazyColumn to ensure proper return values, enhancing interaction behavior.