### PR TITLE
Fix keyboard event handling in BasicSelectableLazyColumn

### DIFF
--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/BasicSelectableLazyColumn.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/BasicSelectableLazyColumn.kt
@@ -99,8 +99,9 @@ public fun BasicSelectableLazyColumn(
                         if (actionHandled) {
                             scope.launch { state.lastActiveItemIndex?.let { state.scrollToItem(it) } }
                         }
+                        return@onPreviewKeyEvent actionHandled
                     }
-                    true
+                    false
                 },
         state = state.lazyListState,
         contentPadding = contentPadding,


### PR DESCRIPTION
Previously, the keyboard event handling logic always returned true, incorrectly intercepting events. This change ensures that actionHandled is returned, allowing correct event propagation when necessary.