### PR TITLE
Add Pointer Release Handler to PointerEventActions

### DIFF
--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/BasicSelectableLazyColumn.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/BasicSelectableLazyColumn.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -234,6 +235,17 @@ private fun Modifier.selectable(
                             keybindings = keybindings,
                             selectableLazyListState = selectableState,
                             selectionMode = selectionMode,
+                            allKeys = allKeys,
+                            key = itemKey,
+                        )
+                    }
+                    PointerEventType.Release -> {
+                        requester?.requestFocus()
+                        actionHandler.handlePointerEventRelease(
+                            pointerEvent = event,
+                            keybindings = keybindings,
+                            selectionMode = selectionMode,
+                            selectableLazyListState = selectableState,
                             allKeys = allKeys,
                             key = itemKey,
                         )

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/tree/KeyActions.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/lazy/tree/KeyActions.kt
@@ -54,6 +54,15 @@ public interface PointerEventActions {
         state: SelectableLazyListState,
         selectionMode: SelectionMode,
     )
+
+    public fun handlePointerEventRelease(
+        pointerEvent: PointerEvent,
+        keybindings: SelectableColumnKeybindings,
+        selectableLazyListState: SelectableLazyListState,
+        selectionMode: SelectionMode,
+        allKeys: List<SelectableLazyListKey>,
+        key: Any,
+    )
 }
 
 public open class DefaultSelectableLazyColumnEventAction : PointerEventActions {
@@ -86,6 +95,17 @@ public open class DefaultSelectableLazyColumnEventAction : PointerEventActions {
                 }
             }
         }
+    }
+
+    override fun handlePointerEventRelease(
+        pointerEvent: PointerEvent,
+        keybindings: SelectableColumnKeybindings,
+        selectableLazyListState: SelectableLazyListState,
+        selectionMode: SelectionMode,
+        allKeys: List<SelectableLazyListKey>,
+        key: Any,
+    ) {
+        // No Default Action. Can be used by consumers to handle release events.
     }
 
     override fun toggleKeySelection(

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/component/ChipsAndTree.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/component/ChipsAndTree.kt
@@ -195,4 +195,16 @@ fun TreeSample(modifier: Modifier = Modifier) {
             Box(Modifier.fillMaxWidth()) { Text(element.data, Modifier.padding(2.dp)) }
         }
     }
+
+    Text("Tree with custom click handler")
+    Box(modifier.border(1.dp, borderColor, RoundedCornerShape(2.dp))) {
+        CustomLazyTree(
+            tree = tree,
+            modifier = Modifier.size(200.dp, 200.dp),
+            onElementClick = {},
+            onElementDoubleClick = {},
+        ) { element ->
+            Box(Modifier.fillMaxWidth()) { Text(element.data, Modifier.padding(2.dp)) }
+        }
+    }
 }

--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/component/CustomLazyTree.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/component/CustomLazyTree.kt
@@ -1,0 +1,127 @@
+package org.jetbrains.jewel.samples.standalone.view.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.takeOrElse
+import androidx.compose.ui.input.pointer.PointerEvent
+import androidx.compose.ui.input.pointer.isPrimaryPressed
+import org.jetbrains.jewel.foundation.ExperimentalJewelApi
+import org.jetbrains.jewel.foundation.lazy.SelectableColumnKeybindings
+import org.jetbrains.jewel.foundation.lazy.SelectableLazyItemScope
+import org.jetbrains.jewel.foundation.lazy.SelectableLazyListKey
+import org.jetbrains.jewel.foundation.lazy.SelectableLazyListState
+import org.jetbrains.jewel.foundation.lazy.SelectionMode
+import org.jetbrains.jewel.foundation.lazy.tree.BasicLazyTree
+import org.jetbrains.jewel.foundation.lazy.tree.DefaultTreeViewKeyActions
+import org.jetbrains.jewel.foundation.lazy.tree.DefaultTreeViewPointerEventAction
+import org.jetbrains.jewel.foundation.lazy.tree.KeyActions
+import org.jetbrains.jewel.foundation.lazy.tree.PointerEventActions
+import org.jetbrains.jewel.foundation.lazy.tree.Tree
+import org.jetbrains.jewel.foundation.lazy.tree.TreeElementState
+import org.jetbrains.jewel.foundation.lazy.tree.TreeState
+import org.jetbrains.jewel.foundation.lazy.tree.rememberTreeState
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.foundation.theme.LocalContentColor
+import org.jetbrains.jewel.ui.component.Icon
+import org.jetbrains.jewel.ui.component.styling.LazyTreeStyle
+import org.jetbrains.jewel.ui.theme.treeStyle
+
+@ExperimentalJewelApi
+@Composable
+fun <T> CustomLazyTree(
+    tree: Tree<T>,
+    modifier: Modifier = Modifier,
+    onElementClick: (Tree.Element<T>) -> Unit = {},
+    treeState: TreeState = rememberTreeState(),
+    onElementDoubleClick: (Tree.Element<T>) -> Unit = {},
+    onSelectionChange: (List<Tree.Element<T>>) -> Unit = {},
+    keyActions: KeyActions = DefaultTreeViewKeyActions(treeState),
+    style: LazyTreeStyle = JewelTheme.treeStyle,
+    nodeContent: @Composable (SelectableLazyItemScope.(Tree.Element<T>) -> Unit),
+) {
+    val colors = style.colors
+    val metrics = style.metrics
+
+    val pointerEventScopedActions: PointerEventActions = remember { CustomTreeViewPointerEventAction(treeState) }
+
+    BasicLazyTree(
+        tree = tree,
+        onElementClick = onElementClick,
+        elementBackgroundFocused = colors.elementBackgroundFocused,
+        elementBackgroundSelectedFocused = colors.elementBackgroundSelectedFocused,
+        elementBackgroundSelected = colors.elementBackgroundSelected,
+        indentSize = metrics.indentSize,
+        elementBackgroundCornerSize = metrics.elementBackgroundCornerSize,
+        elementPadding = metrics.elementPadding,
+        elementContentPadding = metrics.elementContentPadding,
+        elementMinHeight = metrics.elementMinHeight,
+        chevronContentGap = metrics.chevronContentGap,
+        treeState = treeState,
+        modifier = modifier,
+        onElementDoubleClick = onElementDoubleClick,
+        pointerEventScopedActions = pointerEventScopedActions,
+        onSelectionChange = onSelectionChange,
+        keyActions = keyActions,
+        chevronContent = { elementState ->
+            val painterProvider = style.icons.chevron(elementState.isExpanded, elementState.isSelected)
+            Icon(key = painterProvider, contentDescription = null)
+        },
+    ) {
+        val resolvedContentColor =
+            style.colors
+                .contentFor(TreeElementState.of(focused = isActive, selected = isSelected, expanded = false))
+                .value
+                .takeOrElse { LocalContentColor.current }
+
+        CompositionLocalProvider(LocalContentColor provides resolvedContentColor) { nodeContent(it) }
+    }
+}
+
+// Example detecting long press vs short press to handle pointer events separately. Disable
+// selection here for both primary button presses, and long press (drag) use-cases
+class CustomTreeViewPointerEventAction(treeState: TreeState) : DefaultTreeViewPointerEventAction(treeState) {
+    private var pressStartTime: Long = 0
+    private val longPressThreshold: Long = 500L
+    private var isPrimary: Boolean = false
+
+    override fun handlePointerEventPress(
+        pointerEvent: PointerEvent,
+        keybindings: SelectableColumnKeybindings,
+        selectableLazyListState: SelectableLazyListState,
+        selectionMode: SelectionMode,
+        allKeys: List<SelectableLazyListKey>,
+        key: Any,
+    ) {
+        pressStartTime = System.currentTimeMillis()
+        isPrimary = pointerEvent.buttons.isPrimaryPressed
+    }
+
+    override fun handlePointerEventRelease(
+        pointerEvent: PointerEvent,
+        keybindings: SelectableColumnKeybindings,
+        selectableLazyListState: SelectableLazyListState,
+        selectionMode: SelectionMode,
+        allKeys: List<SelectableLazyListKey>,
+        key: Any,
+    ) {
+        val pressDuration = System.currentTimeMillis() - pressStartTime
+
+        if (pressDuration >= longPressThreshold) {
+            // Handle long press if needed, default action do nothing.
+        } else {
+            // Handle short press
+            if (isPrimary) {
+                super.handlePointerEventPress(
+                    pointerEvent,
+                    keybindings,
+                    selectableLazyListState,
+                    selectionMode,
+                    allKeys,
+                    key,
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
Supporting more granular control for consumers by exposing a `handlePointerEventRelease`

Includes example demonstrating Customized `DefaultTreeViewPointerEventAction` modifying long-press vs short-press, and, right click behavior.  Model use case: When you want to use context menu actions with many selectedElement(s). Or, when you want to support click, hold and drag-n-drop actions with selectedElement(s) without reseting the selection state.
