### PR TITLE
Fix missing ⬇️ event on editable ComboBox

### DIFF
--- a/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/SwingComparisonTabPanel.kt
+++ b/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/SwingComparisonTabPanel.kt
@@ -42,6 +42,10 @@ import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.components.BorderLayoutPanel
 import icons.IdeSampleIconKeys
 import icons.JewelIcons
+import javax.swing.BoxLayout
+import javax.swing.DefaultComboBoxModel
+import javax.swing.JLabel
+import javax.swing.JPanel
 import org.jetbrains.jewel.bridge.JewelComposePanel
 import org.jetbrains.jewel.bridge.medium
 import org.jetbrains.jewel.foundation.theme.JewelTheme
@@ -57,10 +61,6 @@ import org.jetbrains.jewel.ui.component.TextField
 import org.jetbrains.jewel.ui.component.Typography
 import org.jetbrains.jewel.ui.theme.comboBoxStyle
 import org.jetbrains.jewel.ui.theme.textAreaStyle
-import javax.swing.BoxLayout
-import javax.swing.DefaultComboBoxModel
-import javax.swing.JLabel
-import javax.swing.JPanel
 
 internal class SwingComparisonTabPanel : BorderLayoutPanel() {
     private val mainContent =

--- a/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/SwingComparisonTabPanel.kt
+++ b/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/SwingComparisonTabPanel.kt
@@ -42,16 +42,13 @@ import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.components.BorderLayoutPanel
 import icons.IdeSampleIconKeys
 import icons.JewelIcons
-import javax.swing.BoxLayout
-import javax.swing.DefaultComboBoxModel
-import javax.swing.JLabel
-import javax.swing.JPanel
 import org.jetbrains.jewel.bridge.JewelComposePanel
 import org.jetbrains.jewel.bridge.medium
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.DefaultButton
 import org.jetbrains.jewel.ui.component.Icon
 import org.jetbrains.jewel.ui.component.ListComboBox
+import org.jetbrains.jewel.ui.component.ListItemState
 import org.jetbrains.jewel.ui.component.OutlinedButton
 import org.jetbrains.jewel.ui.component.SimpleListItem
 import org.jetbrains.jewel.ui.component.Text
@@ -60,6 +57,10 @@ import org.jetbrains.jewel.ui.component.TextField
 import org.jetbrains.jewel.ui.component.Typography
 import org.jetbrains.jewel.ui.theme.comboBoxStyle
 import org.jetbrains.jewel.ui.theme.textAreaStyle
+import javax.swing.BoxLayout
+import javax.swing.DefaultComboBoxModel
+import javax.swing.JLabel
+import javax.swing.JPanel
 
 internal class SwingComparisonTabPanel : BorderLayoutPanel() {
     private val mainContent =
@@ -259,8 +260,7 @@ internal class SwingComparisonTabPanel : BorderLayoutPanel() {
                                 listItemContent = { item, isSelected, isFocused, isItemHovered, isListHovered ->
                                     SimpleListItem(
                                         text = item,
-                                        isSelected = isSelected,
-                                        isHovered = isItemHovered,
+                                        state = ListItemState(isSelected, isListHovered, isItemHovered),
                                         style = JewelTheme.comboBoxStyle.itemStyle,
                                         contentDescription = item,
                                     )
@@ -280,8 +280,7 @@ internal class SwingComparisonTabPanel : BorderLayoutPanel() {
                                 listItemContent = { item, isSelected, isFocused, isItemHovered, isListHovered ->
                                     SimpleListItem(
                                         text = item,
-                                        isSelected = isSelected,
-                                        isHovered = isItemHovered,
+                                        state = ListItemState(isSelected, isListHovered, isItemHovered),
                                         style = JewelTheme.comboBoxStyle.itemStyle,
                                         contentDescription = item,
                                     )
@@ -300,8 +299,7 @@ internal class SwingComparisonTabPanel : BorderLayoutPanel() {
                                 listItemContent = { item, isSelected, isFocused, isItemHovered, isListHovered ->
                                     SimpleListItem(
                                         text = item,
-                                        isSelected = isSelected,
-                                        isHovered = isItemHovered,
+                                        state = ListItemState(isSelected, isListHovered, isItemHovered),
                                         style = JewelTheme.comboBoxStyle.itemStyle,
                                         contentDescription = item,
                                     )

--- a/ui-tests/src/test/kotlin/ListComboBoxUiTest.kt
+++ b/ui-tests/src/test/kotlin/ListComboBoxUiTest.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.assertHasNoClickAction
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasTestTag
@@ -242,10 +243,11 @@ class ListComboBoxUiTest {
     fun `when disabled, ComboBox cannot be interacted with`() {
         val comboBox = disabledEditableComboBox()
         comboBox.assertIsDisplayed().assertHasNoClickAction().performClick()
+        popupMenu.assertDoesNotExist()
 
-        // Ivan: It would be nice to check the absence of the OnClick,
-        // but I believe the BasicTextField adds it even on a disable state 🤷
-        textField.assertIsDisplayed().performClick()
+        // BasicTextField clickable adds an onClick action even when BTF is disabled
+        // textField.assertIsDisplayed().assertIsNotEnabled().assertHasNoClickAction().performClick() ❌
+        textField.assertIsDisplayed().assertIsNotEnabled().performClick()
         popupMenu.assertDoesNotExist()
     }
 

--- a/ui-tests/src/test/kotlin/ListComboBoxUiTest.kt
+++ b/ui-tests/src/test/kotlin/ListComboBoxUiTest.kt
@@ -37,6 +37,7 @@ import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.intui.standalone.theme.IntUiTheme
 import org.jetbrains.jewel.ui.component.EditableComboBox
 import org.jetbrains.jewel.ui.component.ListComboBox
+import org.jetbrains.jewel.ui.component.ListItemState
 import org.jetbrains.jewel.ui.component.SimpleListItem
 import org.jetbrains.jewel.ui.theme.comboBoxStyle
 import org.junit.Rule
@@ -239,14 +240,12 @@ class ListComboBoxUiTest {
 
     @Test
     fun `when disabled, ComboBox cannot be interacted with`() {
-        val comboBox = disabledComboBox()
-
+        val comboBox = disabledEditableComboBox()
         comboBox.assertIsDisplayed().assertHasNoClickAction().performClick()
-        composeRule
-            .onNodeWithTag("Jewel.ComboBox.NonEditableText")
-            .assertIsDisplayed()
-            .assertHasNoClickAction()
-            .performClick()
+
+        // Ivan: It would be nice to check the absence of the OnClick,
+        // but I believe the BasicTextField adds it even on a disable state 🤷
+        textField.assertIsDisplayed().performClick()
         popupMenu.assertDoesNotExist()
     }
 
@@ -435,13 +434,13 @@ class ListComboBoxUiTest {
         return comboBox
     }
 
-    private fun disabledComboBox(): SemanticsNodeInteraction {
+    private fun disabledEditableComboBox(): SemanticsNodeInteraction {
         val focusRequester = FocusRequester()
         injectComboBox(focusRequester, true, false)
         focusRequester.requestFocus()
         val comboBox = comboBox
         comboBox.assertIsDisplayed()
-        composeRule.onNodeWithTag("Jewel.ComboBox.NonEditableText").assertIsDisplayed()
+        textField.assertIsDisplayed()
         return comboBox
     }
 
@@ -470,8 +469,7 @@ class ListComboBoxUiTest {
                         SimpleListItem(
                             text = item,
                             modifier = Modifier.testTag(item),
-                            isSelected = isSelected,
-                            isHovered = isItemHovered,
+                            state = ListItemState(isSelected, isListHovered, isItemHovered),
                             style = JewelTheme.comboBoxStyle.itemStyle,
                             contentDescription = item,
                         )

--- a/ui/api/ui.api
+++ b/ui/api/ui.api
@@ -507,6 +507,17 @@ public final class org/jetbrains/jewel/ui/component/ListComboBoxKt {
 	public static final fun ListComboBox-gNPyAyM (Ljava/util/List;Landroidx/compose/ui/Modifier;ZZFLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function7;Landroidx/compose/runtime/Composer;II)V
 }
 
+public final class org/jetbrains/jewel/ui/component/ListItemState {
+	public static final field $stable I
+	public fun <init> (ZZZ)V
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun isHovered ()Z
+	public final fun isSelected ()Z
+	public final fun isSoftSelected ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class org/jetbrains/jewel/ui/component/MenuItemState : org/jetbrains/jewel/foundation/state/FocusableComponentState, org/jetbrains/jewel/foundation/state/SelectableComponentState {
 	public static final field Companion Lorg/jetbrains/jewel/ui/component/MenuItemState$Companion;
 	public static final synthetic fun box-impl (J)Lorg/jetbrains/jewel/ui/component/MenuItemState;
@@ -774,7 +785,7 @@ public final class org/jetbrains/jewel/ui/component/SelectableLazyColumnKt {
 }
 
 public final class org/jetbrains/jewel/ui/component/SimpleListItemKt {
-	public static final fun SimpleListItem-V-95POc (Ljava/lang/String;ZZZLorg/jetbrains/jewel/ui/component/styling/SimpleListItemStyle;Landroidx/compose/ui/Modifier;FLorg/jetbrains/jewel/ui/icon/IconKey;Ljava/lang/String;Landroidx/compose/runtime/Composer;II)V
+	public static final fun SimpleListItem-iHT-50w (Ljava/lang/String;Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/ui/component/ListItemState;Lorg/jetbrains/jewel/ui/component/styling/SimpleListItemStyle;FLorg/jetbrains/jewel/ui/icon/IconKey;Ljava/lang/String;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class org/jetbrains/jewel/ui/component/SliderKt {

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/EditableComboBox.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/EditableComboBox.kt
@@ -246,7 +246,7 @@ private fun TextInput(
                         if (popupExpanded) {
                             onArrowDownPress()
                         } else {
-                            onSetPopupExpanded(false)
+                            onSetPopupExpandedEvent(true)
                             textFieldFocusRequester.requestFocus()
                         }
                     }
@@ -254,7 +254,6 @@ private fun TextInput(
                         if (popupExpanded) {
                             onArrowUpPress()
                         } else {
-                            onSetPopupExpanded(true)
                             textFieldFocusRequester.requestFocus()
                         }
                     }

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/EditableComboBox.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/EditableComboBox.kt
@@ -1,3 +1,5 @@
+@file:Suppress("ktlint:compose:parameter-naming")
+
 package org.jetbrains.jewel.ui.component
 
 import androidx.compose.foundation.background
@@ -177,10 +179,12 @@ public fun EditableComboBox(
                     onArrowDownPress = onArrowDownPress,
                     onArrowUpPress = onArrowUpPress,
                     onEnterPress = onEnterPress,
-                    onSetPopupExpandedEvent = { popupExpanded = it },
+                    onSetPopupExpanded = { popupExpanded = it },
                     onFocusedChange = { comboBoxState = comboBoxState.copy(focused = it) },
                     onHoveredChange = { textFieldHovered = it },
-                    modifier = Modifier.fillMaxWidth().weight(1f),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f),
                 )
 
                 Chevron(
@@ -189,7 +193,7 @@ public fun EditableComboBox(
                     interactionSource = interactionSource,
                     onHoveredChange = { chevronHovered = it },
                     setPopupExpanded = { popupExpanded = it },
-                    onPressWhenEnable = onPressWhenEnabled,
+                    onPressWhenEnabled = onPressWhenEnabled,
                 )
             }
         }
@@ -215,8 +219,10 @@ public fun EditableComboBox(
     }
 }
 
+@Suppress("ktlint:compose:modifier-without-default-check")
 @Composable
 private fun TextInput(
+    modifier: Modifier,
     isEnabled: Boolean,
     inputTextFieldState: TextFieldState,
     isFocused: Boolean,
@@ -228,10 +234,9 @@ private fun TextInput(
     onArrowDownPress: () -> Unit,
     onArrowUpPress: () -> Unit,
     onEnterPress: () -> Unit,
-    onSetPopupExpandedEvent: (Boolean) -> Unit,
+    onSetPopupExpanded: (Boolean) -> Unit,
     onFocusedChange: (Boolean) -> Unit,
     onHoveredChange: (Boolean) -> Unit,
-    modifier: Modifier = Modifier,
 ) {
     BasicTextField(
         state = inputTextFieldState,
@@ -246,7 +251,7 @@ private fun TextInput(
                         if (popupExpanded) {
                             onArrowDownPress()
                         } else {
-                            onSetPopupExpandedEvent(true)
+                            onSetPopupExpanded(true)
                             textFieldFocusRequester.requestFocus()
                         }
                     }
@@ -260,12 +265,12 @@ private fun TextInput(
 
                     if (it.type == KeyEventType.KeyDown && it.key == Key.Enter) {
                         if (popupExpanded) {
-                            onSetPopupExpandedEvent(false)
+                            onSetPopupExpanded(false)
                         }
                         onEnterPress()
                     }
                     if (it.type == KeyEventType.KeyDown && it.key == Key.Escape && popupExpanded) {
-                        onSetPopupExpandedEvent(false)
+                        onSetPopupExpanded(false)
                     }
                     false
                 }
@@ -285,22 +290,23 @@ private fun Chevron(
     interactionSource: MutableInteractionSource,
     onHoveredChange: (Boolean) -> Unit,
     setPopupExpanded: (Boolean) -> Unit,
-    onPressWhenEnable: () -> Unit,
+    onPressWhenEnabled: () -> Unit,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier =
-            Modifier.testTag("Jewel.ComboBox.ChevronContainer")
+            Modifier
+                .testTag("Jewel.ComboBox.ChevronContainer")
                 .size(style.metrics.arrowAreaSize) // Fixed size
                 .thenIf(isEnabled) {
                     onHover { onHoveredChange(it) }
                         .pointerInput(interactionSource) {
-                            detectPressAndCancel(onPress = onPressWhenEnable, onCancel = { setPopupExpanded(false) })
+                            detectPressAndCancel(onPress = onPressWhenEnabled, onCancel = { setPopupExpanded(false) })
                         }
                         .semantics {
                             onClick(
                                 action = {
-                                    onPressWhenEnable()
+                                    onPressWhenEnabled()
                                     true
                                 },
                                 label = "Chevron",

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/EditableComboBox.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/EditableComboBox.kt
@@ -166,30 +166,30 @@ public fun EditableComboBox(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 TextInput(
-                    modifier = Modifier.fillMaxWidth().weight(1f),
                     isEnabled = isEnabled,
                     inputTextFieldState = inputTextFieldState,
-                    style = style,
                     isFocused = comboBoxState.isFocused,
                     textFieldFocusRequester = textFieldFocusRequester,
+                    style = style,
                     popupExpanded = popupExpanded,
                     textStyle = textStyle,
                     textFieldInteractionSource = textFieldInteractionSource,
                     onArrowDownPress = onArrowDownPress,
                     onArrowUpPress = onArrowUpPress,
                     onEnterPress = onEnterPress,
-                    onSetPopupExpanded = { popupExpanded = it },
-                    onFocusedChanged = { comboBoxState = comboBoxState.copy(focused = it) },
-                    onHoveredChanged = { textFieldHovered = it },
+                    onSetPopupExpandedEvent = { popupExpanded = it },
+                    onFocusedChange = { comboBoxState = comboBoxState.copy(focused = it) },
+                    onHoveredChange = { textFieldHovered = it },
+                    modifier = Modifier.fillMaxWidth().weight(1f),
                 )
 
                 Chevron(
                     isEnabled = isEnabled,
                     style = style,
                     interactionSource = interactionSource,
-                    onHoveredChanged = { chevronHovered = it },
+                    onHoveredChange = { chevronHovered = it },
                     setPopupExpanded = { popupExpanded = it },
-                    onPressWhenEnabled = onPressWhenEnabled,
+                    onPressWhenEnable = onPressWhenEnabled,
                 )
             }
         }
@@ -217,21 +217,21 @@ public fun EditableComboBox(
 
 @Composable
 private fun TextInput(
-    modifier: Modifier,
     isEnabled: Boolean,
     inputTextFieldState: TextFieldState,
-    style: ComboBoxStyle,
     isFocused: Boolean,
     textFieldFocusRequester: FocusRequester,
+    style: ComboBoxStyle,
     popupExpanded: Boolean,
     textStyle: TextStyle,
     textFieldInteractionSource: MutableInteractionSource,
     onArrowDownPress: () -> Unit,
     onArrowUpPress: () -> Unit,
     onEnterPress: () -> Unit,
-    onSetPopupExpanded: (Boolean) -> Unit,
-    onFocusedChanged: (Boolean) -> Unit,
-    onHoveredChanged: (Boolean) -> Unit,
+    onSetPopupExpandedEvent: (Boolean) -> Unit,
+    onFocusedChange: (Boolean) -> Unit,
+    onHoveredChange: (Boolean) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     BasicTextField(
         state = inputTextFieldState,
@@ -239,7 +239,7 @@ private fun TextInput(
             modifier
                 .testTag("Jewel.ComboBox.TextField")
                 .padding(style.metrics.contentPadding)
-                .onFocusChanged { onFocusedChanged(it.isFocused) }
+                .onFocusChanged { onFocusedChange(it.isFocused) }
                 .focusRequester(textFieldFocusRequester)
                 .onPreviewKeyEvent {
                     if (it.type == KeyEventType.KeyDown && it.key == Key.DirectionDown) {
@@ -260,15 +260,17 @@ private fun TextInput(
                     }
 
                     if (it.type == KeyEventType.KeyDown && it.key == Key.Enter) {
-                        if (popupExpanded) onSetPopupExpanded(false)
+                        if (popupExpanded) {
+                            onSetPopupExpandedEvent(false)
+                        }
                         onEnterPress()
                     }
                     if (it.type == KeyEventType.KeyDown && it.key == Key.Escape && popupExpanded) {
-                        onSetPopupExpanded(false)
+                        onSetPopupExpandedEvent(false)
                     }
                     false
                 }
-                .onHover { onHoveredChanged(it) },
+                .onHover { onHoveredChange(it) },
         lineLimits = TextFieldLineLimits.SingleLine,
         textStyle = textStyle.copy(color = style.colors.content),
         cursorBrush = SolidColor(style.colors.content),
@@ -282,9 +284,9 @@ private fun Chevron(
     isEnabled: Boolean,
     style: ComboBoxStyle,
     interactionSource: MutableInteractionSource,
-    onHoveredChanged: (Boolean) -> Unit,
+    onHoveredChange: (Boolean) -> Unit,
     setPopupExpanded: (Boolean) -> Unit,
-    onPressWhenEnabled: () -> Unit,
+    onPressWhenEnable: () -> Unit,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -292,14 +294,14 @@ private fun Chevron(
             Modifier.testTag("Jewel.ComboBox.ChevronContainer")
                 .size(style.metrics.arrowAreaSize) // Fixed size
                 .thenIf(isEnabled) {
-                    onHover { onHoveredChanged(it) }
+                    onHover { onHoveredChange(it) }
                         .pointerInput(interactionSource) {
-                            detectPressAndCancel(onPress = onPressWhenEnabled, onCancel = { setPopupExpanded(false) })
+                            detectPressAndCancel(onPress = onPressWhenEnable, onCancel = { setPopupExpanded(false) })
                         }
                         .semantics {
                             onClick(
                                 action = {
-                                    onPressWhenEnabled()
+                                    onPressWhenEnable()
                                     true
                                 },
                                 label = "Chevron",

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/EditableComboBox.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/EditableComboBox.kt
@@ -182,9 +182,7 @@ public fun EditableComboBox(
                     onSetPopupExpanded = { popupExpanded = it },
                     onFocusedChange = { comboBoxState = comboBoxState.copy(focused = it) },
                     onHoveredChange = { textFieldHovered = it },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .weight(1f),
+                    modifier = Modifier.fillMaxWidth().weight(1f),
                 )
 
                 Chevron(
@@ -295,8 +293,7 @@ private fun Chevron(
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier =
-            Modifier
-                .testTag("Jewel.ComboBox.ChevronContainer")
+            Modifier.testTag("Jewel.ComboBox.ChevronContainer")
                 .size(style.metrics.arrowAreaSize) // Fixed size
                 .thenIf(isEnabled) {
                     onHover { onHoveredChange(it) }

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/ListComboBox.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/ListComboBox.kt
@@ -45,7 +45,6 @@ public fun ListComboBox(
     var selectedItem by remember { mutableIntStateOf(0) }
     var isListHovered by remember { mutableStateOf(false) }
     var hoverItemIndex by remember { mutableStateOf(-1) }
-    var softSelection by remember { mutableStateOf(isListHovered) }
     val scope = rememberCoroutineScope()
 
     LaunchedEffect(selectedItem) { scrollState.selectedKeys = setOf(items[selectedItem]) }


### PR DESCRIPTION
To keep the level of noise manageable, I suggest a commit-by-commit review.