### PR TITLE
Remove deprecated Kotlin build flag

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,9 +2,6 @@ org.gradle.jvmargs=-Xmx2G
 # Disable adding the Kotlin Stdlib by default to avoid issues with IJ plugins
 # See https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency=false
-# Avoid using incremental classpath snapshot until we upgrade to Kotlin 1.9.0+
-# See https://jb.gg/intellij-platform-kotlin-oom
-kotlin.incremental.useClasspathSnapshot=false
 
 org.jetbrains.intellij.platform.buildFeature.useBinaryReleases=false
 


### PR DESCRIPTION
`kotlin.incremental.useClasspathSnapshot` was deprecated in Kotlin 1.9, and we should not be using it anymore. This removes it.