### PR TITLE
Add enabled parameter to Tooltip

### DIFF
--- a/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/component/Tooltips.kt
+++ b/samples/standalone/src/main/kotlin/org/jetbrains/jewel/samples/standalone/view/component/Tooltips.kt
@@ -1,17 +1,43 @@
 package org.jetbrains.jewel.samples.standalone.view.component
 
-import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.unit.dp
-import org.jetbrains.jewel.foundation.theme.JewelTheme
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
+import org.jetbrains.jewel.ui.component.CheckboxRow
+import org.jetbrains.jewel.ui.component.DefaultButton
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.component.Tooltip
 
 @Composable
 fun Tooltips() {
-    Tooltip(tooltip = { Text("This is a tooltip") }) {
-        Text(modifier = Modifier.border(1.dp, JewelTheme.globalColors.borders.normal).padding(4.dp), text = "Hover Me!")
+    var toggleEnabled by remember { mutableStateOf(true) }
+    var enabled by remember { mutableStateOf(true) }
+    LaunchedEffect(toggleEnabled) {
+        if (!toggleEnabled) return@LaunchedEffect
+
+        while (true) {
+            delay(1.seconds)
+            enabled = !enabled
+        }
+    }
+
+    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+        Tooltip(tooltip = { Text("This is a tooltip") }, enabled = enabled) {
+            // Any content works — this is a button just because it's focusable
+            DefaultButton({}) { Text("Hover me!") }
+        }
+
+        CheckboxRow("Enabled", enabled, { enabled = it })
+
+        CheckboxRow("Toggle enabled every 1s", toggleEnabled, { toggleEnabled = it })
     }
 }

--- a/ui/api/ui.api
+++ b/ui/api/ui.api
@@ -962,7 +962,7 @@ public final class org/jetbrains/jewel/ui/component/ToggleableIconButtonState$Co
 }
 
 public final class org/jetbrains/jewel/ui/component/TooltipKt {
-	public static final fun Tooltip (Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/ui/component/styling/TooltipStyle;Landroidx/compose/foundation/TooltipPlacement;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun Tooltip (Lkotlin/jvm/functions/Function2;Landroidx/compose/ui/Modifier;ZLorg/jetbrains/jewel/ui/component/styling/TooltipStyle;Landroidx/compose/foundation/TooltipPlacement;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 	public static final fun rememberPopupPositionProviderAtFixedPosition-7KAyTs4 (JJLandroidx/compose/ui/Alignment;FLandroidx/compose/runtime/Composer;II)Landroidx/compose/ui/window/PopupPositionProvider;
 }
 

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Tooltip.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/Tooltip.kt
@@ -30,48 +30,60 @@ import org.jetbrains.jewel.ui.component.styling.TooltipStyle
 import org.jetbrains.jewel.ui.theme.tooltipStyle
 import org.jetbrains.jewel.ui.util.isDark
 
+/**
+ * Shows a tooltip when the mouse pointer lingers on the [content] for long enough. Provides the styling for the tooltip
+ * container.
+ *
+ * @param tooltip The content of the tooltip.
+ * @param modifier Modifier to apply to the content's wrapper
+ * @param enabled When true, the tooltip can be shown. When false, it will never show.
+ * @param style The style to apply to the tooltip.
+ * @param tooltipPlacement The placement of the tooltip.
+ * @param content The component for which to show the tooltip on hover.
+ */
 @Composable
 public fun Tooltip(
     tooltip: @Composable () -> Unit,
     modifier: Modifier = Modifier,
+    enabled: Boolean = true,
     style: TooltipStyle = JewelTheme.tooltipStyle,
     tooltipPlacement: TooltipPlacement = style.metrics.placement,
     content: @Composable () -> Unit,
 ) {
     TooltipArea(
-        tooltip = {
-            CompositionLocalProvider(
-                LocalContentColor provides style.colors.content,
-                LocalTextStyle provides LocalTextStyle.current.copy(color = style.colors.content),
-            ) {
-                Box(
-                    modifier =
-                        Modifier.shadow(
-                                elevation = style.metrics.shadowSize,
-                                shape = RoundedCornerShape(style.metrics.cornerSize),
-                                ambientColor = style.colors.shadow,
-                                spotColor = Color.Transparent,
-                            )
-                            .background(
-                                color = style.colors.background,
-                                shape = RoundedCornerShape(style.metrics.cornerSize),
-                            )
-                            .border(
-                                width = style.metrics.borderWidth,
-                                color = style.colors.border,
-                                shape = RoundedCornerShape(style.metrics.cornerSize),
-                            )
-                            .padding(style.metrics.contentPadding)
-                ) {
-                    OverrideDarkMode(style.colors.background.isDark()) { tooltip() }
-                }
-            }
-        },
+        tooltip = { if (enabled) TooltipImpl(style, tooltip) else Box {} },
         modifier = modifier,
         delayMillis = style.metrics.showDelay.inWholeMilliseconds.toInt(),
         tooltipPlacement = tooltipPlacement,
         content = content,
     )
+}
+
+@Composable
+private fun TooltipImpl(style: TooltipStyle, tooltip: @Composable () -> Unit) {
+    CompositionLocalProvider(
+        LocalContentColor provides style.colors.content,
+        LocalTextStyle provides LocalTextStyle.current.copy(color = style.colors.content),
+    ) {
+        Box(
+            modifier =
+                Modifier.shadow(
+                        elevation = style.metrics.shadowSize,
+                        shape = RoundedCornerShape(style.metrics.cornerSize),
+                        ambientColor = style.colors.shadow,
+                        spotColor = Color.Transparent,
+                    )
+                    .background(color = style.colors.background, shape = RoundedCornerShape(style.metrics.cornerSize))
+                    .border(
+                        width = style.metrics.borderWidth,
+                        color = style.colors.border,
+                        shape = RoundedCornerShape(style.metrics.cornerSize),
+                    )
+                    .padding(style.metrics.contentPadding)
+        ) {
+            OverrideDarkMode(style.colors.background.isDark()) { tooltip() }
+        }
+    }
 }
 
 /**


### PR DESCRIPTION
This allows the user to suppress tooltips in some circumstances. It is implemented with the if in the TooltipArea's tooltip composable since it preserves focus on the content() when switching it on/off.

![Screen Recording 2024-10-18 at 19 25 45](https://github.com/user-attachments/assets/cd9af6aa-556a-4556-b228-1e68b831e279)
