### PR TITLE
Fix tab icons not existing anymore in 243

### DIFF
--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridge.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/theme/IntUiBridge.kt
@@ -1059,7 +1059,7 @@ private fun readDefaultTabStyle(): TabStyle {
                 tabContentSpacing = 4.dp,
                 tabHeight = retrieveIntAsDpOrUnspecified("TabbedPane.tabHeight").takeOrElse { 24.dp },
             ),
-        icons = TabIcons(close = AllIconsKeys.General.CloseSmall),
+        icons = TabIcons(close = AllIconsKeys.Windows.CloseSmall),
         contentAlpha =
             TabContentAlpha(
                 iconNormal = 1f,
@@ -1112,7 +1112,7 @@ private fun readEditorTabStyle(): TabStyle {
                 tabContentSpacing = 4.dp,
                 tabHeight = retrieveIntAsDpOrUnspecified("TabbedPane.tabHeight").takeOrElse { 24.dp },
             ),
-        icons = TabIcons(close = AllIconsKeys.General.CloseSmall),
+        icons = TabIcons(close = AllIconsKeys.Windows.CloseSmall),
         contentAlpha =
             TabContentAlpha(
                 iconNormal = .7f,

--- a/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
+++ b/samples/ide-plugin/src/main/kotlin/org/jetbrains/jewel/samples/ideplugin/ComponentShowcaseTab.kt
@@ -58,6 +58,8 @@ import org.jetbrains.jewel.ui.component.LazyTree
 import org.jetbrains.jewel.ui.component.OutlinedButton
 import org.jetbrains.jewel.ui.component.RadioButtonRow
 import org.jetbrains.jewel.ui.component.Slider
+import org.jetbrains.jewel.ui.component.TabData
+import org.jetbrains.jewel.ui.component.TabStrip
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.component.TextField
 import org.jetbrains.jewel.ui.component.Tooltip
@@ -70,6 +72,7 @@ import org.jetbrains.jewel.ui.painter.hints.Badge
 import org.jetbrains.jewel.ui.painter.hints.Size
 import org.jetbrains.jewel.ui.painter.hints.Stroke
 import org.jetbrains.jewel.ui.theme.colorPalette
+import org.jetbrains.jewel.ui.theme.defaultTabStyle
 
 @Composable
 internal fun ComponentShowcaseTab(project: Project) {
@@ -278,6 +281,11 @@ private fun RowScope.ColumnTwo(project: Project) {
         MarkdownExample(project)
 
         Divider(Orientation.Horizontal)
+
+        val tabs = remember {
+            listOf(TabData.Default(true, { Text("Tab 1") }), TabData.Default(false, { Text("Tab 2") }))
+        }
+        TabStrip(tabs, JewelTheme.defaultTabStyle, modifier = Modifier.fillMaxWidth())
 
         var activated by remember { mutableStateOf(false) }
         Text("activated: $activated", Modifier.onActivated { activated = it })


### PR DESCRIPTION
Also adds tabs to the ComponentShowcaseTab IDE sample.

Not sure how this even built so far on 243...