### PR TITLE
Make addComposeTab's tab title nullable

### DIFF
--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/ToolWindowExtensions.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/ToolWindowExtensions.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.wm.ToolWindow
 import org.jetbrains.jewel.foundation.enableNewSwingCompositing
 
 public fun ToolWindow.addComposeTab(
-    @TabTitle tabDisplayName: String,
+    @TabTitle tabDisplayName: String? = null,
     isLockable: Boolean = true,
     isCloseable: Boolean = false,
     content: @Composable ToolWindowScope.() -> Unit,


### PR DESCRIPTION
This aligns us with the platform's `createContent()`'s use of a nullable title parameter and was requested by IJP folks.