### PR TITLE
Force Skiko to 0.8.17

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,20 @@ dependencies {
     sarif(projects.ui)
 }
 
+// TODO remove this once the Skiko fix makes it into CMP 1.7.1
+allprojects {
+    configurations.all {
+        resolutionStrategy {
+            eachDependency {
+                if (requested.group == "org.jetbrains.skiko") {
+                    useVersion("0.8.17")
+                    because("Contains important memory usage fix")
+                }
+            }
+        }
+    }
+}
+
 tasks {
     //    val mergeSarifReports by
     //        registering(MergeSarifTask::class) {


### PR DESCRIPTION
This Skiko version contains an important fix for memory usage. It is more recent than the version used by CMP 1.7.0 (0.8.15), but the CMP team assured us it is a binary-compatible change.

As a result you should see greatly decreased memory usage and GC pressure in most scenarios, except when the ComposePanel size changes. That is a more complex fix which will require a number of changes across JBR and Compose, and will come in time.