### PR TITLE
Keep trailing empty lines at the end of the Markdown code block

### DIFF
--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/processing/MarkdownProcessor.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/processing/MarkdownProcessor.kt
@@ -201,7 +201,7 @@ public class MarkdownProcessor(
 
     private fun FencedCodeBlock.toMarkdownCodeBlockOrNull(): CodeBlock.FencedCodeBlock =
         CodeBlock.FencedCodeBlock(
-            content = literal.trimEnd('\n'),
+            content = literal.removeSuffix("\n"),
             mimeType = MimeType.Known.fromMarkdownLanguageName(info),
         )
 

--- a/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/MarkdownProcessorDocumentParsingTest.kt
+++ b/markdown/core/src/test/kotlin/org/jetbrains/jewel/markdown/MarkdownProcessorDocumentParsingTest.kt
@@ -7310,7 +7310,7 @@ class MarkdownProcessorDocumentParsingTest {
          * </ul>
          */
         parsed.assertEquals(
-            unorderedList(listItem(paragraph("a")), listItem(fencedCodeBlock("b")), listItem(paragraph("c")))
+            unorderedList(listItem(paragraph("a")), listItem(fencedCodeBlock("b\n\n")), listItem(paragraph("c")))
         )
     }
 


### PR DESCRIPTION
Fixes #671