### PR TITLE
Allow configuring the ComposePanel via JewelComposePanel APIs

### DIFF
--- a/ide-laf-bridge/api/ide-laf-bridge.api
+++ b/ide-laf-bridge/api/ide-laf-bridge.api
@@ -65,10 +65,14 @@ public final class org/jetbrains/jewel/bridge/JewelBridgeException$KeysNotFoundE
 }
 
 public final class org/jetbrains/jewel/bridge/JewelComposePanelKt {
-	public static final fun JewelComposeNoThemePanel (Lkotlin/jvm/functions/Function2;)Ljavax/swing/JComponent;
-	public static final fun JewelComposePanel (Lkotlin/jvm/functions/Function2;)Ljavax/swing/JComponent;
-	public static final fun JewelToolWindowComposePanel (Lkotlin/jvm/functions/Function2;)Ljavax/swing/JComponent;
-	public static final fun JewelToolWindowNoThemeComposePanel (Lkotlin/jvm/functions/Function2;)Ljavax/swing/JComponent;
+	public static final fun JewelComposeNoThemePanel (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljavax/swing/JComponent;
+	public static synthetic fun JewelComposeNoThemePanel$default (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljavax/swing/JComponent;
+	public static final fun JewelComposePanel (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljavax/swing/JComponent;
+	public static synthetic fun JewelComposePanel$default (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljavax/swing/JComponent;
+	public static final fun JewelToolWindowComposePanel (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljavax/swing/JComponent;
+	public static synthetic fun JewelToolWindowComposePanel$default (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljavax/swing/JComponent;
+	public static final fun JewelToolWindowNoThemeComposePanel (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)Ljavax/swing/JComponent;
+	public static synthetic fun JewelToolWindowNoThemeComposePanel$default (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljavax/swing/JComponent;
 	public static final fun getLocalComponent ()Landroidx/compose/runtime/ProvidableCompositionLocal;
 }
 

--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/JewelComposePanel.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/JewelComposePanel.kt
@@ -22,54 +22,63 @@ import org.jetbrains.jewel.foundation.ExperimentalJewelApi
 import org.jetbrains.jewel.foundation.InternalJewelApi
 
 @Suppress("ktlint:standard:function-naming", "FunctionName") // Swing to Compose bridge API
-public fun JewelComposePanel(content: @Composable () -> Unit): JComponent = createJewelComposePanel { jewelPanel ->
-    setContent {
-        SwingBridgeTheme {
-            CompositionLocalProvider(LocalComponent provides this@createJewelComposePanel) {
-                ComponentDataProviderBridge(jewelPanel, content = content)
-            }
-        }
-    }
-}
-
-@InternalJewelApi
-@Suppress("ktlint:standard:function-naming", "FunctionName") // Swing to Compose bridge API
-public fun JewelToolWindowComposePanel(content: @Composable () -> Unit): JComponent =
+public fun JewelComposePanel(config: ComposePanel.() -> Unit = {}, content: @Composable () -> Unit): JComponent =
     createJewelComposePanel { jewelPanel ->
+        config()
         setContent {
-            Compose17IJSizeBugWorkaround {
-                SwingBridgeTheme {
-                    CompositionLocalProvider(LocalComponent provides this@createJewelComposePanel) {
-                        ComponentDataProviderBridge(jewelPanel, content = content)
-                    }
-                }
-            }
-        }
-    }
-
-@ExperimentalJewelApi
-@Suppress("ktlint:standard:function-naming", "FunctionName") // Swing to Compose bridge API
-public fun JewelComposeNoThemePanel(content: @Composable () -> Unit): JComponent =
-    createJewelComposePanel { jewelPanel ->
-        setContent {
-            CompositionLocalProvider(LocalComponent provides this@createJewelComposePanel) {
-                ComponentDataProviderBridge(jewelPanel, content = content)
-            }
-        }
-    }
-
-@ExperimentalJewelApi
-@Suppress("ktlint:standard:function-naming", "FunctionName") // Swing to Compose bridge API
-public fun JewelToolWindowNoThemeComposePanel(content: @Composable () -> Unit): JComponent =
-    createJewelComposePanel { jewelPanel ->
-        setContent {
-            Compose17IJSizeBugWorkaround {
+            SwingBridgeTheme {
                 CompositionLocalProvider(LocalComponent provides this@createJewelComposePanel) {
                     ComponentDataProviderBridge(jewelPanel, content = content)
                 }
             }
         }
     }
+
+@InternalJewelApi
+@Suppress("ktlint:standard:function-naming", "FunctionName") // Swing to Compose bridge API
+public fun JewelToolWindowComposePanel(
+    config: ComposePanel.() -> Unit = {},
+    content: @Composable () -> Unit,
+): JComponent = createJewelComposePanel { jewelPanel ->
+    config()
+    setContent {
+        Compose17IJSizeBugWorkaround {
+            SwingBridgeTheme {
+                CompositionLocalProvider(LocalComponent provides this@createJewelComposePanel) {
+                    ComponentDataProviderBridge(jewelPanel, content = content)
+                }
+            }
+        }
+    }
+}
+
+@ExperimentalJewelApi
+@Suppress("ktlint:standard:function-naming", "FunctionName") // Swing to Compose bridge API
+public fun JewelComposeNoThemePanel(config: ComposePanel.() -> Unit = {}, content: @Composable () -> Unit): JComponent =
+    createJewelComposePanel { jewelPanel ->
+        config()
+        setContent {
+            CompositionLocalProvider(LocalComponent provides this@createJewelComposePanel) {
+                ComponentDataProviderBridge(jewelPanel, content = content)
+            }
+        }
+    }
+
+@ExperimentalJewelApi
+@Suppress("ktlint:standard:function-naming", "FunctionName") // Swing to Compose bridge API
+public fun JewelToolWindowNoThemeComposePanel(
+    config: ComposePanel.() -> Unit = {},
+    content: @Composable () -> Unit,
+): JComponent = createJewelComposePanel { jewelPanel ->
+    config()
+    setContent {
+        Compose17IJSizeBugWorkaround {
+            CompositionLocalProvider(LocalComponent provides this@createJewelComposePanel) {
+                ComponentDataProviderBridge(jewelPanel, content = content)
+            }
+        }
+    }
+}
 
 private fun createJewelComposePanel(config: ComposePanel.(JewelComposePanel) -> Unit): JewelComposePanel {
     val jewelPanel = JewelComposePanel()


### PR DESCRIPTION
This way one can do things like setting up manual disposing, etc. The change is binary-compatible as the default config is an empty block.