### PR TITLE
Change the New UI detection logic in the bridge

### DIFF
--- a/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/BridgeUtils.kt
+++ b/ide-laf-bridge/src/main/kotlin/org/jetbrains/jewel/bridge/BridgeUtils.kt
@@ -86,7 +86,7 @@ public fun retrieveIntAsDp(key: String, default: Dp? = null): Dp {
 public fun retrieveIntAsDpOrUnspecified(key: String): Dp =
     try {
         retrieveIntAsDp(key)
-    } catch (ignored: JewelBridgeException) {
+    } catch (_: JewelBridgeException) {
         Dp.Unspecified
     }
 
@@ -211,12 +211,7 @@ internal fun scaleDensityWithIdeScale(sourceDensity: Density): Density {
     return Density(density, sourceDensity.fontScale)
 }
 
-internal fun isNewUiTheme(): Boolean {
-    if (!NewUI.isEnabled()) return false
-
-    val lafName = lafName()
-    return lafName == "Light" || lafName == "Dark" || lafName == "Light with Light Header"
-}
+internal fun isNewUiTheme(): Boolean = NewUI.isEnabled()
 
 @Suppress("UnstableApiUsage")
 internal fun lafName(): String {


### PR DESCRIPTION
Somewhere in 242 or 243 the logic to determine whether a theme is "New UI" in the IJP changed. It used to check the theme name, but these days all themes are "New UI" themes when the New UI is enabled (which it is now by default, as by 243 the old UI is an unbundled plugin).

So this changes the check we use to simply be NewUI.isEnabled().

Consider all themes "New UI" in bridge when the New UI is enabled

---

Even tho this feels weird, in IJP 243 (and possibly 242) all themes are now considered to be "New UI" themes when the `NewUI.isEnabled()` flag is enabled. This means that themes like High Contrast and Darcula are also considered "New UI", despite it being unintuitive, at least in Darcula's case (but High Contrast's parent is Darcula in the json, so... ok it's weird that's it)