### PR TITLE
Tune logging

### DIFF
--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/util/JewelLogger.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/util/JewelLogger.kt
@@ -1,10 +1,10 @@
 package org.jetbrains.jewel.foundation.util
 
+import org.jetbrains.annotations.ApiStatus
 import java.lang.reflect.Method
 import java.util.logging.ConsoleHandler
 import java.util.logging.Level
 import java.util.logging.Logger
-import org.jetbrains.annotations.ApiStatus
 
 public inline fun <reified T : Any> T.myLogger(): JewelLogger = JewelLogger.getInstance(T::class.java)
 
@@ -58,11 +58,11 @@ public abstract class JewelLogger {
 
                 // Create a new handler with a higher logging level
                 val handler = ConsoleHandler()
-                handler.level = Level.FINER
+                handler.level = Level.FINE
                 l.addHandler(handler)
 
                 // Tune the logger for level and duplicated messages
-                l.level = Level.FINER
+                l.level = Level.FINE
                 l.useParentHandlers = false
                 l
             }
@@ -101,31 +101,31 @@ public abstract class JewelLogger {
                     override fun trace(message: String?, t: Throwable?) {
                         try {
                             this@ReflectionBasedFactory.trace(message, t, logger)
-                        } catch (ignored: Exception) {}
+                        } catch (_: Exception) {}
                     }
 
                     override fun debug(message: String?, t: Throwable?) {
                         try {
                             this@ReflectionBasedFactory.debug(message, t, logger)
-                        } catch (ignored: Exception) {}
+                        } catch (_: Exception) {}
                     }
 
                     override fun info(message: String?, t: Throwable?) {
                         try {
                             this@ReflectionBasedFactory.info(message, t, logger)
-                        } catch (ignored: Exception) {}
+                        } catch (_: Exception) {}
                     }
 
                     override fun warn(message: String?, t: Throwable?) {
                         try {
                             this@ReflectionBasedFactory.warn(message, t, logger)
-                        } catch (ignored: Exception) {}
+                        } catch (_: Exception) {}
                     }
 
                     override fun error(message: String?, t: Throwable?) {
                         try {
                             this@ReflectionBasedFactory.error(message, t, logger)
-                        } catch (ignored: Exception) {}
+                        } catch (_: Exception) {}
                     }
                 }
             } catch (e: Exception) {
@@ -133,17 +133,17 @@ public abstract class JewelLogger {
             }
         }
 
-        @Throws(Exception::class) protected abstract fun trace(message: String?, t: Throwable?, logger: Any?)
+        @Throws(Exception::class) abstract fun trace(message: String?, t: Throwable?, logger: Any?)
 
-        @Throws(Exception::class) protected abstract fun debug(message: String?, t: Throwable?, logger: Any?)
+        @Throws(Exception::class) abstract fun debug(message: String?, t: Throwable?, logger: Any?)
 
-        @Throws(Exception::class) protected abstract fun error(message: String?, t: Throwable?, logger: Any?)
+        @Throws(Exception::class) abstract fun error(message: String?, t: Throwable?, logger: Any?)
 
-        @Throws(Exception::class) protected abstract fun warn(message: String?, t: Throwable?, logger: Any?)
+        @Throws(Exception::class) abstract fun warn(message: String?, t: Throwable?, logger: Any?)
 
-        @Throws(Exception::class) protected abstract fun info(message: String?, t: Throwable?, logger: Any?)
+        @Throws(Exception::class) abstract fun info(message: String?, t: Throwable?, logger: Any?)
 
-        @Throws(Exception::class) protected abstract fun getLogger(category: String?): Any
+        @Throws(Exception::class) abstract fun getLogger(category: String?): Any
     }
 
     private class IdeaFactory : ReflectionBasedFactory() {
@@ -259,10 +259,10 @@ public abstract class JewelLogger {
         private fun createFactory(): Factory =
             try {
                 IdeaFactory()
-            } catch (t: Throwable) {
+            } catch (_: Throwable) {
                 try {
                     Slf4JFactory()
-                } catch (t2: Throwable) {
+                } catch (_: Throwable) {
                     JavaFactory()
                 }
             }

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/util/JewelLogger.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/util/JewelLogger.kt
@@ -1,10 +1,10 @@
 package org.jetbrains.jewel.foundation.util
 
-import org.jetbrains.annotations.ApiStatus
 import java.lang.reflect.Method
 import java.util.logging.ConsoleHandler
 import java.util.logging.Level
 import java.util.logging.Logger
+import org.jetbrains.annotations.ApiStatus
 
 public inline fun <reified T : Any> T.myLogger(): JewelLogger = JewelLogger.getInstance(T::class.java)
 

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/painter/ResourcePainterProvider.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/painter/ResourcePainterProvider.kt
@@ -11,6 +11,14 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.decodeToImageBitmap
+import org.jetbrains.compose.resources.decodeToImageVector
+import org.jetbrains.compose.resources.decodeToSvgPainter
+import org.jetbrains.jewel.foundation.util.myLogger
+import org.jetbrains.jewel.ui.icon.IconKey
+import org.jetbrains.jewel.ui.icon.LocalNewUiChecker
+import org.w3c.dom.Document
 import java.io.IOException
 import java.io.InputStream
 import java.io.StringWriter
@@ -24,14 +32,6 @@ import javax.xml.transform.TransformerException
 import javax.xml.transform.TransformerFactory
 import javax.xml.transform.dom.DOMSource
 import javax.xml.transform.stream.StreamResult
-import org.jetbrains.compose.resources.ExperimentalResourceApi
-import org.jetbrains.compose.resources.decodeToImageBitmap
-import org.jetbrains.compose.resources.decodeToImageVector
-import org.jetbrains.compose.resources.decodeToSvgPainter
-import org.jetbrains.jewel.foundation.util.myLogger
-import org.jetbrains.jewel.ui.icon.IconKey
-import org.jetbrains.jewel.ui.icon.LocalNewUiChecker
-import org.w3c.dom.Document
 
 private val errorPainter = ColorPainter(Color.Magenta)
 
@@ -78,14 +78,12 @@ public class ResourcePainterProvider(private val basePath: String, vararg classL
         val cacheKey = scope.acceptedHints.hashCode() * 31 + LocalDensity.current.hashCode()
 
         if (cache[cacheKey] != null) {
-            // logger.debug("Cache hit for $basePath (accepted hints:
-            // ${scope.acceptedHints.joinToString()})")
+            logger.trace("Cache hit for $basePath (accepted hints: ${scope.acceptedHints.joinToString()})")
         }
 
         val painter =
             cache.getOrPut(cacheKey) {
-                // logger.debug("Cache miss for $basePath (accepted hints:
-                // ${scope.acceptedHints.joinToString()})")
+                logger.trace("Cache miss for $basePath (accepted hints: ${scope.acceptedHints.joinToString()})")
                 loadPainter(scope)
             }
 
@@ -131,7 +129,7 @@ public class ResourcePainterProvider(private val basePath: String, vararg classL
         for (classLoader in contextClassLoaders) {
             val url = classLoader.getResource(normalized)
             if (url != null) {
-                // logger.debug("Found resource: '$normalized'")
+                logger.trace("Found resource: '$normalized'")
                 return scope to url
             }
         }
@@ -146,8 +144,7 @@ public class ResourcePainterProvider(private val basePath: String, vararg classL
             url = url,
             loadingAction = { resourceUrl ->
                 patchSvg(scope, url.openStream(), scope.acceptedHints).use { inputStream ->
-                    // logger.debug("Loading icon $basePath(${scope.acceptedHints.joinToString()})
-                    // from $resourceUrl")
+                    logger.trace("Loading icon $basePath(${scope.acceptedHints.joinToString()}) from $resourceUrl")
                     inputStream.readAllBytes().decodeToSvgPainter(scope)
                 }
             },
@@ -170,7 +167,7 @@ public class ResourcePainterProvider(private val basePath: String, vararg classL
 
             return document
                 .writeToString()
-                // .also { patchedSvg -> logger.debug("Patched SVG:\n\n$patchedSvg") }
+                .also { patchedSvg -> logger.trace("Patched SVG:\n\n$patchedSvg") }
                 .byteInputStream()
         }
     }

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/painter/ResourcePainterProvider.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/painter/ResourcePainterProvider.kt
@@ -11,14 +11,6 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Density
-import org.jetbrains.compose.resources.ExperimentalResourceApi
-import org.jetbrains.compose.resources.decodeToImageBitmap
-import org.jetbrains.compose.resources.decodeToImageVector
-import org.jetbrains.compose.resources.decodeToSvgPainter
-import org.jetbrains.jewel.foundation.util.myLogger
-import org.jetbrains.jewel.ui.icon.IconKey
-import org.jetbrains.jewel.ui.icon.LocalNewUiChecker
-import org.w3c.dom.Document
 import java.io.IOException
 import java.io.InputStream
 import java.io.StringWriter
@@ -32,6 +24,14 @@ import javax.xml.transform.TransformerException
 import javax.xml.transform.TransformerFactory
 import javax.xml.transform.dom.DOMSource
 import javax.xml.transform.stream.StreamResult
+import org.jetbrains.compose.resources.ExperimentalResourceApi
+import org.jetbrains.compose.resources.decodeToImageBitmap
+import org.jetbrains.compose.resources.decodeToImageVector
+import org.jetbrains.compose.resources.decodeToSvgPainter
+import org.jetbrains.jewel.foundation.util.myLogger
+import org.jetbrains.jewel.ui.icon.IconKey
+import org.jetbrains.jewel.ui.icon.LocalNewUiChecker
+import org.w3c.dom.Document
 
 private val errorPainter = ColorPainter(Color.Magenta)
 


### PR DESCRIPTION
This PR uncomments logging in `ResourcePainterProvider` which should never have been committed to begin with, and adjusts its level to trace (FINER). It also sets the `JavaFactory` level to `FINE` (debug), so that `ResourcePainterProvider`'s logs don't spam the console. Lastly, it cleans up `JewelLogger`'s code with the IDE's _Clean up_ action