### PR TITLE
[REVIEW ONLY] Allow FINER logger with CLI property

### DIFF
--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/util/JewelLogger.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/util/JewelLogger.kt
@@ -1,10 +1,10 @@
 package org.jetbrains.jewel.foundation.util
 
+import org.jetbrains.annotations.ApiStatus
 import java.lang.reflect.Method
 import java.util.logging.ConsoleHandler
 import java.util.logging.Level
 import java.util.logging.Logger
-import org.jetbrains.annotations.ApiStatus
 
 public inline fun <reified T : Any> T.myLogger(): JewelLogger = JewelLogger.getInstance(T::class.java)
 
@@ -58,11 +58,12 @@ public abstract class JewelLogger {
 
                 // Create a new handler with a higher logging level
                 val handler = ConsoleHandler()
-                handler.level = Level.FINE
+                val isVerbose = System.getProperty("jewel.verbose") == "true"
+                handler.level = if (isVerbose) Level.FINEST else Level.FINE
                 l.addHandler(handler)
 
                 // Tune the logger for level and duplicated messages
-                l.level = Level.FINE
+                l.level = if (isVerbose) Level.FINEST else Level.FINE
                 l.useParentHandlers = false
                 l
             }

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/util/JewelLogger.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/util/JewelLogger.kt
@@ -1,10 +1,10 @@
 package org.jetbrains.jewel.foundation.util
 
-import org.jetbrains.annotations.ApiStatus
 import java.lang.reflect.Method
 import java.util.logging.ConsoleHandler
 import java.util.logging.Level
 import java.util.logging.Logger
+import org.jetbrains.annotations.ApiStatus
 
 public inline fun <reified T : Any> T.myLogger(): JewelLogger = JewelLogger.getInstance(T::class.java)
 

--- a/samples/standalone/build.gradle.kts
+++ b/samples/standalone/build.gradle.kts
@@ -60,6 +60,10 @@ tasks {
         afterEvaluate {
             javaLauncher = project.javaToolchains.launcherFor { languageVersion = JavaLanguageVersion.of(jdkLevel) }
             setExecutable(javaLauncher.map { it.executablePath.asFile.absolutePath }.get())
+
+            if (project.hasProperty("jewel.verbose")) {
+                systemProperty("jewel.verbose", "true")
+            }
         }
     }
 }


### PR DESCRIPTION
You can now launch the Standalone sample with TRACE logger level with

```
./gradlew run -Pjewel.verbose
```

I tried to have `./gradlew run --jewel-verbose`, but I wasn't able to find a way to do it with Gradle/Compose.