### PR TITLE
Add slot-based SimpleListItem overloads

### DIFF
--- a/ui/api/ui.api
+++ b/ui/api/ui.api
@@ -826,8 +826,10 @@ public final class org/jetbrains/jewel/ui/component/SelectableIconButtonState$Co
 }
 
 public final class org/jetbrains/jewel/ui/component/SimpleListItemKt {
+	public static final fun SimpleListItem-0vH8DBg (Lorg/jetbrains/jewel/ui/component/ListItemState;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/ui/icon/IconKey;Ljava/lang/String;Lorg/jetbrains/jewel/ui/component/styling/SimpleListItemStyle;FLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 	public static final fun SimpleListItem-aqv2aB4 (Ljava/lang/String;ZLandroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;ZLorg/jetbrains/jewel/ui/icon/IconKey;Ljava/lang/String;Lorg/jetbrains/jewel/ui/component/styling/SimpleListItemStyle;FLandroidx/compose/runtime/Composer;II)V
 	public static final fun SimpleListItem-eKw1uXw (Ljava/lang/String;Lorg/jetbrains/jewel/ui/component/ListItemState;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/ui/icon/IconKey;Ljava/lang/String;Lorg/jetbrains/jewel/ui/component/styling/SimpleListItemStyle;FLandroidx/compose/runtime/Composer;II)V
+	public static final fun SimpleListItem-gMrHQkA (ZLandroidx/compose/ui/Modifier;Landroidx/compose/ui/Modifier;ZLorg/jetbrains/jewel/ui/icon/IconKey;Ljava/lang/String;Lorg/jetbrains/jewel/ui/component/styling/SimpleListItemStyle;FLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class org/jetbrains/jewel/ui/component/SliderKt {

--- a/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/SimpleListItem.kt
+++ b/ui/src/main/kotlin/org/jetbrains/jewel/ui/component/SimpleListItem.kt
@@ -24,6 +24,28 @@ import org.jetbrains.jewel.ui.icon.IconKey
 import org.jetbrains.jewel.ui.theme.simpleListItemStyle
 
 /**
+ * A simple list item layout comprising of a content slot and an optional icon to its start side.
+ *
+ * The text will only take up one line and is ellipsized if too long to fit. The item will draw a background based on
+ * the [isSelected] and [isActive] values.
+ */
+@Composable
+public fun SimpleListItem(
+    isSelected: Boolean,
+    modifier: Modifier = Modifier,
+    iconModifier: Modifier = Modifier,
+    isActive: Boolean = true,
+    icon: IconKey? = null,
+    iconContentDescription: String? = null,
+    style: SimpleListItemStyle = JewelTheme.simpleListItemStyle,
+    height: Dp = JewelTheme.globalMetrics.rowHeight,
+    content: @Composable () -> Unit,
+) {
+    val state = remember(isSelected, isActive) { ListItemState(isSelected, isActive) }
+    SimpleListItem(state, modifier, iconModifier, icon, iconContentDescription, style, height, content)
+}
+
+/**
  * A simple list item layout comprising of a text and an optional icon to its start side.
  *
  * The text will only take up one line and is ellipsized if too long to fit. The item will draw a background based on
@@ -64,6 +86,35 @@ public fun SimpleListItem(
     style: SimpleListItemStyle = JewelTheme.simpleListItemStyle,
     height: Dp = JewelTheme.globalMetrics.rowHeight,
 ) {
+    SimpleListItem(state, modifier, iconModifier, icon, iconContentDescription, style, height) {
+        Text(
+            text = text,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            style = JewelTheme.defaultTextStyle,
+            color = style.colors.contentFor(state).value,
+            modifier = textModifier,
+        )
+    }
+}
+
+/**
+ * A simple list item layout comprising of a content slot and an optional icon to its start side.
+ *
+ * The text will only take up one line and is ellipsized if too long to fit. The item will draw a background based on
+ * the [state].
+ */
+@Composable
+public fun SimpleListItem(
+    state: ListItemState,
+    modifier: Modifier = Modifier,
+    iconModifier: Modifier = Modifier,
+    icon: IconKey? = null,
+    iconContentDescription: String? = null,
+    style: SimpleListItemStyle = JewelTheme.simpleListItemStyle,
+    height: Dp = JewelTheme.globalMetrics.rowHeight,
+    content: @Composable () -> Unit,
+) {
     Row(
         modifier =
             modifier
@@ -82,14 +133,7 @@ public fun SimpleListItem(
         if (icon != null) {
             Icon(modifier = iconModifier.size(16.dp), key = icon, contentDescription = iconContentDescription)
         }
-        Text(
-            text = text,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            style = JewelTheme.defaultTextStyle,
-            color = style.colors.contentFor(state).value,
-            modifier = textModifier,
-        )
+        content()
     }
 }
 


### PR DESCRIPTION
This lets folks define more complex list item content layouts (e.g., multiple text runs, additional icons, etc). For example, one may use it to build items like these:

<img width="722" alt="Completion menu screenshot" src="https://github.com/user-attachments/assets/284392dc-f388-4931-a29c-bd8b6b40d5ca" />
