### PR TITLE
Bugfix decorated window on windows - clickable components inside title area should work now

### DIFF
--- a/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/TitleBar.Windows.kt
+++ b/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/TitleBar.Windows.kt
@@ -1,6 +1,8 @@
 package org.jetbrains.jewel.window
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -27,7 +29,7 @@ internal fun DecoratedWindowScope.TitleBarOnWindows(
     val titleBar = remember { JBR.getWindowDecorations().createCustomTitleBar() }
 
     TitleBarImpl(
-        modifier = modifier.customTitleBarMouseEventHandler(titleBar),
+        modifier = modifier,
         gradientStartColor = gradientStartColor,
         style = style,
         applyTitleBar = { height, _ ->
@@ -35,6 +37,9 @@ internal fun DecoratedWindowScope.TitleBarOnWindows(
             titleBar.putProperty("controls.dark", style.colors.background.isDark())
             JBR.getWindowDecorations().setCustomTitleBar(window, titleBar)
             PaddingValues(start = titleBar.leftInset.dp, end = titleBar.rightInset.dp)
+        },
+        backgroundContent = {
+            Spacer(modifier = modifier.fillMaxSize().customTitleBarMouseEventHandler(titleBar))
         },
         content = content,
     )

--- a/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/TitleBar.kt
+++ b/decorated-window/src/main/kotlin/org/jetbrains/jewel/window/TitleBar.kt
@@ -1,8 +1,10 @@
 package org.jetbrains.jewel.window
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
@@ -77,6 +79,7 @@ internal fun DecoratedWindowScope.TitleBarImpl(
     gradientStartColor: Color = Color.Unspecified,
     style: TitleBarStyle = JewelTheme.defaultTitleBarStyle,
     applyTitleBar: (Dp, DecoratedWindowState) -> PaddingValues,
+    backgroundContent: @Composable () -> Unit = {},
     content: @Composable TitleBarScope.(DecoratedWindowState) -> Unit,
 ) {
     val titleBarInfo = LocalTitleBarInfo.current
@@ -102,29 +105,33 @@ internal fun DecoratedWindowScope.TitleBarImpl(
             }
         }
 
-    Layout(
-        content = {
-            CompositionLocalProvider(
-                LocalContentColor provides style.colors.content,
-                LocalIconButtonStyle provides style.iconButtonStyle,
-                LocalDefaultDropdownStyle provides style.dropdownStyle,
-            ) {
-                OverrideDarkMode(background.isDark()) {
-                    val scope = TitleBarScopeImpl(titleBarInfo.title, titleBarInfo.icon)
-                    scope.content(state)
+    Box(
+        modifier = modifier
+            .background(backgroundBrush)
+            .focusProperties { canFocus = false }
+            .layoutId(TITLE_BAR_LAYOUT_ID)
+            .height(style.metrics.height)
+            .onSizeChanged { with(density) { applyTitleBar(it.height.toDp(), state) } }
+            .fillMaxWidth()
+    ) {
+        backgroundContent()
+        Layout(
+            content = {
+                CompositionLocalProvider(
+                    LocalContentColor provides style.colors.content,
+                    LocalIconButtonStyle provides style.iconButtonStyle,
+                    LocalDefaultDropdownStyle provides style.dropdownStyle,
+                ) {
+                    OverrideDarkMode(background.isDark()) {
+                        val scope = TitleBarScopeImpl(titleBarInfo.title, titleBarInfo.icon)
+                        scope.content(state)
+                    }
                 }
-            }
-        },
-        modifier =
-            modifier
-                .background(backgroundBrush)
-                .focusProperties { canFocus = false }
-                .layoutId(TITLE_BAR_LAYOUT_ID)
-                .height(style.metrics.height)
-                .onSizeChanged { with(density) { applyTitleBar(it.height.toDp(), state) } }
-                .fillMaxWidth(),
-        measurePolicy = rememberTitleBarMeasurePolicy(window, state, applyTitleBar),
-    )
+            },
+            modifier = modifier.fillMaxSize(),
+            measurePolicy = rememberTitleBarMeasurePolicy(window, state, applyTitleBar),
+        )
+    }
 
     Spacer(Modifier.layoutId(TITLE_BAR_BORDER_LAYOUT_ID).height(1.dp).fillMaxWidth().background(style.colors.border))
 }


### PR DESCRIPTION
**Idea**

Place a background composable behind the title content that handles all windows draggable header related stuff. This way, everything inside the title bar is placed **on top** of the composable that forwards the events to the draggable header.

**Issues this solves**

when clicking a dropdown menu in the title bar, the popup did not pop up until the next mouse move => fixed

**TODO**

* the macos implementation does use `customTitleBarMouseEventHandler` as well - it may be necessary to use the same fix there? I don't know, I don't have a mac and I don't know if the mac has the same issues
* for the sake of minimal adjustments I kept the `customTitleBarMouseEventHandler` as is (also because I don't know how it is used on mac) - it may be possible to simplifiy it like following as there is no need to try to detect if we are over a user control or not anymore because of the layerig of the background composable and the content.

```
internal fun Modifier.customTitleBarMouseEventHandler(titleBar: CustomTitleBar): Modifier =
    pointerInput(Unit) {
        val currentContext = currentCoroutineContext()
        awaitPointerEventScope {
            while (currentContext.isActive) {
                awaitPointerEvent(PointerEventPass.Main)
                titleBar.forceHitTest(false)
            }
        }
    }
```