### PR TITLE
Move the `thenIf` modifier from ui to foundation module

### DIFF
--- a/foundation/api/foundation.api
+++ b/foundation/api/foundation.api
@@ -831,6 +831,10 @@ public final class org/jetbrains/jewel/foundation/modifier/BorderKt {
 	public static synthetic fun border-QWjY48E$default (Landroidx/compose/ui/Modifier;Lorg/jetbrains/jewel/foundation/Stroke$Alignment;FJLandroidx/compose/ui/graphics/Shape;FILjava/lang/Object;)Landroidx/compose/ui/Modifier;
 }
 
+public final class org/jetbrains/jewel/foundation/modifier/ModifierExtensionsKt {
+	public static final fun thenIf (Landroidx/compose/ui/Modifier;ZLkotlin/jvm/functions/Function1;)Landroidx/compose/ui/Modifier;
+}
+
 public final class org/jetbrains/jewel/foundation/modifier/OnHoverModifierKt {
 	public static final fun onHover (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;)Landroidx/compose/ui/Modifier;
 }

--- a/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/modifier/ModifierExtensions.kt
+++ b/foundation/src/main/kotlin/org/jetbrains/jewel/foundation/modifier/ModifierExtensions.kt
@@ -1,4 +1,4 @@
-package org.jetbrains.jewel.ui.util
+package org.jetbrains.jewel.foundation.modifier
 
 import androidx.compose.ui.Modifier
 
@@ -6,9 +6,5 @@ import androidx.compose.ui.Modifier
  * Conditionally applies the [action] to the receiver [Modifier], if [precondition] is true. Returns the receiver as-is
  * otherwise.
  */
-@Deprecated(
-    message = "This modifier has been moved to org.jetbrains.jewel.foundation.util. Please update your imports.",
-    ReplaceWith("thenIf(precondition, action)", "org.jetbrains.jewel.foundation.util"),
-)
 public inline fun Modifier.thenIf(precondition: Boolean, action: Modifier.() -> Modifier): Modifier =
     if (precondition) action() else this


### PR DESCRIPTION
There is no reason why it should be in the ui package, as we have other Modifier extensions in foundation, and we may want to use it there, too (e.g., in `BasicTableLayout`).