### PR TITLE
[REVIEW ONLY] Update to Compose 1.8.0 and remove pinned Skiko version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,20 +22,6 @@ dependencies {
     sarif(projects.ui)
 }
 
-// TODO remove this once the Skiko fix makes it into CMP 1.7.1
-allprojects {
-    configurations.all {
-        resolutionStrategy {
-            eachDependency {
-                if (requested.group == "org.jetbrains.skiko") {
-                    useVersion("0.8.17")
-                    because("Contains important memory usage fix")
-                }
-            }
-        }
-    }
-}
-
 tasks {
     //    val mergeSarifReports by
     //        registering(MergeSarifTask::class) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 commonmark = "0.24.0"
-composeDesktop = "1.7.1"
+composeDesktop = "1.8.0-alpha01"
 detekt = "1.23.6"
 dokka = "1.9.20"
 idea = "243.21155.17"


### PR DESCRIPTION
Tests are passing ✅ 
Smoke test of Standalone and IDE didn't show problems ✅ 

Closes #725
Closes #666
Relates to #665 