### PR TITLE
Passing through the onUrlClicked in recursive call to appendInlineMarkdownFrom

### DIFF
--- a/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultInlineMarkdownRenderer.kt
+++ b/markdown/core/src/main/kotlin/org/jetbrains/jewel/markdown/rendering/DefaultInlineMarkdownRenderer.kt
@@ -35,13 +35,13 @@ public open class DefaultInlineMarkdownRenderer(private val rendererExtensions: 
 
                 is InlineMarkdown.Emphasis -> {
                     withStyles(styling.emphasis.withEnabled(enabled), child) {
-                        appendInlineMarkdownFrom(it.inlineContent, styling, enabled)
+                        appendInlineMarkdownFrom(it.inlineContent, styling, enabled, onUrlClicked)
                     }
                 }
 
                 is InlineMarkdown.StrongEmphasis -> {
                     withStyles(styling.strongEmphasis.withEnabled(enabled), child) {
-                        appendInlineMarkdownFrom(it.inlineContent, styling, enabled)
+                        appendInlineMarkdownFrom(it.inlineContent, styling, enabled, onUrlClicked)
                     }
                 }
 


### PR DESCRIPTION
Currently, links within Markdown emphasis (or strong emphasis) are not clickable because the `onUrlClicked` handler is not propagated during recursive `Builder.appendInlineMarkdownFrom` calls. This change resolves the issue.